### PR TITLE
refactor: extract VERSION/BUILD_TIME/APP_NAME to src/version.ts

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -87,16 +87,14 @@ import { getRemainingResources } from "./shared/resources.ts";
 import { calculateSimulationResult } from "./shared/scoring.ts";
 import type { GameSoundName } from "./audio/gameAudio.ts";
 import { ROWS } from "./arena/render.ts";
+import { VERSION, BUILD_TIME, APP_NAME } from "./version.ts";
 
 // ── Constants ───────────────────────────────────────────────────────────────
 
 const DRAFT_POOL_SIZE = 7;
 const DRAFT_PICK_TARGET = HAND_SIZE; // 5
 
-const VERSION = "0.14.2";
-const BUILD_TIME = "__BUILD_TIME_PLACEHOLDER__";
-const gameName = "Trekkopoly";
-console.log(`${gameName} v${VERSION} (build ${BUILD_TIME}) running!`);
+console.log(`${APP_NAME} v${VERSION} (build ${BUILD_TIME}) running!`);
 
 // ── Exhaust lock token system ──────────────────────────────────────────────
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,9 @@
+/**
+ * Application version and build metadata.
+ * Bump VERSION before each release.
+ * BUILD_TIME is replaced at build time by the bundler (rollup).
+ */
+
+export const VERSION = "0.14.3";
+export const BUILD_TIME = "__BUILD_TIME_PLACEHOLDER__";
+export const APP_NAME = "Trekkopoly";


### PR DESCRIPTION
Move hardcoded version constants from `app.ts` to a dedicated `version.ts` module.

- `VERSION`, `BUILD_TIME`, `APP_NAME` now live in `src/version.ts`
- `app.ts` imports from there instead of hardcoding
- Version bump: 0.14.2 → 0.14.3

Now version bumps are obvious — just edit `src/version.ts`.