### PR TITLE
feat: focused card popup overlay (hold 500ms to view enlarged card)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -82,8 +82,9 @@ const DRAFT_POOL_SIZE = 7;
 const DRAFT_PICK_TARGET = HAND_SIZE; // 5
 
 const VERSION = "0.13.0";
+const BUILD_TIME = Date.now();
 const gameName = "Trekkopoly";
-console.log(`${gameName} v${VERSION} running!`);
+console.log(`${gameName} v${VERSION} (build ${new Date(BUILD_TIME).toISOString().slice(0, 19).replace("T", " ")}) running!`);
 
 // Initialise audio
 setupGameAudioDelegation();

--- a/src/app.ts
+++ b/src/app.ts
@@ -55,6 +55,9 @@ import {
 	setRemainingTurnSeconds,
 	getLocalCoinDebt,
 	setLocalCoinDebt,
+	setSuppressNextClick,
+	getHoldTimerId,
+	setHoldTimerId,
 } from "./state.ts";
 import type { TravelCard } from "./shared/types.ts";
 import { createInitialDeck, shuffleCards } from "./shared/deck.ts";
@@ -78,7 +81,7 @@ import { ROWS } from "./arena/render.ts";
 const DRAFT_POOL_SIZE = 7;
 const DRAFT_PICK_TARGET = HAND_SIZE; // 5
 
-const VERSION = "0.12.5";
+const VERSION = "0.13.0";
 const gameName = "Trekkopoly";
 console.log(`${gameName} v${VERSION} running!`);
 
@@ -652,6 +655,37 @@ function startNextDayOrPhase() {
 		return;
 	}
 };
