### PR TITLE
fix: remove rootDir from tsconfig to unblock LSP for scr/shared/

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,6 @@
     "target": "esnext",
     "module": "esnext",
     "moduleResolution": "node",
-    "rootDir": "src",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
The `rootDir: "src"` option conflicted with including `scr/shared/` — TypeScript compiler rejects files outside rootDir. Removing it lets the LSP resolve cross-file imports in `scr/shared/` (after the TS server restarts).

```diff
- rootDir: src,
```