### PR TITLE
hotfix: fetch LFS audio on deploy, copy source map

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -28,6 +28,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: true
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -51,6 +53,7 @@ jobs:
           # Build output
           cp build/client.js _site/build/
           cp build/client.css _site/build/
+          cp build/client.js.map _site/build/ 2>/dev/null || true
           # Assets (strip public/ prefix — SW expects /assets/...)
           cp -r public/assets/* _site/assets/
 


### PR DESCRIPTION
Audio files (ui-click.mp3, card-deal.mp3 etc.) are Git LFS-tracked. GitHub Pages served LFS pointer files (130 bytes of text) instead of actual MP3s → browser can't decode.

Fix: `actions/checkout@v4` with `lfs: true` so actual binaries are used.

Also copies `client.js.map` to \_site to stop 404 noise.