### PR TITLE
fix: remove trailing entrypoint arg from deno deploy command

### DIFF
--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -29,12 +29,7 @@ jobs:
           deno-version: v2.x
 
       - name: Deploy to Deno Deploy
-        run: |
-          deno deploy \
-            --org "${{ vars.DENO_DEPLOY_ORG }}" \
-            --app "${{ vars.DENO_DEPLOY_APP }}" \
-            --prod \
-            server/server.ts
+        run: deno deploy --org "${{ vars.DENO_DEPLOY_ORG }}" --app "${{ vars.DENO_DEPLOY_APP }}" --prod
         env:
           DENO_DEPLOY_TOKEN: ${{ secrets.DENO_DEPLOY_TOKEN }}
           CORS_ORIGIN: ${{ vars.CORS_ORIGIN || 'https://tankhoitv.github.io' }}


### PR DESCRIPTION
The positional arg 'server/server.ts' was being interpreted as a config file path by `deno deploy`, causing a JSON parse error at line 17 col 1. Entrypoint was already configured when the app was created in the Deno Deploy dashboard.