### PR TITLE
chore: normalize line endings via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,13 +1,43 @@
-# LFS tracking for game assets
-TREKPOLOGY/**/*.mp4 filter=lfs diff=lfs merge=lfs -text
-TREKPOLOGY/**/*.mp3 filter=lfs diff=lfs merge=lfs -text
-TREKPOLOGY/**/*.jpg filter=lfs diff=lfs merge=lfs -text
-TREKPOLOGY/**/*.jpeg filter=lfs diff=lfs merge=lfs -text
-TREKPOLOGY/**/*.png filter=lfs diff=lfs merge=lfs -text
+# ── Line endings ──────────────────────────────────────────────────────────
+# Deno expects LF line endings. Normalise all text files on commit.
+* text=auto eol=lf
 
-# Canonical asset store (Phase 1+)
-public/assets/**/*.mp4 filter=lfs diff=lfs merge=lfs -text
-public/assets/**/*.mp3 filter=lfs diff=lfs merge=lfs -text
-public/assets/**/*.jpg filter=lfs diff=lfs merge=lfs -text
-public/assets/**/*.jpeg filter=lfs diff=lfs merge=lfs -text
-public/assets/**/*.png filter=lfs diff=lfs merge=lfs -text
+# Explicit source types
+*.ts       text eol=lf
+*.js       text eol=lf
+*.json     text eol=lf
+*.md       text eol=lf
+*.html     text eol=lf
+*.css      text eol=lf
+*.less     text eol=lf
+*.yml      text eol=lf
+*.yaml     text eol=lf
+*.sh       text eol=lf
+.gitattributes text eol=lf
+.gitignore     text eol=lf
+
+# Binary assets — never touch
+*.jpg      binary
+*.jpeg     binary
+*.png      binary
+*.mp4      binary
+*.mp3      binary
+*.ico      binary
+*.svg      binary
+*.woff2    binary
+*.eot      binary
+*.ttf      binary
+*.m3u8     binary
+
+# ── LFS tracking (game assets) ───────────────────────────────────────────────
+TREKPOLOGY/**/*.mp4   filter=lfs diff=lfs merge=lfs -text
+TREKPOLOGY/**/*.mp3   filter=lfs diff=lfs merge=lfs -text
+TREKPOLOGY/**/*.jpg   filter=lfs diff=lfs merge=lfs -text
+TREKPOLOGY/**/*.jpeg  filter=lfs diff=lfs merge=lfs -text
+TREKPOLOGY/**/*.png   filter=lfs diff=lfs merge=lfs -text
+
+public/assets/**/*.mp4   filter=lfs diff=lfs merge=lfs -text
+public/assets/**/*.mp3   filter=lfs diff=lfs merge=lfs -text
+public/assets/**/*.jpg   filter=lfs diff=lfs merge=lfs -text
+public/assets/**/*.jpeg  filter=lfs diff=lfs merge=lfs -text
+public/assets/**/*.png   filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Sets `* text=auto eol=lf` to normalise all text files to LF on commit, preventing CRLF injection into Deno source files (the cause of #72's board.ts LSP errors).\n\n- Explicit eol=lf for .ts/.js/.json/.md/.html/.css/.less/.yml/.sh\n- Binary types (jpg, png, mp4, mp3, ico, svg) set to binary — never touched\n- LFS tracking preserved for game assets