### PR TITLE
docs: add README and CONTRIBUTING adapted from internal template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,58 +1,144 @@
-## Branch and Commit Naming
+# Contributing to Traveling Game
 
-### Branches
+Thanks for helping build the Traveling Game. This is a **documentation-first** repo — we plan and agree on architecture before writing code. All contributions are welcome: docs, ADRs, diagrams, meeting notes, and eventually source code.
 
-Branch names follow the pattern `<type>/<short-description>`, where words
-are separated by hyphens.
+## Repository Overview
 
 ```
-feat/sql-parser
-fix/crc32-overflow
-chore/pr-templates
-ci/release-workflow
+compthink-2026/
+├── docs/
+│   ├── adr/               # Architecture Decision Records
+│   ├── poc/               # Proof-of-concept documents
+│   │   └── ui-docs/       # UX/UI specifications
+│   ├── meetings/notes/    # Sprint notes and discussion records
+│   ├── architecture.html  # System architecture diagram
+│   └── team-scoping-plan.html  # Domain & interface breakdown
+├── README.md
+├── CONTRIBUTING.md
+└── LICENSE
 ```
 
-**Types:**
+## Working with Branches
+
+The `main` branch is protected. All work goes through feature branches.
+
+### Branch Naming
+
+```
+<type>/<short-description>
+```
+
+Examples:
+
+```
+feat/game-loop-flow
+docs/adr-scoring-module
+fix/typo-architecture-diagram
+chore/meeting-notes-sprint-3
+```
 
 | Type | Use for |
 |---|---|
-| `feat` | New feature or capability |
-| `fix` | Bug fix |
-| `refactor` | Code restructuring with no behavior change |
-| `docs` | Documentation only |
-| `test` | Adding or updating tests |
-| `chore` | Repo/project maintenance (config, templates, tooling) |
-| `ci` | CI/CD pipeline and automation changes |
+| `feat` | New feature, capability, or design document |
+| `fix` | Correction to an existing doc or spec |
+| `docs` | Documentation-only changes |
+| `refactor` | Restructuring docs with no content change |
+| `test` | Test plans or acceptance criteria |
+| `chore` | Repo maintenance (templates, config, tooling) |
+| `ci` | CI/CD or automation changes |
 
----
+### Commit Messages
 