+
+// ── Focused card popup (hold 500ms to view enlarged card) ────────────────
+
+(globalThis as any).startHoldHandCard = (cardId: string) => {
+	if (getGamePhase() === "simulation") return;
+
+	clearHoldCardTimer();
+
+	const id = window.setTimeout(() => {
+		setFocusedHandCardId(cardId);
+		setFocusedBoardCard(null);
+		setSuppressNextClick(true);
+		setShowFocusedPopup(true);
+		setHoldTimerId(null);
+		rerenderGameShell();
+	}, 500);
+
+	setHoldTimerId(id);
+};
+
+(globalThis as any).cancelHoldHandCard = () => {
+	clearHoldCardTimer();
+};
+
+function clearHoldCardTimer() {
+	const id = getHoldTimerId();
+	if (id !== null) {
+		clearTimeout(id);
+		setHoldTimerId(null);
+	}
+}
 
 (globalThis as any).clearSelectedHandCard = () => {
 	setSelectedHandCardId(null);

--- a/src/app.ts
+++ b/src/app.ts
@@ -16,6 +16,7 @@ import {
 	transitionToScreen,
 	updateTimerDom,
 } from "./router.ts";
+import { renderFocusedCard } from "./arena/render.ts";
 import {
 	setDeck,
 	setPlayerHand,
@@ -31,6 +32,7 @@ import {
 	setSelectedHandCardId,
 	setFocusedHandCardId,
 	setFocusedBoardCard,
+	getFocusedBoardCard,
 	getDeck,
 	getPlayerHand,
 	getGamePhase,
@@ -84,7 +86,9 @@ const DRAFT_PICK_TARGET = HAND_SIZE; // 5
 const VERSION = "0.13.0";
 const BUILD_TIME = Date.now();
 const gameName = "Trekkopoly";
-console.log(`${gameName} v${VERSION} (build ${new Date(BUILD_TIME).toISOString().slice(0, 19).replace("T", " ")}) running!`);
+console.log(
+	`${gameName} v${VERSION} (build ${new Date(BUILD_TIME).toISOString().slice(0, 19).replace("T", " ")}) running!`,
+);
 
 // Initialise audio
 setupGameAudioDelegation();
@@ -631,11 +635,7 @@ function startNextDayOrPhase() {
 				el.classList.remove("hand-card--selected");
 			});
 		// Remove any focused popup overlay
-		const popup = document.getElementById("focused-card-close");
-		if (popup) {
-			const overlay = popup.closest(".hand-card__overlay");
-			overlay?.remove();
-		}
+		hideFocusedCardOverlay();
 
 		if (currentSelected === cardId) {
 			// Toggle off: deselect
@@ -670,7 +670,9 @@ function startNextDayOrPhase() {
 		setSuppressNextClick(true);
 		setShowFocusedPopup(true);
 		setHoldTimerId(null);
-		rerenderGameShell();
+
+		// Direct DOM injection — avoids flicker from full rerender
+		showFocusedCardOverlay(cardId);
 	}, 500);
 
 	setHoldTimerId(id);
@@ -688,10 +690,64 @@ function clearHoldCardTimer() {
 	}
 }
 
+function showFocusedCardOverlay(cardId: string) {
+	// Remove any existing overlay first
+	hideFocusedCardOverlay();
+
+	// Find the card — check hand first, then draft pool
+	let card: TravelCard | null =
+		getPlayerHand().find((c) => c.id === cardId) ?? null;
+
+	if (!card) {
+		card = getDraftPool().find((c) => c.id === cardId) ?? null;
+	}
+
+	if (!card) {
+		card = getFocusedBoardCard();
+	}
+
+	if (!card) return;
+
+	const html = renderFocusedCard(card);
+
+	// Create wrapper and insert into DOM
+	const wrapper = document.createElement("div");
+	wrapper.id = "focused-card-wrapper";
+	wrapper.style.position = "relative";
+	wrapper.style.zIndex = "10000";
+	// biome-ignore lint/suspicious/noInnerHTML: template from own render code, not user input
+	wrapper.innerHTML = html;
+
+	const app = document.getElementById("app");
+	if (app) {
+		app.appendChild(wrapper);
+
+		// Attach close handler directly
+		const closeBtn = document.getElementById("focused-card-close");
+		if (closeBtn) {
+			closeBtn.addEventListener("click", () => {
+				// If there's a selected card, also close the focused card
+				setFocusedHandCardId(null);
+				setFocusedBoardCard(null);
+				setShowFocusedPopup(false);
+				hideFocusedCardOverlay();
+			});
+		}
+	}
+}
+
+function hideFocusedCardOverlay() {
+	const existing = document.getElementById("focused-card-wrapper");
+	if (existing) {
+		existing.remove();
+	}
+}
+
 (globalThis as any).clearSelectedHandCard = () => {
 	setSelectedHandCardId(null);
 	setFocusedHandCardId(null);
 	setShowFocusedPopup(false);
+	hideFocusedCardOverlay();
 	document
 		.querySelectorAll("[data-hand-card-id].hand-card--selected")
 		.forEach((el) => {

--- a/src/router.ts
+++ b/src/router.ts
@@ -6,6 +6,10 @@
 
 import type { AppScreen } from "./shared/client-types.ts";
 import { renderMainArena } from "./arena/render.ts";
+import {
+	getSuppressNextClick,
+	setSuppressNextClick,
+} from "./state.ts";
 
 // ── Screen state ────────────────────────────────────────────────────────────
 
@@ -132,12 +136,10 @@ document.addEventListener(
 		// Hand card click
 		const handCard = target.closest("[data-hand-card-id]");
 		if (handCard && !handCard.closest(".hand-card__close")) {
-			import("./state.ts").then((s) => {
-				if (s.getSuppressNextClick()) {
-					s.setSuppressNextClick(false);
-					return; // was a hold-to-focus, suppress selection
-				}
-			});
+			if (getSuppressNextClick()) {
+				setSuppressNextClick(false);
+				return; // was a hold-to-focus, suppress selection
+			}
 			const cardId = handCard.getAttribute("data-hand-card-id");
 			if (cardId) {
 				e.preventDefault();

--- a/src/router.ts
+++ b/src/router.ts
@@ -6,10 +6,7 @@
 
 import type { AppScreen } from "./shared/client-types.ts";
 import { renderMainArena } from "./arena/render.ts";
-import {
-	getSuppressNextClick,
-	setSuppressNextClick,
-} from "./state.ts";
+import { getSuppressNextClick, setSuppressNextClick } from "./state.ts";
 
 // ── Screen state ────────────────────────────────────────────────────────────
 
@@ -98,6 +95,14 @@ function reattachCardClickDelegation() {
 		el.addEventListener("pointerup", () => handleHandCardUp());
 	});
 
+	// Draft card hold-to-focus (same mechanism, different selector)
+	document.querySelectorAll("[data-draft-card-id]").forEach((el) => {
+		const cardId = el.getAttribute("data-draft-card-id");
+		if (!cardId) return;
+		el.addEventListener("pointerdown", () => handleHandCardDown(cardId));
+		el.addEventListener("pointerup", () => handleHandCardUp());
+	});
+
 	// Focused card close
 	const closeBtn = document.getElementById("focused-card-close");
 	if (closeBtn) {
@@ -124,6 +129,10 @@ document.addEventListener(
 		// Draft card click (via [data-draft-card-id] wrapper)
 		const draftCard = target.closest("[data-draft-card-id]");
 		if (draftCard) {
+			if (getSuppressNextClick()) {
+				setSuppressNextClick(false);
+				return;
+			}
 			const cardId = draftCard.getAttribute("data-draft-card-id");
 			if (cardId) {
 				e.preventDefault();

--- a/src/router.ts
+++ b/src/router.ts
@@ -84,12 +84,14 @@ export function updateTimerDom() {
 // ── Card click delegation (backup for inline handlers, hover) ───────────────
 
 function reattachCardClickDelegation() {
-	// Hand card hover (visual feedback, no rerender)
+	// Hand card hover (visual feedback, no rerender) + hold-to-focus
 	document.querySelectorAll("[data-hand-card-id]").forEach((el) => {
 		const cardId = el.getAttribute("data-hand-card-id");
 		if (!cardId) return;
 		el.addEventListener("pointerenter", () => handleHandCardEnter(cardId));
 		el.addEventListener("pointerleave", () => handleHandCardLeave());
+		el.addEventListener("pointerdown", () => handleHandCardDown(cardId));
+		el.addEventListener("pointerup", () => handleHandCardUp());
 	});
 
 	// Focused card close
@@ -130,6 +132,12 @@ document.addEventListener(
 		// Hand card click
 		const handCard = target.closest("[data-hand-card-id]");
 		if (handCard && !handCard.closest(".hand-card__close")) {
+			import("./state.ts").then((s) => {
+				if (s.getSuppressNextClick()) {
+					s.setSuppressNextClick(false);
+					return; // was a hold-to-focus, suppress selection
+				}
+			});
 			const cardId = handCard.getAttribute("data-hand-card-id");
 			if (cardId) {
 				e.preventDefault();
@@ -168,4 +176,13 @@ function handleHandCardLeave() {
 	import("./state.ts").then((state) => {
 		state.setFocusedHandCardId(null);
 	});
+	(globalThis as any).cancelHoldHandCard?.();
+}
+
+function handleHandCardDown(cardId: string) {
+	(globalThis as any).startHoldHandCard?.(cardId);
+}
+
+function handleHandCardUp() {
+	(globalThis as any).cancelHoldHandCard?.();
 }

--- a/src/state.ts
+++ b/src/state.ts
@@ -269,6 +269,16 @@ export function setSuppressNextClick(v: boolean) {
 	suppressNextClick = v;
 }
 
+let holdTimerId: number | null = null;
+
+export function getHoldTimerId(): number | null {
+	return holdTimerId;
+}
+
+export function setHoldTimerId(id: number | null) {
+	holdTimerId = id;
+}
+
 export function getLocalCoinDebt(): number {
 	return localCoinDebt;
 }


### PR DESCRIPTION
**Adds hold-to-focus card popup** — hold any hand/draft card for 500ms to see an enlarged view with full details.

**Implementation:**
-  /  on globalThis (app.ts)
-  injects overlay DOM directly (no full rerender → no flicker)
-  prevents accidental selection after hold
- Draft cards and hand cards both supported (pointerdown/pointerup on both selectors)
- Build timestamp in console for local build identification

**Testing:** hold 500ms → popup appears while finger is down → release → click is suppressed → second click selects normally. Works in both draft and placement phases.