### PR TITLE
fix: white bar, re-entrancy guard, simulation timer cleanup

### DIFF
--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -1,0 +1,3 @@
+{
+  "skills": [".internal/skills"]
+}

--- a/css/client.less
+++ b/css/client.less
@@ -11,6 +11,13 @@
 #game-container > h1 {
   display: none;
 }
+
+/* Clip any sub-pixel rendering artifacts from the wrapper element */
+#game-container {
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
 @paper-light: #fbf8f1;
 @ink: #4e3a2b;
 @dash: #c6ad8f;
@@ -8770,11 +8777,11 @@ body,
   overflow: hidden !important;
   background:
     radial-gradient(
-      circle at center,
-      rgba(255, 255, 255, 0.4),
-      transparent 58%
+      ellipse at center,
+      transparent 60%,
+      rgba(80, 55, 25, 0.06) 100%
     ),
-    linear-gradient(180deg, #f5efe6, #e8dccb) !important;
+    #e9dece no-repeat !important;
 }
 
 .game-shell {
@@ -8875,25 +8882,39 @@ body,
 }
 
 html,
-body,
-#app {
+body {
   width: 100%;
   height: 100%;
   margin: 0;
   overflow: hidden !important;
+  /* Solid warm-beige base with a subtle edge vignette for the letterbox.
+     This replaces the radial+linear gradient overlay so borders around the
+     zoom-scaled game shell look like an intentional frame rather than blank
+     space or white-ish highlights. */
   background:
     radial-gradient(
-      circle at center,
-      rgba(255, 255, 255, 0.75),
-      transparent 58%
+      ellipse at center,
+      transparent 60%,
+      rgba(80, 55, 25, 0.06) 100%
     ),
-    linear-gradient(180deg, #f5efe6, #e8dccb) !important;
+    #e9dece no-repeat !important;
 }
 
 #app {
+  width: 100%;
+  height: 100%;
   position: fixed !important;
   inset: 0 !important;
   overflow: hidden !important;
+  /* Same letterbox styling so the fixed-position #app fills the viewport
+     with the same warm-beige frame look. */
+  background:
+    radial-gradient(
+      ellipse at center,
+      transparent 60%,
+      rgba(80, 55, 25, 0.06) 100%
+    ),
+    #e9dece no-repeat !important;
 }
 
 /*

--- a/src/app.ts
+++ b/src/app.ts
@@ -66,6 +66,10 @@ import {
 	getHandPointerDragState,
 	setHandPointerDragState,
 	setDraggedHandCardId,
+	getPlacingInProgress,
+	setPlacingInProgress,
+	getSimulationAdvanceTimeoutId,
+	setSimulationAdvanceTimeoutId,
 } from "./state.ts";
 import type { TravelCard } from "./shared/types.ts";
 import { createInitialDeck, shuffleCards } from "./shared/deck.ts";
@@ -89,7 +93,7 @@ import { ROWS } from "./arena/render.ts";
 const DRAFT_POOL_SIZE = 7;
 const DRAFT_PICK_TARGET = HAND_SIZE; // 5
 
-const VERSION = "0.14.1";
+const VERSION = "0.14.2";
 const BUILD_TIME = "__BUILD_TIME_PLACEHOLDER__";
 const gameName = "Trekkopoly";
 console.log(`${gameName} v${VERSION} (build ${BUILD_TIME}) running!`);
@@ -374,9 +378,15 @@ function placeHandCardOnBoard(
 ) {
 	if (getGamePhase() !== "placement") return;
 	if (colIndex !== getCurrentDayIndex()) return;
+	// Re-entrancy guard — prevent double-fire from click + drag-drop racing
+	if (getPlacingInProgress()) return;
+	setPlacingInProgress(true);
 
 	const board = getBoardSlots();
-	if (board[rowIndex]?.[colIndex] !== null) return;
+	if (board[rowIndex]?.[colIndex] !== null) {
+		setPlacingInProgress(false);
+		return;
+	}
 
 	const hand = getPlayerHand();
 	const handIndex = hand.findIndex((c) => c.id === cardId);
@@ -417,6 +427,9 @@ function placeHandCardOnBoard(
 	setFocusedBoardCard(null);
 	playGameSound("cardPlace");
 	rerenderGameShell();
+
+	// Release re-entrancy guard after render completes
+	setPlacingInProgress(false);
 
 	// Flash animation on the placed cell
 	requestAnimationFrame(() => {
@@ -505,9 +518,11 @@ function runSystemSimulation() {
 			rerenderGameShell();
 
 			// Advance to next day after 2s
-			window.setTimeout(() => {
+			const advanceTimeoutId = window.setTimeout(() => {
+				setSimulationAdvanceTimeoutId(null);
 				startNextDayOrPhase();
 			}, 2000);
+			setSimulationAdvanceTimeoutId(advanceTimeoutId);
 			return;
 		}
 
@@ -561,6 +576,14 @@ function clearSimulationTimer() {
 	if (id !== null) {
 		clearInterval(id);
 		setSimulationTimerId(null);
+	}
+}
+
+function cancelSimulationAdvanceTimeout() {
+	const id = getSimulationAdvanceTimeoutId();
+	if (id !== null) {
+		clearTimeout(id);
+		setSimulationAdvanceTimeoutId(null);
 	}
 }
 
@@ -654,7 +677,13 @@ function startTurnTimer() {
 }
 
 function startNextDayOrPhase() {
+	// Guard: only advance from simulation or placement; prevents stale
+	// timeouts from a previous replay from advancing the game out of order.
+	const phase = getGamePhase();
+	if (phase !== "simulation" && phase !== "placement") return;
+
 	stopTurnTimer();
+	cancelSimulationAdvanceTimeout();
 
 	// Apply coin debt penalty before advancing
 	const debt = getLocalCoinDebt();

--- a/src/state.ts
+++ b/src/state.ts
@@ -345,4 +345,28 @@ export function setPlayerBoards(boards: Record<PlayerId, BoardSlots>) {
 	playerBoards = boards;
 }
 
+// ── Placement re-entrancy guard ───────────────────────────────────────────
+
+let placingInProgress = false;
+
+export function getPlacingInProgress(): boolean {
+	return placingInProgress;
+}
+
+export function setPlacingInProgress(v: boolean) {
+	placingInProgress = v;
+}
+
+// ── Simulation advance timeout (2s delay after replay) ────────────────────
+
+let simulationAdvanceTimeoutId: number | null = null;
+
+export function getSimulationAdvanceTimeoutId(): number | null {
+	return simulationAdvanceTimeoutId;
+}
+
+export function setSimulationAdvanceTimeoutId(id: number | null) {
+	simulationAdvanceTimeoutId = id;
+}
+
 export { currentPlayerId, playerIds };


### PR DESCRIPTION
### What

- **White bar / blank borders:** Changed `html, body, #app` background to `#e9dece` solid base with subtle edge vignette. Letterbox now shows warm beige frame matching `.arena__main` instead of radial-gradient white highlights or blank space.
- **Board placement re-entrancy:** Added `placingInProgress` guard to `placeHandCardOnBoard()` — prevents double-fire from click + drag-drop racing.
- **Simulation timer cleanup:** Stored the 2s post-replay `setTimeout` in state; added `cancelSimulationAdvanceTimeout()` + phase guard to prevent stale callbacks advancing the game out of order.
- **Skills config:** `.pi/settings.json` pointing to `.internal/skills/` for 18 skills.sh skills (Deno, TS engineering, UI design).
- **Version:** 0.14.1 → 0.14.2

### Files changed

```
 css/client.less | 41 +++++++++++++++++++++++----------
 src/app.ts      | 35 ++++++++++++++++++++++++++---
 src/state.ts    | 24 ++++++++++++++++++++++
 .pi/settings.json | 1 +
 4 files changed, 90 insertions(+), 13 deletions(-)
```

### Related

- White bar fix (P0)
- Background borders fix (P0)
- Re-entrancy guard (T1)
- Simulation timer cleanup (T1)