-### Commits
-
-Commits follow [Conventional Commits](https://www.conventionalcommits.org/):
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
 
 ```
-<type>[optional scope]: <short description>
+<type>(<scope>): <short description>
 ```
 
-The description is lowercase, imperative mood, and has no trailing period.
+Keep the description lowercase, imperative mood, no trailing period.
 
 ```
-feat(sql): add recursive descent parser for SELECT
-fix(kv): handle CRC-32 overflow on large entries
-docs: document Schema::compute_metadata contract
-chore(github): add issue and PR templates
-ci(build): pin actions/checkout to SHA
+docs(adr): add ADR for location card scoring
+feat(game): outline game-loop state machine
+docs(meeting): add sprint-3 notes
+fix(architecture): correct interface IF-2 arrow direction
 ```
 
-**Scopes** are optional but encouraged for larger codebases. Use the
-module or subsystem name: `core`, `kv`, `table`, `sql`, `ci`, `github`.
+**Scopes** we use:
 
-**Breaking changes** are marked with a `!` before the colon and explained
-in the commit body:
+| Scope | Use for |
+|---|---|
+| `adr` | Architecture Decision Records |
+| `poc` | Proof-of-concept documents |
+| `ui` | UI/UX specifications |
+| `meeting` | Sprint notes and meeting minutes |
+| `infra` | Infrastructure and deployment docs |
+| `game` | Game mechanics and rules docs |
+| `data` | Data pipeline and content bundles |
 
+## Workflow
+
+1. Sync your local `main`:
+   ```bash
+   git checkout main
+   git pull origin main --rebase
+   ```
+
+2. Create a working branch:
+   ```bash
+   git checkout -b <type>/<short-description>
+   ```
+
+3. Make your changes. For docs, we prefer **plain Markdown** where possible. Use `.html` only when the content benefits from embedded SVG diagrams or interactive elements.
+
+4. Commit and push:
+   ```bash
+   git add <files>
+   git commit -m "<type>(<scope>): <description>"
+   git push -u origin <branch>
+   ```
+
+5. Open a Pull Request against `main`. Reference any related issues. Use the PR template:
+   - What this change does
+   - Related issue(s) or ADR(s)
+   - Any decisions or trade-offs made
+
+### Merge Strategy
+
+Always **squash merge** PRs into `main`. Every merged PR becomes one clean commit. No merge commits or rebase merges for feature branches.
+
+## Working with ADRs
+
+Architecture Decision Records live in `docs/adr/`. Each ADR is a Markdown file following the standard template:
+
+```markdown
+# ADR-<number>: <Title>
+
+**Status:** Proposed | Accepted | Deprecated | Superseded
+
+**Context:** ...what is the problem or decision to be made?
+
+**Decision:** ...what did we decide and why?
+
+**Consequences:** ...what trade-offs, risks, or follow-ups arise?
 ```
-feat(sql)!: replace token enum with std::variant
 
-BREAKING CHANGE: TokenKind is no longer a plain enum.
-Callers must update match arms to use the new variant types.
-```
+- To propose a new ADR, create a file with **Status: Proposed** and open a PR.
+- To change an existing ADR, update the file and note the reason in the commit body.
+- Superseded ADRs remain in the repo for history — update their status, don't delete them.
+
+## Documentation Style
+
+- Use **clear, plain English**. Avoid jargon unless it's defined.
+- Prefer **tables and lists** over dense paragraphs for specifications.
+- Diagrams should be embedded as **SVG** or **Mermaid** when possible.
+- All docs live under `docs/` — keep the root clean.
+- When updating an existing doc, preserve the original author's intent unless a formal decision changed it.
+
+## Need Help?
+
+Open an issue with the appropriate template (task or question). Assign it to the relevant team member. If it's a quick question, bring it up in the team channel.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,1 +1,84 @@
-# compthink-2026
+# Traveling Game
+
+A location-based travel strategy board game — delivered as a **Progressive Web App**.
+
+Plan a virtual travel itinerary by drafting Location Cards, managing resources (Gold, Stamina), arranging cards on a 3×5 grid board, and scoring Victory Points (VP). Export your final board layout as a real-world travel plan: *Play to Plan.*
+
+Built by a university team for the Computational Thinking course.
+
+## Concept
+
+| What | How |
+|---|---|
+| **Drafting** | Pick from random Location Cards, build your hand |
+| **Board Building** | Arrange cards on a 3×5 grid (3 time slots × 5 days) |
+| **Resource Management** | Balance Gold and Stamina as you play |
+| **Simulation** | Distance checks, random events, combo multipliers |
+| **Scoring** | Maximise VP through clever placement |
+| **Export** | Your final board becomes a real travel itinerary |
+
+## Tech Stack
+
+| Layer | Choice |
+|---|---|
+| **Frontend** | Vanilla TypeScript + Less + CSS Grid + Rollup |
+| **Backend** | Deno + WebSocket + JSON-RPC 2.0 |
+| **Database** | PocketBase (SQLite) |
+| **Offline** | Service Worker (cache-first) + IndexedDB (Dexie.js) |
+| **Deployment** | Docker (backend), static host (frontend PWA) |
+
+**Shared logic** (`src/`) — board, rules, scoring, dice — runs on both client and server. Optimistic client with authoritative server validation.
+
+## Project Status
+
+This repository is in the **planning and documentation** phase. No source code yet.
+
+| Milestone | Target |
+|---|---|
+| Proof of Concept | 16 May 2026 |
+| MVP | 30 May 2026 |
+| Final Delivery | 27 June 2026 |
+
+## Team
+
+| Role | Focus |
+|---|---|
+| Product Owner | Vision & prioritisation |
+| Frontend Dev | Client app, Service Worker, UI |
+| Backend Dev | Server, game logic, PocketBase |
+| Data Dev | Content bundles, analytics |
+| UI/UX Designers | Visual design, experience flow |
+| QA | Testing & validation |
+| Game Designer | Mechanics & balancing |
+| Analysts | Domain research & scoping |
+
+## Getting Started
+
+This is a documentation-phase repository. To explore the project:
+
+```
+docs/
+├── adr/               # Architecture Decision Records
+│   ├── 001-frontend-client.md
+│   └── 002-backend.md
+├── poc/               # Proof-of-concept docs
+│   ├── 1_ProblemStatement.md
+│   ├── 2_Constraints_Assumptions.md
+│   ├── 3_SolutionProposal.md
+│   ├── ...
+│   └── ui-docs/       # UX/UI specifications
+├── architecture.html  # System architecture diagram
+├── team-scoping-plan.html  # Domain & interface breakdown
+└── meetings/notes/    # Sprint notes and discussions
+```
+
+Start with:
+1. [`docs/team-scoping-plan.html`](docs/team-scoping-plan.html) — top-down view of domains, data flows, interfaces, and deliverables
+2. [`docs/architecture.html`](docs/architecture.html) — system diagram with module descriptions
+3. [`docs/adr/001-frontend-client.md`](docs/adr/001-frontend-client.md) — frontend architecture decision
+4. [`docs/adr/002-backend.md`](docs/adr/002-backend.md) — backend architecture decision
+5. [`docs/poc/3_SolutionProposal.md`](docs/poc/3_SolutionProposal.md) — game mechanics in plain language
+
+## License
+
+MIT — see [LICENSE](LICENSE).


### PR DESCRIPTION
Closes #50

## What this change does

Replaces the stub README.md (one-liner) and the bare CONTRIBUTING.md (branch/commit naming only) with full project-appropriate versions, adapted from the `.internal/` template structure.

- **README.md** — game concept, tech stack, milestones, team roles, navigation into `docs/`
- **CONTRIBUTING.md** — branch/commit conventions, project scopes, squash merge, ADR workflow, doc style guide