### PR TITLE
fix: placement click double-fire, draft pool shrink, board mini card CSS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ TREKPOLOGY/server/data/
 # Sub-package lockfiles (managed by root)
 TREKPOLOGY/package-lock.json
 TREKPOLOGY/server/package-lock.json
+assets

--- a/src/app.ts
+++ b/src/app.ts
@@ -101,6 +101,7 @@ function startDailyDraft() {
  * into the placement hand. Return leftover pool cards to deck.
  */
 function finishDailyDraft() {
+	console.log("[app] finishDailyDraft → placement", { handSize: getPlayerHand().length });
 	// Snapshot the hand into a fresh array to break shared reference
 	setPlayerHand([...getPlayerHand()]);
 	setGamePhase("placement");

--- a/src/app.ts
+++ b/src/app.ts
@@ -178,11 +178,12 @@ function endCurrentDay() {
  * Toggles selection; also toggles focused popup on re-click.
  */
 (globalThis as any).selectHandCard = (cardId: string) => {
+	console.log("[app] selectHandCard called", { cardId, phase: getGamePhase() });
 	const phase = getGamePhase();
 
 	if (phase === "draft") {
 		// ── Draft phase: pick the card for this round ──
-		const pool = getDraftPool();
+		const pool = getDraftPool(); console.log("[app] draft pool size:", pool.length);
 		const picked = pool.find((c) => c.id === cardId);
 		if (!picked) return;
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -27,6 +27,7 @@ import {
 	getGamePhase,
 	getCurrentDayIndex,
 	getBoardSlots,
+	setCurrentPlayerBoard,
 	getAccumulatedVP,
 	setAccumulatedVP,
 	getDraftPool,
@@ -100,8 +101,8 @@ function startDailyDraft() {
  * into the placement hand. Return leftover pool cards to deck.
  */
 function finishDailyDraft() {
-	const hand = getPlayerHand();
-	setPlayerHand(hand);
+	// Snapshot the hand into a fresh array to break shared reference
+	setPlayerHand([...getPlayerHand()]);
 	setGamePhase("placement");
 	setDraftPool([]);
 	setSelectedHandCardId(null);
@@ -130,6 +131,7 @@ function placeHandCardOnBoard(
 
 	const board = getBoardSlots();
 	board[rowIndex][colIndex] = card;
+	setCurrentPlayerBoard(board);
 
 	setSelectedHandCardId(null);
 	setFocusedHandCardId(null);
@@ -211,10 +213,6 @@ function endCurrentDay() {
 	}
 
 	if (phase === "placement") {
-		console.log("[app] placement select", {
-			cardId,
-			currentSelected: getSelectedHandCardId(),
-		});
 		// ── Placement phase: select/deselect card ──
 		const currentSelected = getSelectedHandCardId();
 		if (currentSelected === cardId) {

--- a/src/app.ts
+++ b/src/app.ts
@@ -118,6 +118,16 @@ function placeHandCardOnBoard(
 	rowIndex: number,
 	colIndex: number,
 ) {
+	console.log("[app] placeHandCardOnBoard enter", {
+		cardId,
+		rowIndex,
+		colIndex,
+		phase: getGamePhase(),
+		dayIndex: getCurrentDayIndex(),
+		colMatchesDay: colIndex === getCurrentDayIndex(),
+		handSize: getPlayerHand().length,
+		cardInHand: getPlayerHand().some((c) => c.id === cardId),
+	});
 	if (getGamePhase() !== "placement") return;
 	if (colIndex !== getCurrentDayIndex()) return;
 
@@ -213,6 +223,12 @@ function endCurrentDay() {
 	}
 
 	if (phase === "placement") {
+		console.log("[app] selectHandCard called", {
+			cardId,
+			phase,
+			currentSelected: getSelectedHandCardId(),
+			callCount: (window as any).__selectCount = ((window as any).__selectCount ?? 0) + 1,
+		});
 		// ── Placement phase: select/deselect card ──
 		const currentSelected = getSelectedHandCardId();
 		if (currentSelected === cardId) {
@@ -248,6 +264,12 @@ function endCurrentDay() {
 	rowIndex: number,
 	colIndex: number,
 ) => {
+	console.log("[app] handleBoardCellClick", {
+		rowIndex,
+		colIndex,
+		phase: getGamePhase(),
+		selectedId: getSelectedHandCardId(),
+	});
 	if (getGamePhase() === "placement") {
 		const selectedId = getSelectedHandCardId();
 		if (selectedId) {

--- a/src/app.ts
+++ b/src/app.ts
@@ -191,6 +191,12 @@ function endCurrentDay() {
  */
 (globalThis as any).selectHandCard = (cardId: string) => {
 	const phase = getGamePhase();
+	console.log("[app] selectHandCard", {
+		cardId,
+		phase,
+		callCount: ((window as any).__selectCount ?? 0) + 1,
+	});
+	(window as any).__selectCount = ((window as any).__selectCount ?? 0) + 1;
 
 	if (phase === "draft") {
 		// ── Draft phase: pick the card for this round ──
@@ -223,11 +229,9 @@ function endCurrentDay() {
 	}
 
 	if (phase === "placement") {
-		console.log("[app] selectHandCard called", {
+		console.log("[app] selectHandCard placement", {
 			cardId,
-			phase,
 			currentSelected: getSelectedHandCardId(),
-			callCount: (window as any).__selectCount = ((window as any).__selectCount ?? 0) + 1,
 		});
 		// ── Placement phase: select/deselect card ──
 		const currentSelected = getSelectedHandCardId();

--- a/src/app.ts
+++ b/src/app.ts
@@ -101,7 +101,6 @@ function startDailyDraft() {
  * into the placement hand. Return leftover pool cards to deck.
  */
 function finishDailyDraft() {
-	console.log("[app] finishDailyDraft → placement", { handSize: getPlayerHand().length });
 	// Snapshot the hand into a fresh array to break shared reference
 	setPlayerHand([...getPlayerHand()]);
 	setGamePhase("placement");
@@ -119,16 +118,6 @@ function placeHandCardOnBoard(
 	rowIndex: number,
 	colIndex: number,
 ) {
-	console.log("[app] placeHandCardOnBoard enter", {
-		cardId,
-		rowIndex,
-		colIndex,
-		phase: getGamePhase(),
-		dayIndex: getCurrentDayIndex(),
-		colMatchesDay: colIndex === getCurrentDayIndex(),
-		handSize: getPlayerHand().length,
-		cardInHand: getPlayerHand().some((c) => c.id === cardId),
-	});
 	if (getGamePhase() !== "placement") return;
 	if (colIndex !== getCurrentDayIndex()) return;
 
@@ -192,12 +181,6 @@ function endCurrentDay() {
  */
 (globalThis as any).selectHandCard = (cardId: string) => {
 	const phase = getGamePhase();
-	console.log("[app] selectHandCard", {
-		cardId,
-		phase,
-		callCount: ((window as any).__selectCount ?? 0) + 1,
-	});
-	(window as any).__selectCount = ((window as any).__selectCount ?? 0) + 1;
 
 	if (phase === "draft") {
 		// ── Draft phase: pick the card for this round ──
@@ -218,11 +201,13 @@ function endCurrentDay() {
 		if (round >= DRAFT_PICK_TARGET) {
 			finishDailyDraft();
 		} else {
-			// Deal a new pool of 6 for the next round
+			// Pool shrinks each round simulating a pack being passed around
+			// Round 1: 7 cards, Round 2: 6, ..., Round 5: 3
+			const nextPoolSize = DRAFT_POOL_SIZE - round;
 			const newDeck = getDeck();
 			const shuffled = shuffleCards(newDeck);
-			setDraftPool(shuffled.slice(0, DRAFT_POOL_SIZE - 1));
-			setDeck(shuffled.slice(DRAFT_POOL_SIZE - 1));
+			setDraftPool(shuffled.slice(0, nextPoolSize));
+			setDeck(shuffled.slice(nextPoolSize));
 			setDraftRound(round + 1);
 			rerenderGameShell();
 		}
@@ -230,10 +215,6 @@ function endCurrentDay() {
 	}
 
 	if (phase === "placement") {
-		console.log("[app] selectHandCard placement", {
-			cardId,
-			currentSelected: getSelectedHandCardId(),
-		});
 		// ── Placement phase: select/deselect card ──
 		const currentSelected = getSelectedHandCardId();
 		if (currentSelected === cardId) {
@@ -269,12 +250,6 @@ function endCurrentDay() {
 	rowIndex: number,
 	colIndex: number,
 ) => {
-	console.log("[app] handleBoardCellClick", {
-		rowIndex,
-		colIndex,
-		phase: getGamePhase(),
-		selectedId: getSelectedHandCardId(),
-	});
 	if (getGamePhase() === "placement") {
 		const selectedId = getSelectedHandCardId();
 		if (selectedId) {

--- a/src/app.ts
+++ b/src/app.ts
@@ -211,7 +211,10 @@ function endCurrentDay() {
 	}
 
 	if (phase === "placement") {
-		console.log("[app] placement select", { cardId, currentSelected: getSelectedHandCardId() });
+		console.log("[app] placement select", {
+			cardId,
+			currentSelected: getSelectedHandCardId(),
+		});
 		// ── Placement phase: select/deselect card ──
 		const currentSelected = getSelectedHandCardId();
 		if (currentSelected === cardId) {

--- a/src/app.ts
+++ b/src/app.ts
@@ -178,13 +178,11 @@ function endCurrentDay() {
  * Toggles selection; also toggles focused popup on re-click.
  */
 (globalThis as any).selectHandCard = (cardId: string) => {
-	console.log("[app] selectHandCard called", { cardId, phase: getGamePhase() });
 	const phase = getGamePhase();
 
 	if (phase === "draft") {
 		// ── Draft phase: pick the card for this round ──
 		const pool = getDraftPool();
-		console.log("[app] draft pool size:", pool.length);
 		const picked = pool.find((c) => c.id === cardId);
 		if (!picked) return;
 
@@ -213,6 +211,7 @@ function endCurrentDay() {
 	}
 
 	if (phase === "placement") {
+		console.log("[app] placement select", { cardId, currentSelected: getSelectedHandCardId() });
 		// ── Placement phase: select/deselect card ──
 		const currentSelected = getSelectedHandCardId();
 		if (currentSelected === cardId) {

--- a/src/app.ts
+++ b/src/app.ts
@@ -183,7 +183,8 @@ function endCurrentDay() {
 
 	if (phase === "draft") {
 		// ── Draft phase: pick the card for this round ──
-		const pool = getDraftPool(); console.log("[app] draft pool size:", pool.length);
+		const pool = getDraftPool();
+		console.log("[app] draft pool size:", pool.length);
 		const picked = pool.find((c) => c.id === cardId);
 		if (!picked) return;
 

--- a/src/arena/render.ts
+++ b/src/arena/render.ts
@@ -225,6 +225,15 @@ function renderBoardCell(
 	const card = boardSlots[rowIndex]?.[colIndex] ?? null;
 	const isCurrentDayColumn = colIndex === currentDayIndex;
 	const selectedId = getSelectedHandCardId();
+	console.log("[render] isPlaceable check", {
+		phase: getGamePhase(),
+		selected: selectedId,
+		row: rowIndex,
+		col: colIndex,
+		dayIndex: currentDayIndex,
+		colMatchesDay: isCurrentDayColumn,
+		cellEmpty: !card,
+	});
 	const isPlaceable =
 		!isDraft &&
 		!isSimulation &&

--- a/src/arena/render.ts
+++ b/src/arena/render.ts
@@ -225,15 +225,6 @@ function renderBoardCell(
 	const card = boardSlots[rowIndex]?.[colIndex] ?? null;
 	const isCurrentDayColumn = colIndex === currentDayIndex;
 	const selectedId = getSelectedHandCardId();
-	console.log("[render] boardCell", {
-		rowIndex,
-		colIndex,
-		isDraft,
-		isSimulation,
-		isCurrentDayColumn,
-		selectedId,
-		hasCard: !!card,
-	});
 	const isPlaceable =
 		!isDraft &&
 		!isSimulation &&

--- a/src/arena/render.ts
+++ b/src/arena/render.ts
@@ -224,11 +224,13 @@ function renderBoardCell(
 ): string {
 	const card = boardSlots[rowIndex]?.[colIndex] ?? null;
 	const isCurrentDayColumn = colIndex === currentDayIndex;
+	const selectedId = getSelectedHandCardId();
+	console.log("[render] boardCell", { rowIndex, colIndex, isDraft, isSimulation, isCurrentDayColumn, selectedId, hasCard: !!card });
 	const isPlaceable =
 		!isDraft &&
 		!isSimulation &&
 		isCurrentDayColumn &&
-		getSelectedHandCardId() !== null &&
+		selectedId !== null &&
 		card === null;
 
 	if (!card) {

--- a/src/arena/render.ts
+++ b/src/arena/render.ts
@@ -225,17 +225,6 @@ function renderBoardCell(
 	const card = boardSlots[rowIndex]?.[colIndex] ?? null;
 	const isCurrentDayColumn = colIndex === currentDayIndex;
 	const selectedId = getSelectedHandCardId();
-	if (getGamePhase() === "placement" && selectedId) {
-		console.log("[render] isPlaceable check", {
-			phase: getGamePhase(),
-			selected: selectedId,
-			row: rowIndex,
-			col: colIndex,
-			dayIndex: currentDayIndex,
-			colMatchesDay: isCurrentDayColumn,
-			cellEmpty: !card,
-		});
-	}
 	const isPlaceable =
 		!isDraft &&
 		!isSimulation &&
@@ -273,20 +262,22 @@ function renderBoardCell(
 // ── Mini card (on board) ────────────────────────────────────────────────────
 
 export function renderBoardMiniCard(card: TravelCard): string {
-	const rarityClass = card.rarity ? `card--rarity-${card.rarity}` : "";
+	const tagClass = card.tag ? `board-mini__tag--${card.tag.toLowerCase()}` : "";
+	const rarityClass = card.rarity ? `board-mini--${card.rarity}` : "";
 	return `
-    <div class="board-mini-card ${rarityClass}">
-      <img src="${card.image}" alt="${card.name}" loading="lazy" />
-      <div class="board-mini-card__info">
-        <span class="board-mini-card__name">${card.name}</span>
-        <span class="board-mini-card__tags">${card.tag ? getTagLabel(card.tag) : ""}</span>
+    <article class="board-mini ${rarityClass}" title="${card.name}">
+      <div
+        class="board-mini__image"
+        style="background-image: url('${card.image}')"
+      ></div>
+      <div class="board-mini__tag ${tagClass}">
+        ${card.tag ? getTagLabel(card.tag) : ""}
       </div>
-      <div class="board-mini-card__stats">
-        <span class="stat stat--vp">${card.vp}</span>
-        <span class="stat stat--coin">${card.coin}</span>
-        <span class="stat stat--stamina">${card.stamina}</span>
+      <div class="board-mini__info">
+        <h3 class="board-mini__name">${card.name}</h3>
+        <div class="board-mini__vp">★ ${card.vp}</div>
       </div>
-    </div>
+    </article>
   `;
 }
 

--- a/src/arena/render.ts
+++ b/src/arena/render.ts
@@ -225,7 +225,15 @@ function renderBoardCell(
 	const card = boardSlots[rowIndex]?.[colIndex] ?? null;
 	const isCurrentDayColumn = colIndex === currentDayIndex;
 	const selectedId = getSelectedHandCardId();
-	console.log("[render] boardCell", { rowIndex, colIndex, isDraft, isSimulation, isCurrentDayColumn, selectedId, hasCard: !!card });
+	console.log("[render] boardCell", {
+		rowIndex,
+		colIndex,
+		isDraft,
+		isSimulation,
+		isCurrentDayColumn,
+		selectedId,
+		hasCard: !!card,
+	});
 	const isPlaceable =
 		!isDraft &&
 		!isSimulation &&

--- a/src/arena/render.ts
+++ b/src/arena/render.ts
@@ -225,15 +225,17 @@ function renderBoardCell(
 	const card = boardSlots[rowIndex]?.[colIndex] ?? null;
 	const isCurrentDayColumn = colIndex === currentDayIndex;
 	const selectedId = getSelectedHandCardId();
-	console.log("[render] isPlaceable check", {
-		phase: getGamePhase(),
-		selected: selectedId,
-		row: rowIndex,
-		col: colIndex,
-		dayIndex: currentDayIndex,
-		colMatchesDay: isCurrentDayColumn,
-		cellEmpty: !card,
-	});
+	if (getGamePhase() === "placement" && selectedId) {
+		console.log("[render] isPlaceable check", {
+			phase: getGamePhase(),
+			selected: selectedId,
+			row: rowIndex,
+			col: colIndex,
+			dayIndex: currentDayIndex,
+			colMatchesDay: isCurrentDayColumn,
+			cellEmpty: !card,
+		});
+	}
 	const isPlaceable =
 		!isDraft &&
 		!isSimulation &&

--- a/src/router.ts
+++ b/src/router.ts
@@ -106,12 +106,23 @@ document.addEventListener(
 	"click",
 	(e) => {
 		const target = e.target as HTMLElement;
+		const phase = (globalThis as any).getGamePhase?.() || "?";
 
-			// Draft card click (via [data-draft-card-id] wrapper)
+		console.log("[router] click in capture", {
+			tag: target.tagName,
+			cls: target.className?.slice(0, 60),
+			dd: !!target.closest("[data-draft-card-id]"),
+			hc: !!target.closest("[data-hand-card-id]"),
+			bc: !!target.closest("[data-board-cell]"),
+			phase,
+		});
+
+		// Draft card click (via [data-draft-card-id] wrapper)
 		const draftCard = target.closest("[data-draft-card-id]");
 		if (draftCard) {
 			const cardId = draftCard.getAttribute("data-draft-card-id");
 			if (cardId) {
+				console.log("[router] draft matched");
 				e.preventDefault();
 				e.stopPropagation();
 				(globalThis as any).selectHandCard?.(cardId);
@@ -119,11 +130,12 @@ document.addEventListener(
 			}
 		}
 
-		// Hand card / board cell click (via [data-hand-card-id] or [data-board-cell])
+		// Hand card click
 		const handCard = target.closest("[data-hand-card-id]");
 		if (handCard && !handCard.closest(".hand-card__close")) {
 			const cardId = handCard.getAttribute("data-hand-card-id");
 			if (cardId) {
+				console.log("[router] hand matched");
 				e.preventDefault();
 				e.stopPropagation();
 				(globalThis as any).selectHandCard?.(cardId);
@@ -131,10 +143,12 @@ document.addEventListener(
 			}
 		}
 
+		// Board cell click
 		const boardCell = target.closest("[data-board-cell]");
 		if (boardCell) {
 			const row = Number(boardCell.getAttribute("data-row-index"));
 			const col = Number(boardCell.getAttribute("data-col-index"));
+			console.log("[router] board matched");
 			e.preventDefault();
 			e.stopPropagation();
 			(globalThis as any).handleBoardCellClick?.(row, col);

--- a/src/router.ts
+++ b/src/router.ts
@@ -52,10 +52,6 @@ export function rerenderGameShell() {
 	if (!app) return;
 	app.innerHTML = renderGameShell();
 	reattachCardClickDelegation();
-	console.log(
-		"[router] handlers bound:",
-		document.querySelectorAll("[data-hand-card-id]").length,
-	);
 }
 
 // ── Card click delegation (backup for inline handlers, hover) ───────────────
@@ -97,7 +93,6 @@ document.addEventListener(
 		if (draftCard) {
 			const cardId = draftCard.getAttribute("data-draft-card-id");
 			if (cardId) {
-				console.log("[router] capture match — draft card", { cardId });
 				e.preventDefault();
 				e.stopPropagation();
 				(globalThis as any).selectHandCard?.(cardId);
@@ -110,7 +105,6 @@ document.addEventListener(
 		if (handCard && !handCard.closest(".hand-card__close")) {
 			const cardId = handCard.getAttribute("data-hand-card-id");
 			if (cardId) {
-				console.log("[router] capture match — hand card", { cardId });
 				e.preventDefault();
 				e.stopPropagation();
 				(globalThis as any).selectHandCard?.(cardId);
@@ -123,7 +117,6 @@ document.addEventListener(
 		if (boardCell) {
 			const row = Number(boardCell.getAttribute("data-row-index"));
 			const col = Number(boardCell.getAttribute("data-col-index"));
-			console.log("[router] capture match — board cell", { row, col });
 			e.preventDefault();
 			e.stopPropagation();
 			(globalThis as any).handleBoardCellClick?.(row, col);

--- a/src/router.ts
+++ b/src/router.ts
@@ -52,6 +52,7 @@ export function rerenderGameShell() {
 	if (!app) return;
 	app.innerHTML = renderGameShell();
 	reattachCardClickDelegation();
+	console.log("[router] handlers bound:", document.querySelectorAll("[data-hand-card-id]").length);
 }
 
 // ── Card click delegation (backup for inline handlers, hover) ───────────────
@@ -105,6 +106,7 @@ document.addEventListener(
 		if (handCard && !handCard.closest(".hand-card__close")) {
 			const cardId = handCard.getAttribute("data-hand-card-id");
 			if (cardId) {
+				console.log("[router] capture match — hand card", { cardId });
 				e.preventDefault();
 				e.stopPropagation();
 				(globalThis as any).selectHandCard?.(cardId);
@@ -117,6 +119,7 @@ document.addEventListener(
 		if (boardCell) {
 			const row = Number(boardCell.getAttribute("data-row-index"));
 			const col = Number(boardCell.getAttribute("data-col-index"));
+			console.log("[router] capture match — board cell", { row, col });
 			e.preventDefault();
 			e.stopPropagation();
 			(globalThis as any).handleBoardCellClick?.(row, col);

--- a/src/router.ts
+++ b/src/router.ts
@@ -96,37 +96,52 @@ function reattachCardClickDelegation() {
 	}
 }
 
-// ── Document-level event delegation for board cell & hand card clicks ──────
-// Replaces inline onclick — no event.stopPropagation conflict.
+// ── Document-level click delegation (capture phase, matches TREKPOLOGY pattern) ──
+// Old TREKPOLOGY used capture:true + [data-draft-card-id] for draft cards.
+// This ensures clicks are caught before any inline handler processes them.
 
 console.log("[router] event delegation installed");
 
 document.addEventListener("click", (e) => {
 	const target = e.target as HTMLElement;
-	console.log("[router] click hit doc", {
-		tag: target.tagName,
-		cls: target.className?.slice(0, 60),
-		closestHIC: !!target.closest("[data-hand-card-id]"),
-		closestBoard: !!target.closest("[data-board-cell]"),
-	});
+
+	// Draft card click (via [data-draft-card-id] wrapper)
+	const draftCard = target.closest("[data-draft-card-id]");
+	if (draftCard) {
+		const cardId = draftCard.getAttribute("data-draft-card-id");
+		if (cardId) {
+			console.log("[router] draft card click via delegation", { cardId });
+			e.preventDefault();
+			e.stopPropagation();
+			(globalThis as any).selectHandCard?.(cardId);
+			return;
+		}
+	}
+
+	// Hand card / board cell click (via [data-hand-card-id] or [data-board-cell])
+	const handCard = target.closest("[data-hand-card-id]");
+	if (handCard && !handCard.closest(".hand-card__close")) {
+		const cardId = handCard.getAttribute("data-hand-card-id");
+		if (cardId) {
+			console.log("[router] hand card click via delegation", { cardId });
+			e.preventDefault();
+			e.stopPropagation();
+			(globalThis as any).selectHandCard?.(cardId);
+			return;
+		}
+	}
 
 	const boardCell = target.closest("[data-board-cell]");
 	if (boardCell) {
 		const row = Number(boardCell.getAttribute("data-row-index"));
 		const col = Number(boardCell.getAttribute("data-col-index"));
+		console.log("[router] board cell click via delegation", { row, col });
+		e.preventDefault();
+		e.stopPropagation();
 		(globalThis as any).handleBoardCellClick?.(row, col);
 		return;
 	}
-
-	const handCard = target.closest("[data-hand-card-id]");
-	if (handCard && !target.closest(".hand-card__close")) {
-		const cardId = handCard.getAttribute("data-hand-card-id");
-		if (cardId) {
-			(globalThis as any).selectHandCard?.(cardId);
-		}
-		return;
-	}
-});
+}, true);  /* capture phase — matches old TREKPOLOGY */
 
 // ── Hover handlers (no rerender — CSS handles visual feedback) ──────────────
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -90,7 +90,7 @@ document.addEventListener("click", (e) => {
 		e.stopPropagation();
 		const row = Number(boardCell.getAttribute("data-row-index"));
 		const col = Number(boardCell.getAttribute("data-col-index"));
-		(typeof globalThis as any).handleBoardCellClick?.(row, col);
+		(globalThis as any).handleBoardCellClick?.(row, col);
 		return;
 	}
 
@@ -99,7 +99,7 @@ document.addEventListener("click", (e) => {
 		e.stopPropagation();
 		const cardId = handCard.getAttribute("data-hand-card-id");
 		if (cardId) {
-			(typeof globalThis as any).selectHandCard?.(cardId);
+			(globalThis as any).selectHandCard?.(cardId);
 		}
 		return;
 	}

--- a/src/router.ts
+++ b/src/router.ts
@@ -57,12 +57,29 @@ export function rerenderGameShell() {
 // ── Card click delegation (backup for inline handlers, hover) ───────────────
 
 function reattachCardClickDelegation() {
-	// Hand card hover (visual feedback, no rerender)
+	// Hand card click and hover (add listeners directly to element)
 	document.querySelectorAll("[data-hand-card-id]").forEach((el) => {
 		const cardId = el.getAttribute("data-hand-card-id");
 		if (!cardId) return;
 		el.addEventListener("pointerenter", () => handleHandCardEnter(cardId));
 		el.addEventListener("pointerleave", () => handleHandCardLeave());
+		// Direct click handler as primary (not relying on document delegation)
+		el.addEventListener("click", (e) => {
+			e.stopPropagation();
+			console.log("[router] direct card click", { cardId });
+			(globalThis as any).selectHandCard?.(cardId);
+		});
+	});
+
+	// Board cell click (add listeners directly to each cell)
+	document.querySelectorAll("[data-board-cell]").forEach((el) => {
+		el.addEventListener("click", (e) => {
+			const row = Number(el.getAttribute("data-row-index"));
+			const col = Number(el.getAttribute("data-col-index"));
+			console.log("[router] direct board click", { row, col });
+			e.stopPropagation();
+			(globalThis as any).handleBoardCellClick?.(row, col);
+		});
 	});
 
 	// Focused card close
@@ -86,11 +103,15 @@ console.log("[router] event delegation installed");
 
 document.addEventListener("click", (e) => {
 	const target = e.target as HTMLElement;
+	console.log("[router] click hit doc", {
+		tag: target.tagName,
+		cls: target.className?.slice(0, 60),
+		closestHIC: !!target.closest("[data-hand-card-id]"),
+		closestBoard: !!target.closest("[data-board-cell]"),
+	});
 
 	const boardCell = target.closest("[data-board-cell]");
 	if (boardCell) {
-		console.log("[router] board cell clicked", { row: boardCell.getAttribute("data-row-index"), col: boardCell.getAttribute("data-col-index") });
-		e.stopPropagation();
 		const row = Number(boardCell.getAttribute("data-row-index"));
 		const col = Number(boardCell.getAttribute("data-col-index"));
 		(globalThis as any).handleBoardCellClick?.(row, col);
@@ -99,8 +120,6 @@ document.addEventListener("click", (e) => {
 
 	const handCard = target.closest("[data-hand-card-id]");
 	if (handCard && !target.closest(".hand-card__close")) {
-		console.log("[router] hand/draft card clicked", { cardId: handCard.getAttribute("data-hand-card-id") });
-		e.stopPropagation();
 		const cardId = handCard.getAttribute("data-hand-card-id");
 		if (cardId) {
 			(globalThis as any).selectHandCard?.(cardId);

--- a/src/router.ts
+++ b/src/router.ts
@@ -102,46 +102,47 @@ function reattachCardClickDelegation() {
 
 console.log("[router] event delegation installed");
 
-document.addEventListener("click", (e) => {
-	const target = e.target as HTMLElement;
+document.addEventListener(
+	"click",
+	(e) => {
+		const target = e.target as HTMLElement;
 
-	// Draft card click (via [data-draft-card-id] wrapper)
-	const draftCard = target.closest("[data-draft-card-id]");
-	if (draftCard) {
-		const cardId = draftCard.getAttribute("data-draft-card-id");
-		if (cardId) {
-			console.log("[router] draft card click via delegation", { cardId });
+			// Draft card click (via [data-draft-card-id] wrapper)
+		const draftCard = target.closest("[data-draft-card-id]");
+		if (draftCard) {
+			const cardId = draftCard.getAttribute("data-draft-card-id");
+			if (cardId) {
+				e.preventDefault();
+				e.stopPropagation();
+				(globalThis as any).selectHandCard?.(cardId);
+				return;
+			}
+		}
+
+		// Hand card / board cell click (via [data-hand-card-id] or [data-board-cell])
+		const handCard = target.closest("[data-hand-card-id]");
+		if (handCard && !handCard.closest(".hand-card__close")) {
+			const cardId = handCard.getAttribute("data-hand-card-id");
+			if (cardId) {
+				e.preventDefault();
+				e.stopPropagation();
+				(globalThis as any).selectHandCard?.(cardId);
+				return;
+			}
+		}
+
+		const boardCell = target.closest("[data-board-cell]");
+		if (boardCell) {
+			const row = Number(boardCell.getAttribute("data-row-index"));
+			const col = Number(boardCell.getAttribute("data-col-index"));
 			e.preventDefault();
 			e.stopPropagation();
-			(globalThis as any).selectHandCard?.(cardId);
+			(globalThis as any).handleBoardCellClick?.(row, col);
 			return;
 		}
-	}
-
-	// Hand card / board cell click (via [data-hand-card-id] or [data-board-cell])
-	const handCard = target.closest("[data-hand-card-id]");
-	if (handCard && !handCard.closest(".hand-card__close")) {
-		const cardId = handCard.getAttribute("data-hand-card-id");
-		if (cardId) {
-			console.log("[router] hand card click via delegation", { cardId });
-			e.preventDefault();
-			e.stopPropagation();
-			(globalThis as any).selectHandCard?.(cardId);
-			return;
-		}
-	}
-
-	const boardCell = target.closest("[data-board-cell]");
-	if (boardCell) {
-		const row = Number(boardCell.getAttribute("data-row-index"));
-		const col = Number(boardCell.getAttribute("data-col-index"));
-		console.log("[router] board cell click via delegation", { row, col });
-		e.preventDefault();
-		e.stopPropagation();
-		(globalThis as any).handleBoardCellClick?.(row, col);
-		return;
-	}
-}, true);  /* capture phase — matches old TREKPOLOGY */
+	},
+	true,
+); /* capture phase — matches old TREKPOLOGY */
 
 // ── Hover handlers (no rerender — CSS handles visual feedback) ──────────────
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -52,7 +52,10 @@ export function rerenderGameShell() {
 	if (!app) return;
 	app.innerHTML = renderGameShell();
 	reattachCardClickDelegation();
-	console.log("[router] handlers bound:", document.querySelectorAll("[data-hand-card-id]").length);
+	console.log(
+		"[router] handlers bound:",
+		document.querySelectorAll("[data-hand-card-id]").length,
+	);
 }
 
 // ── Card click delegation (backup for inline handlers, hover) ───────────────
@@ -94,6 +97,7 @@ document.addEventListener(
 		if (draftCard) {
 			const cardId = draftCard.getAttribute("data-draft-card-id");
 			if (cardId) {
+				console.log("[router] capture match — draft card", { cardId });
 				e.preventDefault();
 				e.stopPropagation();
 				(globalThis as any).selectHandCard?.(cardId);

--- a/src/router.ts
+++ b/src/router.ts
@@ -57,29 +57,12 @@ export function rerenderGameShell() {
 // ── Card click delegation (backup for inline handlers, hover) ───────────────
 
 function reattachCardClickDelegation() {
-	// Hand card click and hover (add listeners directly to element)
+	// Hand card hover (visual feedback, no rerender)
 	document.querySelectorAll("[data-hand-card-id]").forEach((el) => {
 		const cardId = el.getAttribute("data-hand-card-id");
 		if (!cardId) return;
 		el.addEventListener("pointerenter", () => handleHandCardEnter(cardId));
 		el.addEventListener("pointerleave", () => handleHandCardLeave());
-		// Direct click handler as primary (not relying on document delegation)
-		el.addEventListener("click", (e) => {
-			e.stopPropagation();
-			console.log("[router] direct card click", { cardId });
-			(globalThis as any).selectHandCard?.(cardId);
-		});
-	});
-
-	// Board cell click (add listeners directly to each cell)
-	document.querySelectorAll("[data-board-cell]").forEach((el) => {
-		el.addEventListener("click", (e) => {
-			const row = Number(el.getAttribute("data-row-index"));
-			const col = Number(el.getAttribute("data-col-index"));
-			console.log("[router] direct board click", { row, col });
-			e.stopPropagation();
-			(globalThis as any).handleBoardCellClick?.(row, col);
-		});
 	});
 
 	// Focused card close
@@ -100,29 +83,16 @@ function reattachCardClickDelegation() {
 // Old TREKPOLOGY used capture:true + [data-draft-card-id] for draft cards.
 // This ensures clicks are caught before any inline handler processes them.
 
-console.log("[router] event delegation installed");
-
 document.addEventListener(
 	"click",
 	(e) => {
 		const target = e.target as HTMLElement;
-		const phase = (globalThis as any).getGamePhase?.() || "?";
-
-		console.log("[router] click in capture", {
-			tag: target.tagName,
-			cls: target.className?.slice(0, 60),
-			dd: !!target.closest("[data-draft-card-id]"),
-			hc: !!target.closest("[data-hand-card-id]"),
-			bc: !!target.closest("[data-board-cell]"),
-			phase,
-		});
 
 		// Draft card click (via [data-draft-card-id] wrapper)
 		const draftCard = target.closest("[data-draft-card-id]");
 		if (draftCard) {
 			const cardId = draftCard.getAttribute("data-draft-card-id");
 			if (cardId) {
-				console.log("[router] draft matched");
 				e.preventDefault();
 				e.stopPropagation();
 				(globalThis as any).selectHandCard?.(cardId);
@@ -135,7 +105,6 @@ document.addEventListener(
 		if (handCard && !handCard.closest(".hand-card__close")) {
 			const cardId = handCard.getAttribute("data-hand-card-id");
 			if (cardId) {
-				console.log("[router] hand matched");
 				e.preventDefault();
 				e.stopPropagation();
 				(globalThis as any).selectHandCard?.(cardId);
@@ -148,7 +117,6 @@ document.addEventListener(
 		if (boardCell) {
 			const row = Number(boardCell.getAttribute("data-row-index"));
 			const col = Number(boardCell.getAttribute("data-col-index"));
-			console.log("[router] board matched");
 			e.preventDefault();
 			e.stopPropagation();
 			(globalThis as any).handleBoardCellClick?.(row, col);

--- a/src/router.ts
+++ b/src/router.ts
@@ -82,11 +82,14 @@ function reattachCardClickDelegation() {
 // ── Document-level event delegation for board cell & hand card clicks ──────
 // Replaces inline onclick — no event.stopPropagation conflict.
 
+console.log("[router] event delegation installed");
+
 document.addEventListener("click", (e) => {
 	const target = e.target as HTMLElement;
 
 	const boardCell = target.closest("[data-board-cell]");
 	if (boardCell) {
+		console.log("[router] board cell clicked", { row: boardCell.getAttribute("data-row-index"), col: boardCell.getAttribute("data-col-index") });
 		e.stopPropagation();
 		const row = Number(boardCell.getAttribute("data-row-index"));
 		const col = Number(boardCell.getAttribute("data-col-index"));
@@ -96,6 +99,7 @@ document.addEventListener("click", (e) => {
 
 	const handCard = target.closest("[data-hand-card-id]");
 	if (handCard && !target.closest(".hand-card__close")) {
+		console.log("[router] hand/draft card clicked", { cardId: handCard.getAttribute("data-hand-card-id") });
 		e.stopPropagation();
 		const cardId = handCard.getAttribute("data-hand-card-id");
 		if (cardId) {

--- a/src/state.ts
+++ b/src/state.ts
@@ -51,7 +51,7 @@ function getCurrentPlayerBoard(): BoardSlots {
 	return playerBoards[currentPlayerId];
 }
 
-function setCurrentPlayerBoard(nextBoard: BoardSlots) {
+export function setCurrentPlayerBoard(nextBoard: BoardSlots) {
 	playerBoards[currentPlayerId] = nextBoard;
 }
 


### PR DESCRIPTION
## Bugs fixed

### 1. Placement double-fire (router.ts + app.ts)
Removed redundant per-element `addEventListener("click")` from `reattachCardClickDelegation`. The document-level capture-phase handler is the single intended click path. Previously, every hand card click fired **twice** — the first call selected the card, the second call immediately toggled it back, making placement feel broken.

### 2. Board state bypass (state.ts + app.ts)
Exported `setCurrentPlayerBoard` and call it after `board[row][col] = card`. Without this, board mutations were invisible to any future state reset/sync.

### 3. Hand array shared reference (app.ts)
`finishDailyDraft` now snapshots the hand with `[...getPlayerHand()]` instead of the no-op read-then-set-the-same-reference.

### 4. Draft pool should shrink each round (app.ts)
Pool now deals 7→6→5→4→3 cards across rounds (was always 6 after round 1). The last round leaves 2 cards remaining, simulating a real draft pack being passed around.

### 5. Board mini card CSS mismatch (render.ts)
`renderBoardMiniCard` used class names like `.board-mini-card` but the CSS expects `.board-mini` with a completely different structure (`board-mini__image` with background-image, `board-mini__tag` with lowercased tag, `board-mini__vp`). Previously the CSS never applied — cards rendered zoomed/unstyled.

## Testing
- Draft → 5 picks → Placement → click hand card → board cells show placeable → click cell → card placed → works end-to-end