### PR TITLE
fix: use document-relative asset paths for GitHub Pages subpath

### DIFF
--- a/src/audio/gameAudio.ts
+++ b/src/audio/gameAudio.ts
@@ -13,17 +13,17 @@ export type GameSoundName =
   | "reject";
 
 const GAME_SOUND_FILES = {
-  deal: "/assets/audio/sounds/card-deal.mp3",
-  returnDeck: "/assets/audio/sounds/card-return-deck.mp3",
-  cardSelect: "/assets/audio/sounds/card-select.mp3",
-  cardPlace: "/assets/audio/sounds/card-place.mp3",
-  button: "/assets/audio/sounds/ui-click.mp3",
-  scanCell: "/assets/audio/sounds/scan-cell.mp3",
-  scanBad: "/assets/audio/sounds/scan-bad.mp3",
-  eventTraffic: "/assets/audio/sounds/event-traffic.mp3",
-  eventDistance: "/assets/audio/sounds/event-distance.mp3",
-  eventStorm: "/assets/audio/sounds/event-storm.mp3",
-  eventPromo: "/assets/audio/sounds/event-promo.mp3",
+  deal: "assets/audio/sounds/card-deal.mp3",
+  returnDeck: "assets/audio/sounds/card-return-deck.mp3",
+  cardSelect: "assets/audio/sounds/card-select.mp3",
+  cardPlace: "assets/audio/sounds/card-place.mp3",
+  button: "assets/audio/sounds/ui-click.mp3",
+  scanCell: "assets/audio/sounds/scan-cell.mp3",
+  scanBad: "assets/audio/sounds/scan-bad.mp3",
+  eventTraffic: "assets/audio/sounds/event-traffic.mp3",
+  eventDistance: "assets/audio/sounds/event-distance.mp3",
+  eventStorm: "assets/audio/sounds/event-storm.mp3",
+  eventPromo: "assets/audio/sounds/event-promo.mp3",
 } as const;
 
 let gameAudioContext: AudioContext | null = null;

--- a/src/screens/dashboard.ts
+++ b/src/screens/dashboard.ts
@@ -1,6 +1,6 @@
 import { authClientState } from "../online/socketClient.ts";
 
