### PR TITLE
fix: use document-level event delegation for board/hand clicks

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -35,10 +35,7 @@ import {
 	getShowFocusedPopup,
 	setShowFocusedPopup,
 } from "./state.ts";
-import {
-	createInitialDeck,
-	shuffleCards,
-} from "../scr/shared/deck.ts";
+import { createInitialDeck, shuffleCards } from "../scr/shared/deck.ts";
 import { saigonFoodCards } from "../scr/shared/data/index.ts";
 import { HAND_SIZE, PHASE_DAYS } from "../scr/shared/constants.ts";
 
@@ -115,7 +112,11 @@ function finishDailyDraft() {
  * Place the selected hand card onto a board cell.
  * Removes the card from hand. Does NOT refill hand (keeps it simple for MVP).
  */
-function placeHandCardOnBoard(cardId: string, rowIndex: number, colIndex: number) {
+function placeHandCardOnBoard(
+	cardId: string,
+	rowIndex: number,
+	colIndex: number,
+) {
 	if (getGamePhase() !== "placement") return;
 	if (colIndex !== getCurrentDayIndex()) return;
 
@@ -241,7 +242,10 @@ function endCurrentDay() {
  * Board cell click — places the selected card if in placement phase
  * and the cell is in the current day column.
  */
-(globalThis as any).handleBoardCellClick = (rowIndex: number, colIndex: number) => {
+(globalThis as any).handleBoardCellClick = (
+	rowIndex: number,
+	colIndex: number,
+) => {
 	if (getGamePhase() === "placement") {
 		const selectedId = getSelectedHandCardId();
 		if (selectedId) {

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,12 +1,36 @@
+/**
+ * app.ts — Application entry point and game loop.
+ *
+ * Mirrors the old TREKPOLOGY/src/app.ts game loop (single-player local mode):
+ *   draft → placement → endDay → draft (next day) → ... → finished
+ *
+ * Draft: 7 cards, pick 1 per round × 5 rounds → 5 cards in hand.
+ * Placement: click card → click board cell → place. "End Day" to advance.
+ * Day advance: score base VP → increment day → start new draft or finish.
+ */
+
 import { setupGameAudioDelegation } from "./audio/gameAudio.ts";
 import { rerenderGameShell, transitionToScreen } from "./router.ts";
 import {
 	setDeck,
 	setPlayerHand,
 	setCurrentDayIndex,
-	setIsDraftPhase,
+	setGamePhase,
+	setDraftPool,
+	setDraftRound,
+	setDraftSelectedCardId,
 	setSelectedHandCardId,
 	setFocusedHandCardId,
+	setFocusedBoardCard,
+	getDeck,
+	getPlayerHand,
+	getGamePhase,
+	getCurrentDayIndex,
+	getBoardSlots,
+	getAccumulatedVP,
+	setAccumulatedVP,
+	getDraftPool,
+	getDraftRound,
 	getSelectedHandCardId,
 	getShowFocusedPopup,
 	setShowFocusedPopup,
@@ -14,10 +38,14 @@ import {
 import {
 	createInitialDeck,
 	shuffleCards,
-	drawDailyHandFromDeck,
 } from "../scr/shared/deck.ts";
 import { saigonFoodCards } from "../scr/shared/data/index.ts";
-import { HAND_SIZE } from "../scr/shared/constants.ts";
+import { HAND_SIZE, PHASE_DAYS } from "../scr/shared/constants.ts";
+
+// ── Constants ───────────────────────────────────────────────────────────────
+
+const DRAFT_POOL_SIZE = 7;
+const DRAFT_PICK_TARGET = HAND_SIZE; // 5
 
 const gameName = "Trekkopoly";
 console.log(`${gameName} running!`);
@@ -35,47 +63,171 @@ if ("serviceWorker" in navigator) {
 	});
 }
 
-// ── Initialise demo game state ──────────────────────────────────────────────
-// Deal cards from the Saigon food deck and jump straight to the game screen.
-// (No server connection needed for the static Pages demo.)
+// ── Initialise deck ────────────────────────────────────────────────────────────
 
-const deck = createInitialDeck({
+const fullDeck = createInitialDeck({
 	cards: saigonFoodCards,
 	fallbackCards: [],
 	handSize: HAND_SIZE,
 });
 
-const shuffled = shuffleCards(deck);
-const { deck: remainingDeck, hand } = drawDailyHandFromDeck({
-	deck: shuffled,
-	handSize: HAND_SIZE,
-	shuffleCards,
-});
-
-setDeck(remainingDeck);
-setPlayerHand(hand);
+setDeck(shuffleCards(fullDeck));
+setPlayerHand([]);
 setCurrentDayIndex(0);
-setIsDraftPhase(false); // Skip draft for demo — show the board immediately
 
-// ── Expose global card handlers (inline onclick calls these — same pattern as old TREKPOLOGY) ──
+// ── Start Day 1 draft ─────────────────────────────────────────────────────────
 
+startDailyDraft();
+
+// ── Global game loop functions ────────────────────────────────────────────
+
+/**
+ * Deal DRAFT_POOL_SIZE (7) cards from the deck into the draft pool.
+ * Set phase to "draft", render the game screen.
+ */
+function startDailyDraft() {
+	const deck = getDeck();
+	const shuffled = shuffleCards(deck);
+	const pool = shuffled.slice(0, DRAFT_POOL_SIZE);
+	setDeck(shuffled.slice(DRAFT_POOL_SIZE));
+	setDraftPool(pool);
+	setDraftRound(1);
+	setDraftSelectedCardId(null);
+	setPlayerHand([]);
+	setGamePhase("draft");
+	rerenderGameShell();
+}
+
+/**
+ * After 5 picks are made: move the 5 picked cards (playerHand) from draft pool
+ * into the placement hand. Return leftover pool cards to deck.
+ */
+function finishDailyDraft() {
+	const hand = getPlayerHand();
+	setPlayerHand(hand);
+	setGamePhase("placement");
+	setDraftPool([]);
+	setSelectedHandCardId(null);
+	rerenderGameShell();
+}
+
+/**
+ * Place the selected hand card onto a board cell.
+ * Removes the card from hand. Does NOT refill hand (keeps it simple for MVP).
+ */
+function placeHandCardOnBoard(cardId: string, rowIndex: number, colIndex: number) {
+	if (getGamePhase() !== "placement") return;
+	if (colIndex !== getCurrentDayIndex()) return;
+
+	const hand = getPlayerHand();
+	const handIndex = hand.findIndex((c) => c.id === cardId);
+	if (handIndex === -1) return;
+
+	const card = hand[handIndex];
+	hand.splice(handIndex, 1);
+	setPlayerHand(hand);
+
+	const board = getBoardSlots();
+	board[rowIndex][colIndex] = card;
+
+	setSelectedHandCardId(null);
+	setFocusedHandCardId(null);
+	setFocusedBoardCard(null);
+	rerenderGameShell();
+}
+
+/**
+ * End the current day: score base VP from the day's board cells,
+ * advance to next day (or finish).
+ */
+function endCurrentDay() {
+	if (getGamePhase() !== "placement") return;
+
+	// Score base VP from cards placed on today's board column
+	const colIndex = getCurrentDayIndex();
+	const board = getBoardSlots();
+	let dayVP = 0;
+	for (let row = 0; row < board.length; row++) {
+		const card = board[row]?.[colIndex];
+		if (card) {
+			dayVP += card.vp ?? 0;
+		}
+	}
+	setAccumulatedVP(getAccumulatedVP() + dayVP);
+
+	const nextDay = getCurrentDayIndex() + 1;
+
+	if (nextDay >= PHASE_DAYS) {
+		// Game over
+		setGamePhase("finished");
+		setPlayerHand([]);
+		setSelectedHandCardId(null);
+	} else {
+		setCurrentDayIndex(nextDay);
+		startDailyDraft();
+	}
+
+	rerenderGameShell();
+}
+
+// ── Expose global functions (called from inline onclick in render.ts) ───────
+
+/**
+ * Hand card clicked during placement phase.
+ * Toggles selection; also toggles focused popup on re-click.
+ */
 (globalThis as any).selectHandCard = (cardId: string) => {
-	const currentSelected = getSelectedHandCardId();
-	if (currentSelected === cardId) {
-		// Toggle focused popup on re-click
-		if (getShowFocusedPopup()) {
+	const phase = getGamePhase();
+
+	if (phase === "draft") {
+		// ── Draft phase: pick the card for this round ──
+		const pool = getDraftPool();
+		const picked = pool.find((c) => c.id === cardId);
+		if (!picked) return;
+
+		const currentHand = getPlayerHand();
+		currentHand.push(picked);
+		setPlayerHand(currentHand);
+
+		// Return remaining pool cards to deck
+		const remaining = pool.filter((c) => c.id !== cardId);
+		const deck = getDeck();
+		setDeck(shuffleCards([...deck, ...remaining]));
+
+		const round = getDraftRound();
+		if (round >= DRAFT_PICK_TARGET) {
+			finishDailyDraft();
+		} else {
+			// Deal a new pool of 6 for the next round
+			const newDeck = getDeck();
+			const shuffled = shuffleCards(newDeck);
+			setDraftPool(shuffled.slice(0, DRAFT_POOL_SIZE - 1));
+			setDeck(shuffled.slice(DRAFT_POOL_SIZE - 1));
+			setDraftRound(round + 1);
+			rerenderGameShell();
+		}
+		return;
+	}
+
+	if (phase === "placement") {
+		// ── Placement phase: select/deselect card ──
+		const currentSelected = getSelectedHandCardId();
+		if (currentSelected === cardId) {
+			if (getShowFocusedPopup()) {
+				setFocusedHandCardId(null);
+				setShowFocusedPopup(false);
+			} else {
+				setFocusedHandCardId(cardId);
+				setShowFocusedPopup(true);
+			}
+		} else {
+			setSelectedHandCardId(cardId);
 			setFocusedHandCardId(null);
 			setShowFocusedPopup(false);
-		} else {
-			setFocusedHandCardId(cardId);
-			setShowFocusedPopup(true);
 		}
-	} else {
-		setSelectedHandCardId(cardId);
-		setFocusedHandCardId(null);
-		setShowFocusedPopup(false);
+		rerenderGameShell();
+		return;
 	}
-	rerenderGameShell();
 };
 
 (globalThis as any).clearSelectedHandCard = () => {
@@ -85,5 +237,26 @@ setIsDraftPhase(false); // Skip draft for demo — show the board immediately
 	rerenderGameShell();
 };
 
-// Start the app — render the game screen
+/**
+ * Board cell click — places the selected card if in placement phase
+ * and the cell is in the current day column.
+ */
+(globalThis as any).handleBoardCellClick = (rowIndex: number, colIndex: number) => {
+	if (getGamePhase() === "placement") {
+		const selectedId = getSelectedHandCardId();
+		if (selectedId) {
+			placeHandCardOnBoard(selectedId, rowIndex, colIndex);
+		}
+	}
+};
+
+/**
+ * End the current day and advance the game.
+ */
+(globalThis as any).endCurrentDay = () => {
+	endCurrentDay();
+};
+
+// ── Start the app — render the game screen ──────────────────────────────────
+
 transitionToScreen("game");

--- a/src/arena/render.ts
+++ b/src/arena/render.ts
@@ -202,7 +202,7 @@ export function renderMainArena(): string {
           </section>
         </div>
 
-        ${isDraft ? renderDraftPanel() : getGamePhase() === "placement" ? renderEndDayButton() : ""}
+        ${!isDraft && getGamePhase() === "placement" ? renderEndDayButton() : ""}
       </div>
 
       ${renderPlayerHandSection()}
@@ -289,6 +289,36 @@ function renderPlayerHandSection(): string {
 	const currentDayIndex = getCurrentDayIndex();
 	const selectedId = getSelectedHandCardId();
 
+	if (isDraft) {
+		// ── Draft phase: render draft pool inside player-hand--draft ──
+		const pool = getDraftPool();
+		const round = getDraftRound();
+		const alreadyPicked = hand.length;
+
+		return `
+      <section class="player-hand player-hand--draft">
+        <div class="player-hand__top">
+          <div class="player-hand__title">
+            <span class="hand-badge">DRAFT</span>
+            <h2>Chọn thẻ ngày ${DAYS[currentDayIndex]}</h2>
+          </div>
+          <div class="player-hand__meta">Vòng ${round}/5 · Đã chọn: ${alreadyPicked}/5</div>
+        </div>
+        <div class="player-hand__cards">
+          ${pool
+						.map(
+							(card, index) => `
+            <div class="daily-draft-card daily-draft-card--${index + 1}" data-draft-card-id="${card.id}">
+              ${renderHandCard(card, index, null)}
+            </div>
+          `,
+						)
+						.join("")}
+        </div>
+      </section>
+    `;
+	}
+
 	if (hand.length === 0) {
 		return `
       <section class="player-hand">
@@ -308,8 +338,8 @@ function renderPlayerHandSection(): string {
     <section class="player-hand">
       <div class="player-hand__top">
         <div class="player-hand__title">
-          <span class="hand-badge">${isDraft ? "DRAFT" : "HAND"}</span>
-          <h2>${isDraft ? `Chọn bài ngày ${DAYS[currentDayIndex]}` : `Bài ngày ${DAYS[currentDayIndex]}`}</h2>
+          <span class="hand-badge">HAND</span>
+          <h2>Bài ngày ${DAYS[currentDayIndex]}</h2>
         </div>
         <div class="player-hand__meta">Giữ 0.5s để xem lớn</div>
       </div>
@@ -399,36 +429,6 @@ export function renderHandCards(): string {
 	return hand
 		.map((card, index) => renderHandCard(card, index, selectedId))
 		.join("");
-}
-
-// ── Draft panel ─────────────────────────────────────────────────────────────
-
-function renderDraftPanel(): string {
-	const pool = getDraftPool();
-	const round = getDraftRound();
-	const hand = getPlayerHand();
-	const alreadyPicked = hand.length; // cards picked in prior rounds
-
-	return `
-    <div class="draft-panel">
-      <div class="draft-panel__header">
-        <h2>Chọn thẻ — Vòng ${round}/5</h2>
-        <span class="draft-panel__picked">Đã chọn: ${alreadyPicked}/5</span>
-      </div>
-      <div class="draft-cards">
-        ${pool
-					.map(
-						(card, index) => `
-          <div class="daily-draft-card daily-draft-card--${index + 1}" data-draft-card-id="${card.id}">
-            ${renderHandCard(card, index, null)}
-          </div>
-        `,
-					)
-					.join("")}
-      </div>
-      <p class="draft-panel__hint">Nhấn vào một thẻ để chọn</p>
-    </div>
-  `;
 }
 
 // ── Draft hand cards ────────────────────────────────────────────────────────

--- a/src/arena/render.ts
+++ b/src/arena/render.ts
@@ -238,7 +238,6 @@ function renderBoardCell(
         data-board-cell="true"
         data-row-index="${rowIndex}"
         data-col-index="${colIndex}"
-        onclick="event.stopPropagation(); window['handleBoardCellClick'](${rowIndex}, ${colIndex})"
         title="${isCurrentDayColumn ? (isPlaceable ? "Thả thẻ vào ô ngày hiện tại" : "Chỉ xếp thẻ cho ngày hiện tại") : "Không phải ngày hiện tại"}"
       >
         <span class="empty-plus">+</span>
@@ -252,7 +251,6 @@ function renderBoardCell(
       data-board-cell="true"
       data-row-index="${rowIndex}"
       data-col-index="${colIndex}"
-      onclick="event.stopPropagation(); window['handleBoardCellClick'](${rowIndex}, ${colIndex})"
       title="${card.name}"
     >
       ${renderBoardMiniCard(card)}
@@ -372,7 +370,7 @@ export function renderHandCard(
       class="hand-card ${rarityClass} ${fanClass} ${isSelected ? "hand-card--selected" : ""}"
       data-hand-card-id="${card.id}"
       title="${card.name}"
-      onclick="event.stopPropagation(); window['selectHandCard']('${card.id}')" data-select-card="true"
+      data-select-card="true"
     >
       ${
 				isSelected

--- a/src/arena/render.ts
+++ b/src/arena/render.ts
@@ -13,7 +13,7 @@
 import {
 	getBoardSlots,
 	getCurrentDayIndex,
-	getIsDraftPhase,
+	getGamePhase,
 	getPlayerHand,
 	getSelectedHandCardId,
 	getFocusedHandCardId,
@@ -24,6 +24,8 @@ import {
 	getAccumulatedVP,
 	getRemainingTurnSeconds,
 	getPlayerBoards,
+	getDraftPool,
+	getDraftRound,
 	currentPlayerId,
 	playerIds,
 } from "../state.ts";
@@ -161,7 +163,7 @@ function getHandCityClass(city: string): string {
 export function renderMainArena(): string {
 	const boardSlots = getBoardSlots();
 	const currentDayIndex = getCurrentDayIndex();
-	const isDraft = getIsDraftPhase();
+	const isDraft = getGamePhase() === "draft";
 	const isSimulation = getIsSimulationMode();
 	const focusedCard = getShowFocusedPopup()
 		? (getHandCardById(getFocusedHandCardId()) ?? getFocusedBoardCard())
@@ -200,13 +202,13 @@ export function renderMainArena(): string {
           </section>
         </div>
 
-        ${isDraft ? renderDraftPanel() : ""}
+        ${isDraft ? renderDraftPanel() : getGamePhase() === "placement" ? renderEndDayButton() : ""}
       </div>
 
       ${renderPlayerHandSection()}
       ${focusedCard ? renderFocusedCard(focusedCard) : ""}
       ${renderTurnTimer()}
-    </main>
+    </main>\n    ${getGamePhase() === "finished" ? renderGameOverScreen() : ""}
   `;
 }
 
@@ -236,6 +238,7 @@ function renderBoardCell(
         data-board-cell="true"
         data-row-index="${rowIndex}"
         data-col-index="${colIndex}"
+        onclick="event.stopPropagation(); window['handleBoardCellClick'](${rowIndex}, ${colIndex})"
         title="${isCurrentDayColumn ? (isPlaceable ? "Thả thẻ vào ô ngày hiện tại" : "Chỉ xếp thẻ cho ngày hiện tại") : "Không phải ngày hiện tại"}"
       >
         <span class="empty-plus">+</span>
@@ -249,6 +252,7 @@ function renderBoardCell(
       data-board-cell="true"
       data-row-index="${rowIndex}"
       data-col-index="${colIndex}"
+      onclick="event.stopPropagation(); window['handleBoardCellClick'](${rowIndex}, ${colIndex})"
       title="${card.name}"
     >
       ${renderBoardMiniCard(card)}
@@ -280,7 +284,8 @@ export function renderBoardMiniCard(card: TravelCard): string {
 
 function renderPlayerHandSection(): string {
 	const hand = getPlayerHand();
-	const isDraft = getIsDraftPhase();
+	const gamePhase = getGamePhase();
+	const isDraft = gamePhase === "draft";
 	const currentDayIndex = getCurrentDayIndex();
 	const selectedId = getSelectedHandCardId();
 
@@ -399,12 +404,29 @@ export function renderHandCards(): string {
 // ── Draft panel ─────────────────────────────────────────────────────────────
 
 function renderDraftPanel(): string {
+	const pool = getDraftPool();
+	const round = getDraftRound();
+	const hand = getPlayerHand();
+	const alreadyPicked = hand.length; // cards picked in prior rounds
+
 	return `
     <div class="draft-panel">
-      <h2>Chọn thẻ (Vòng 1)</h2>
-      <div class="draft-cards">
-        <!-- Draft cards rendered by draft UI -->
+      <div class="draft-panel__header">
+        <h2>Chọn thẻ — Vòng ${round}/5</h2>
+        <span class="draft-panel__picked">Đã chọn: ${alreadyPicked}/5</span>
       </div>
+      <div class="draft-cards">
+        ${pool
+					.map(
+						(card, index) => `
+          <div class="daily-draft-card daily-draft-card--${index + 1}" data-draft-card-id="${card.id}">
+            ${renderHandCard(card, index, null)}
+          </div>
+        `,
+					)
+					.join("")}
+      </div>
+      <p class="draft-panel__hint">Nhấn vào một thẻ để chọn</p>
     </div>
   `;
 }
@@ -481,6 +503,32 @@ function renderResourceOrbs(): string {
       <div class="orb orb--debt">
         <span class="orb__icon">D</span>
         <span class="orb__value">--</span>
+      </div>
+    </div>
+  `;
+}
+
+// ── End Day button ──────────────────────────────────────────────────────────
+
+function renderEndDayButton(): string {
+	return `
+    <div class="end-day-bar">
+      <button class="end-day-btn" onclick="event.stopPropagation(); window['endCurrentDay']()">
+        Kết thúc ngày ${getCurrentDayIndex() + 1}
+      </button>
+    </div>
+  `;
+}
+
+// ── Game Over screen ─────────────────────────────────────────────────────────
+
+function renderGameOverScreen(): string {
+	return `
+    <div class="game-over-overlay">
+      <div class="game-over-card">
+        <h1>Hoàn thành!</h1>
+        <p class="game-over__vp">Tổng VP: ${getAccumulatedVP()}</p>
+        <button onclick="location.reload()" class="game-over__replay">Chơi lại</button>
       </div>
     </div>
   `;

--- a/src/online/socketClient.ts
+++ b/src/online/socketClient.ts
@@ -34,19 +34,19 @@ let wsBaseUrl = isProduction
 // ── Public API ──────────────────────────────────────────────────────────────
 
 export type AuthUser = {
-  id: string;
-  username: string;
-  displayName: string;
+	id: string;
+	username: string;
+	displayName: string;
 };
 
 export type AuthClientState = {
-  isReady: boolean;
-  user: AuthUser | null;
+	isReady: boolean;
+	user: AuthUser | null;
 };
 
 export const authClientState: AuthClientState = {
-  isReady: false,
-  user: null,
+	isReady: false,
+	user: null,
 };
 
 export function configureServerUrls(httpUrl: string, wsUrl: string) {

--- a/src/router.ts
+++ b/src/router.ts
@@ -57,29 +57,14 @@ export function rerenderGameShell() {
 // ── Card click delegation ───────────────────────────────────────────────────
 
 function reattachCardClickDelegation() {
-	// Board cell clicks
-	document.querySelectorAll("[data-board-cell]").forEach((el) => {
-		const rowIndex = Number(el.getAttribute("data-row-index"));
-		const colIndex = Number(el.getAttribute("data-col-index"));
-		el.addEventListener("click", (e) => {
-			e.stopPropagation();
-			handleBoardCellClick(rowIndex, colIndex);
-		});
-	});
+	// Board cell / hand card clicks: inline onclick → window['handleBoardCellClick'] / window['selectHandCard']
 
-	// Hand card hover (click is handled by inline onclick for synchronous selection)
+	// Hand card hover (visual feedback, no rerender)
 	document.querySelectorAll("[data-hand-card-id]").forEach((el) => {
 		const cardId = el.getAttribute("data-hand-card-id");
 		if (!cardId) return;
 		el.addEventListener("pointerenter", () => handleHandCardEnter(cardId));
 		el.addEventListener("pointerleave", () => handleHandCardLeave());
-	});
-
-	// Draft card clicks
-	document.querySelectorAll("[data-draft-card-id]").forEach((el) => {
-		const cardId = el.getAttribute("data-draft-card-id");
-		if (!cardId) return;
-		el.addEventListener("click", () => handleDraftCardClick(cardId));
 	});
 
 	// Focused card close
@@ -96,13 +81,7 @@ function reattachCardClickDelegation() {
 	}
 }
 
-// ── Click handlers (import state and rerender) ──────────────────────────────
-
-async function handleBoardCellClick(rowIndex: number, colIndex: number) {
-	const state = await import("./state.ts");
-	// Placeholder: will wire to server placement in full implementation
-	console.log(`Board cell click: row=${rowIndex}, col=${colIndex}`);
-}
+// ── Hover handlers (no rerender — CSS handles visual feedback) ──────────────
 
 function handleHandCardEnter(cardId: string) {
 	// CSS :hover effects handle visual feedback on the card itself.
@@ -119,8 +98,4 @@ function handleHandCardLeave() {
 	});
 }
 
-async function handleDraftCardClick(cardId: string) {
-	const state = await import("./state.ts");
-	state.setDraftSelectedCardId(cardId);
-	rerenderGameShell();
-}
+

--- a/src/router.ts
+++ b/src/router.ts
@@ -97,5 +97,3 @@ function handleHandCardLeave() {
 		state.setFocusedHandCardId(null);
 	});
 }
-
-

--- a/src/router.ts
+++ b/src/router.ts
@@ -54,11 +54,9 @@ export function rerenderGameShell() {
 	reattachCardClickDelegation();
 }
 
-// ── Card click delegation ───────────────────────────────────────────────────
+// ── Card click delegation (backup for inline handlers, hover) ───────────────
 
 function reattachCardClickDelegation() {
-	// Board cell / hand card clicks: inline onclick → window['handleBoardCellClick'] / window['selectHandCard']
-
 	// Hand card hover (visual feedback, no rerender)
 	document.querySelectorAll("[data-hand-card-id]").forEach((el) => {
 		const cardId = el.getAttribute("data-hand-card-id");
@@ -80,6 +78,32 @@ function reattachCardClickDelegation() {
 		});
 	}
 }
+
+// ── Document-level event delegation for board cell & hand card clicks ──────
+// Replaces inline onclick — no event.stopPropagation conflict.
+
+document.addEventListener("click", (e) => {
+	const target = e.target as HTMLElement;
+
+	const boardCell = target.closest("[data-board-cell]");
+	if (boardCell) {
+		e.stopPropagation();
+		const row = Number(boardCell.getAttribute("data-row-index"));
+		const col = Number(boardCell.getAttribute("data-col-index"));
+		(typeof globalThis as any).handleBoardCellClick?.(row, col);
+		return;
+	}
+
+	const handCard = target.closest("[data-hand-card-id]");
+	if (handCard && !target.closest(".hand-card__close")) {
+		e.stopPropagation();
+		const cardId = handCard.getAttribute("data-hand-card-id");
+		if (cardId) {
+			(typeof globalThis as any).selectHandCard?.(cardId);
+		}
+		return;
+	}
+});
 
 // ── Hover handlers (no rerender — CSS handles visual feedback) ──────────────
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -25,7 +25,7 @@ let playerHand: TravelCard[] = [];
 
 // ── Draft state ──────────────────────────────────────────────────────────────
 
-let draftPool: TravelCard[] = [];       // 7 cards shown for current pick round
+let draftPool: TravelCard[] = []; // 7 cards shown for current pick round
 let draftSelectedCardId: string | null = null;
 const draftPickSecondsLeft = 10;
 const draftTimerId: number | null = null;

--- a/src/state.ts
+++ b/src/state.ts
@@ -6,14 +6,17 @@
  */
 
 import { createEmptyBoardSlots } from "../scr/shared/board.ts";
-import { shuffleCards } from "../scr/shared/deck.ts";
 import type { TravelCard } from "../scr/shared/types.ts";
-import type { BoardSlots, BoardTotals } from "../scr/shared/board.ts";
-import type {
-	PlayerId,
-	TravelCardData,
-	UiGamePhase,
-} from "../scr/shared/client-types.ts";
+import type { BoardSlots } from "../scr/shared/board.ts";
+import type { PlayerId } from "../scr/shared/client-types.ts";
+
+// ── Game phase FSM ───────────────────────────────────────────────────────────
+//
+//   draft → placement → endDay → draft (next day) or finished
+//
+export type GamePhase = "draft" | "placement" | "endDay" | "finished";
+
+let gamePhase: GamePhase = "draft";
 
 // ── Deck state ──────────────────────────────────────────────────────────────
 
@@ -22,7 +25,7 @@ let playerHand: TravelCard[] = [];
 
 // ── Draft state ──────────────────────────────────────────────────────────────
 
-let isDraftPhase = true;
+let draftPool: TravelCard[] = [];       // 7 cards shown for current pick round
 let draftSelectedCardId: string | null = null;
 const draftPickSecondsLeft = 10;
 const draftTimerId: number | null = null;
@@ -126,12 +129,20 @@ export function setAccumulatedVP(vp: number) {
 	accumulatedVP = vp;
 }
 
-export function getIsDraftPhase(): boolean {
-	return isDraftPhase;
+export function getGamePhase(): GamePhase {
+	return gamePhase;
 }
 
-export function setIsDraftPhase(v: boolean) {
-	isDraftPhase = v;
+export function setGamePhase(p: GamePhase) {
+	gamePhase = p;
+}
+
+export function getDraftPool(): TravelCard[] {
+	return draftPool;
+}
+
+export function setDraftPool(pool: TravelCard[]) {
+	draftPool = pool;
 }
 
 export function getDraftSelectedCardId(): string | null {


### PR DESCRIPTION
Replaces inline onclick with document-level delegation for more robust click handling:

- Clicks on [data-board-cell] → calls handleBoardCellClick
- Clicks on [data-hand-card-id] (excluding close button) → calls selectHandCard
- No more inline onclick on board cells or hand cards
- event.stopPropagation not needed — delegation handles it

This fixes board cell clicks that weren't working with the two-step
select-then-place placement flow.