### PR TITLE
fix: keep hover but only show full popup on deliberate click

### DIFF
--- a/src/arena/render.ts
+++ b/src/arena/render.ts
@@ -18,6 +18,7 @@ import {
 	getSelectedHandCardId,
 	getFocusedHandCardId,
 	getFocusedBoardCard,
+	getShowFocusedPopup,
 	getIsSimulationMode,
 	getPhaseNumber,
 	getAccumulatedVP,
@@ -141,12 +142,13 @@ function getHandCityClass(city: string): string {
 // ── Main arena ──────────────────────────────────────────────────────────────
 
 export function renderMainArena(): string {
-	const boardSlots = getBoardSlots();
-	const currentDayIndex = getCurrentDayIndex();
-	const isDraft = getIsDraftPhase();
-	const isSimulation = getIsSimulationMode();
-	const focusedCard =
-		getHandCardById(getFocusedHandCardId()) ?? getFocusedBoardCard();
+const boardSlots = getBoardSlots();
+const currentDayIndex = getCurrentDayIndex();
+const isDraft = getIsDraftPhase();
+const isSimulation = getIsSimulationMode();
+const focusedCard = getShowFocusedPopup()
+? getHandCardById(getFocusedHandCardId()) ?? getFocusedBoardCard()
+: null;
 
 	return `
     <main class="arena ${isSimulation ? "arena--scanning" : ""}">

--- a/src/router.ts
+++ b/src/router.ts
@@ -72,6 +72,8 @@ function reattachCardClickDelegation() {
 		const cardId = el.getAttribute("data-hand-card-id");
 		if (!cardId) return;
 		el.addEventListener("click", () => handleHandCardClick(cardId));
+		el.addEventListener("pointerenter", () => handleHandCardEnter(cardId));
+		el.addEventListener("pointerleave", () => handleHandCardLeave());
 	});
 
 	// Draft card clicks
@@ -109,17 +111,36 @@ async function handleHandCardClick(cardId: string) {
 	if (currentSelected === cardId) {
 		// Card already selected — toggle focused detail popup
 		const currentlyFocused = state.getFocusedHandCardId();
-		if (currentlyFocused === cardId) {
+		if (currentlyFocused === cardId && state.getShowFocusedPopup()) {
+			// Already showing popup — dismiss
 			state.setFocusedHandCardId(null);
+			state.setShowFocusedPopup(false);
 		} else {
+			// Show popup
 			state.setFocusedHandCardId(cardId);
+			state.setShowFocusedPopup(true);
 		}
 	} else {
 		// Select the card, clear any focused popup
 		state.setSelectedHandCardId(cardId);
 		state.setFocusedHandCardId(null);
+		state.setShowFocusedPopup(false);
 	}
 
+	rerenderGameShell();
+}
+
+async function handleHandCardEnter(cardId: string) {
+	const state = await import("./state.ts");
+	state.setFocusedHandCardId(cardId);
+	state.setShowFocusedPopup(false);
+	rerenderGameShell();
+}
+
+async function handleHandCardLeave() {
+	const state = await import("./state.ts");
+	state.setFocusedHandCardId(null);
+	state.setShowFocusedPopup(false);
 	rerenderGameShell();
 }
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -76,6 +76,7 @@ let suppressNextClick = false;
 let isSimulationMode = false;
 const simulationReplayIndex = 0;
 const isReplayComplete = false;
+let showFocusedPopup = false;
 
 // ── Timer state ──────────────────────────────────────────────────────────────
 
@@ -175,6 +176,14 @@ export function setFocusedBoardCard(card: TravelCard | null) {
 
 export function getIsSimulationMode(): boolean {
 	return isSimulationMode;
+}
+
+export function getShowFocusedPopup(): boolean {
+	return showFocusedPopup;
+}
+
+export function setShowFocusedPopup(v: boolean) {
+	showFocusedPopup = v;
 }
 
 export function setIsSimulationMode(v: boolean) {

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "trekkopoly-v2";
+const CACHE_NAME = "trekkopoly-v3";
 
 // Danh sách các file cần lưu vào bộ nhớ đệm để chơi offline
 const ASSETS_TO_CACHE = [


### PR DESCRIPTION
Hover behavior restored (user liked it), but the full-screen overlay (position:fixed, inset:0, z-index:9999) only appears when requested via click, not on passive hover.

- **state.ts**: added  flag
- **router.ts**: hover sets focused card without showing overlay; clicking an already-selected card toggles the detail popup
- **render.ts**: only renders the overlay when  is true
- **sw.js**: bumped to v3 to force fresh cache install (fixes stale-while-revalidate serving old code)