-export const HERO_VIDEO_SRC = "/assets/videos/one-minute-in-vietnam.mp4";
+export const HERO_VIDEO_SRC = "assets/videos/one-minute-in-vietnam.mp4";
 
 export function initDashboardHub() {
 	const media = document.getElementById("hub-hero-media") as HTMLElement | null;

--- a/sw.js
+++ b/sw.js
@@ -1,45 +1,51 @@
-const CACHE_NAME = 'trekkopoly-v2';
+const CACHE_NAME = "trekkopoly-v2";
 
 // Danh sách các file cần lưu vào bộ nhớ đệm để chơi offline
 const ASSETS_TO_CACHE = [
-    './',
-    './index.html',
-    './manifest.json',
-    './build/client.js',
-    './build/client.css',
-    '/assets/videos/chuyencanh2.mp4',
-    '/assets/images/cities/danang.jpg',
-    '/assets/images/cities/hanoi.jpeg',
-    '/assets/images/cities/saigon.jpg',
-    '/assets/images/backgrounds/lobby-bg.jpg',
-    '/assets/images/backgrounds/saigon-collage-hover/saigon-collage-bg.png',
-    '/assets/audio/music/in-game-background.mp3',
+	"./",
+	"./index.html",
+	"./manifest.json",
+	"./build/client.js",
+	"./build/client.css",
+	"assets/videos/chuyencanh2.mp4",
+	"assets/images/cities/danang.jpg",
+	"assets/images/cities/hanoi.jpeg",
+	"assets/images/cities/saigon.jpg",
+	"assets/images/backgrounds/lobby-bg.jpg",
+	"assets/images/backgrounds/saigon-collage-hover/saigon-collage-bg.png",
+	"assets/audio/music/in-game-background.mp3",
 ];
 
 // 1. Sự kiện Cài đặt (Install) - Gom hàng vào kho Cache
-self.addEventListener('install', (event) => {
-    event.waitUntil(
-        caches.open(CACHE_NAME).then((cache) => {
-            console.log('SW: Đang nạp các file tĩnh vào bộ nhớ đệm...');
-            return cache.addAll(ASSETS_TO_CACHE);
-        }).then(() => self.skipWaiting()) // Buộc SW mới kích hoạt ngay lập tức
-    );
+self.addEventListener("install", (event) => {
+	event.waitUntil(
+		caches
+			.open(CACHE_NAME)
+			.then((cache) => {
+				console.log("SW: Đang nạp các file tĩnh vào bộ nhớ đệm...");
+				return cache.addAll(ASSETS_TO_CACHE);
+			})
+			.then(() => self.skipWaiting()), // Buộc SW mới kích hoạt ngay lập tức
+	);
 });
 
 // 2. Sự kiện Kích hoạt (Activate) - Dọn dẹp cache cũ khi nâng cấp version (v2, v3...)
-self.addEventListener('activate', (event) => {
-    event.waitUntil(
-        caches.keys().then((cacheNames) => {
-            return Promise.all(
-                cacheNames.map((cache) => {
-                    if (cache !== CACHE_NAME) {
-                        console.log('SW: Đang xóa cache cũ:', cache);
-                        return caches.delete(cache);
-                    }
-                })
-            );
-        }).then(() => self.clients.claim())
-    );
+self.addEventListener("activate", (event) => {
+	event.waitUntil(
+		caches
+			.keys()
+			.then((cacheNames) => {
+				return Promise.all(
+					cacheNames.map((cache) => {
+						if (cache !== CACHE_NAME) {
+							console.log("SW: Đang xóa cache cũ:", cache);
+							return caches.delete(cache);
+						}
+					}),
+				);
+			})
+			.then(() => self.clients.claim()),
+	);
 });
 
 // 3. Chiến lược lai (Hybrid):
@@ -49,38 +55,40 @@ self.addEventListener('activate', (event) => {
 //      người dùng xoá cache hay hard refresh.
 //    - Static assets (ảnh, nhạc, video): Cache-First — không đổi thường xuyên.
 //    - index.html: Network-First — luôn lấy bản mới từ server.
-self.addEventListener('fetch', (event) => {
-    const url = new URL(event.request.url);
-    const isBuildAsset = url.pathname.endsWith('/build/client.js') ||
-                         url.pathname.endsWith('/build/client.css');
-    const isIndex = url.pathname.endsWith('/') || url.pathname.endsWith('/index.html');
+self.addEventListener("fetch", (event) => {
+	const url = new URL(event.request.url);
+	const isBuildAsset =
+		url.pathname.endsWith("/build/client.js") ||
+		url.pathname.endsWith("/build/client.css");
+	const isIndex =
+		url.pathname.endsWith("/") || url.pathname.endsWith("/index.html");
 
-    if (isBuildAsset) {
-        // Stale-While-Revalidate for JS/CSS
-        event.respondWith(
-            caches.open(CACHE_NAME).then((cache) => {
-                return cache.match(event.request).then((cached) => {
-                    const fetchPromise = fetch(event.request).then((network) => {
-                        cache.put(event.request, network.clone());
-                        return network;
-                    }).catch(() => cached); // fallback to cache if offline
-                    return cached || fetchPromise;
-                });
-            })
-        );
-    } else if (isIndex) {
-        // Network-First for index.html
-        event.respondWith(
-            fetch(event.request).catch(() =>
-                caches.match(event.request)
-            )
-        );
-    } else {
-        // Cache-First for everything else (images, audio, fonts, etc.)
-        event.respondWith(
-            caches.match(event.request).then((cached) =>
-                cached || fetch(event.request)
-            )
-        );
-    }
+	if (isBuildAsset) {
+		// Stale-While-Revalidate for JS/CSS
+		event.respondWith(
+			caches.open(CACHE_NAME).then((cache) => {
+				return cache.match(event.request).then((cached) => {
+					const fetchPromise = fetch(event.request)
+						.then((network) => {
+							cache.put(event.request, network.clone());
+							return network;
+						})
+						.catch(() => cached); // fallback to cache if offline
+					return cached || fetchPromise;
+				});
+			}),
+		);
+	} else if (isIndex) {
+		// Network-First for index.html
+		event.respondWith(
+			fetch(event.request).catch(() => caches.match(event.request)),
+		);
+	} else {
+		// Cache-First for everything else (images, audio, fonts, etc.)
+		event.respondWith(
+			caches
+				.match(event.request)
+				.then((cached) => cached || fetch(event.request)),
+		);
+	}
 });

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'trekkopoly-v1';
+const CACHE_NAME = 'trekkopoly-v2';
 
 // Danh sách các file cần lưu vào bộ nhớ đệm để chơi offline
 const ASSETS_TO_CACHE = [
@@ -42,15 +42,45 @@ self.addEventListener('activate', (event) => {
     );
 });
 
-// 3. Chiến lược Cache-First
-// Khi game yêu cầu file, SW sẽ lục trong bộ nhớ máy trước, nếu không có mới lên mạng tải
+// 3. Chiến lược lai (Hybrid):
+//    - Build assets (JS/CSS): Stale-While-Revalidate — phục vụ ngay từ cache,
+//      đồng thời tải bản mới ở nền và cập nhật cache cho lần sau.
+//      Giúp game luôn chạy code mới nhất sau mỗi lần deploy mà không cần
+//      người dùng xoá cache hay hard refresh.
+//    - Static assets (ảnh, nhạc, video): Cache-First — không đổi thường xuyên.
+//    - index.html: Network-First — luôn lấy bản mới từ server.
 self.addEventListener('fetch', (event) => {
-    event.respondWith(
-        caches.match(event.request).then((cachedResponse) => {
-            if (cachedResponse) {
-                return cachedResponse; // Trả về file trong máy ngay lập tức (< 1s)
-            }
-            return fetch(event.request); // Nếu máy chưa có thì mới lên mạng lấy
-        })
-    );
+    const url = new URL(event.request.url);
+    const isBuildAsset = url.pathname.endsWith('/build/client.js') ||
+                         url.pathname.endsWith('/build/client.css');
+    const isIndex = url.pathname.endsWith('/') || url.pathname.endsWith('/index.html');
+
+    if (isBuildAsset) {
+        // Stale-While-Revalidate for JS/CSS
+        event.respondWith(
+            caches.open(CACHE_NAME).then((cache) => {
+                return cache.match(event.request).then((cached) => {
+                    const fetchPromise = fetch(event.request).then((network) => {
+                        cache.put(event.request, network.clone());
+                        return network;
+                    }).catch(() => cached); // fallback to cache if offline
+                    return cached || fetchPromise;
+                });
+            })
+        );
+    } else if (isIndex) {
+        // Network-First for index.html
+        event.respondWith(
+            fetch(event.request).catch(() =>
+                caches.match(event.request)
+            )
+        );
+    } else {
+        // Cache-First for everything else (images, audio, fonts, etc.)
+        event.respondWith(
+            caches.match(event.request).then((cached) =>
+                cached || fetch(event.request)
+            )
+        );
+    }
 });


### PR DESCRIPTION
All root-absolute `/assets/...` paths resolve to `https://tankhoitv.github.io/assets/...` but the actual files are at `https://tankhoitv.github.io/compthink-2026/assets/...`. Changed to document-relative (`assets/...`) so they resolve correctly.

- **gameAudio.ts**: 11 sound effect paths (the console 404s you saw)
- **sw.js**: 7 cached asset paths (videos, images, music)
- **dashboard.ts**: hero video source path