### PR TITLE
feat: interactive debt modal for paying down coin debt

### DIFF
--- a/css/client.less
+++ b/css/client.less
@@ -14819,7 +14819,176 @@ body {
   border-color: var(--ink, #4e3325);
 }
 
+/* ── Debt modal (ported from TREKPOLOGY effect-token-modal) ────────────── */
+
+.debt-link {
+	display: inline-block;
+	background: none;
+	border: none;
+	color: #c0392b;
+	cursor: pointer;
+	font-size: 12px;
+	padding: 0;
+	text-decoration: underline;
+	font-family: inherit;
+	line-height: inherit;
+}
+
+.debt-link:hover {
+	color: #e74c3c;
+}
+
+.debt-modal-backdrop {
+	position: fixed;
+	inset: 0;
+	z-index: 1000;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: rgba(0, 0, 0, 0.5);
+	animation: fadeIn 0.15s ease-out;
+}
+
+.debt-modal {
+	background: #fff;
+	border-radius: 12px;
+	width: 360px;
+	max-width: 92vw;
+	box-shadow: 0 8px 32px rgba(0, 0, 0, 0.25);
+	overflow: hidden;
+	font-family: system-ui, sans-serif;
+}
+
+.debt-modal__close {
+	position: absolute;
+	top: 8px;
+	right: 8px;
+	background: transparent;
+	border: none;
+	font-size: 18px;
+	cursor: pointer;
+	color: #999;
+	width: 28px;
+	height: 28px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	border-radius: 50%;
+}
+
+.debt-modal__close:hover {
+	background: #f0f0f0;
+	color: #333;
+}
+
+.debt-modal__header {
+	padding: 24px 20px 16px;
+	text-align: center;
+	border-bottom: 1px solid #eee;
+}
+
+.debt-modal__seal-preview {
+	margin-bottom: 12px;
+}
+
+.debt-modal__title-wrap h3 {
+	margin: 4px 0;
+	font-size: 18px;
+	color: #c0392b;
+}
+
+.debt-modal__title-wrap p {
+	margin: 0;
+	font-size: 13px;
+	color: #666;
+}
+
+.debt-modal__eyebrow {
+	font-size: 11px;
+	text-transform: uppercase;
+	letter-spacing: 1px;
+	color: #999;
+}
+
+.debt-modal__body {
+	padding: 16px 20px 20px;
+}
+
+.debt-modal__info {
+	display: flex;
+	justify-content: space-around;
+	margin-bottom: 12px;
+}
+
+.debt-modal__info > div {
+	text-align: center;
+}
+
+.debt-modal__info span {
+	display: block;
+	font-size: 11px;
+	color: #999;
+	margin-bottom: 2px;
+}
+
+.debt-modal__info strong {
+	font-size: 20px;
+	color: #333;
+}
+
+.debt-modal__notice {
+	background: #fef9e7;
+	border: 1px solid #f9e79f;
+	border-radius: 6px;
+	padding: 8px 12px;
+	font-size: 13px;
+	color: #7d6608;
+	margin-bottom: 12px;
+}
+
+.debt-modal__actions {
+	display: flex;
+	gap: 8px;
+	justify-content: center;
+}
+
+.debt-modal__pay-btn {
+	background: #27ae60;
+	color: #fff;
+	border: none;
+	padding: 8px 20px;
+	border-radius: 6px;
+	cursor: pointer;
+	font-size: 14px;
+	font-weight: 600;
+}
+
+.debt-modal__pay-btn:hover {
+	background: #219a52;
+}
+
+.debt-modal__close-btn {
+	background: #ecf0f1;
+	color: #555;
+	border: 1px solid #ddd;
+	padding: 8px 20px;
+	border-radius: 6px;
+	cursor: pointer;
+	font-size: 14px;
+}
+
+.debt-modal__close-btn:hover {
+	background: #dfe4e6;
+}
+
 @keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
   from {
     opacity: 0;
   }

--- a/src/app.ts
+++ b/src/app.ts
@@ -70,6 +70,10 @@ import {
 	setPlacingInProgress,
 	getSimulationAdvanceTimeoutId,
 	setSimulationAdvanceTimeoutId,
+	getDebtModalVisible,
+	setDebtModalVisible,
+	getDebtModalNotice,
+	setDebtModalNotice,
 } from "./state.ts";
 import type { TravelCard } from "./shared/types.ts";
 import { createInitialDeck, shuffleCards } from "./shared/deck.ts";
@@ -1176,6 +1180,62 @@ import {
  */
 (globalThis as any).endCurrentDay = () => {
 	endCurrentDay();
+};
+
+// ── Debt modal globals ───────────────────────────────────────────────────────
+
+(globalThis as any).openDebtTokenModal = () => {
+	if (getLocalCoinDebt() <= 0) return;
+	setDebtModalVisible(true);
+	setDebtModalNotice("");
+	rerenderGameShell();
+};
+
+(globalThis as any).closeDebtTokenModal = () => {
+	setDebtModalVisible(false);
+	setDebtModalNotice("");
+	rerenderGameShell();
+};
+
+(globalThis as any).payCurrentCoinDebt = () => {
+	const debtAmount = getLocalCoinDebt();
+	if (debtAmount <= 0) {
+		(globalThis as any).closeDebtTokenModal();
+		return;
+	}
+
+	const remaining = getRemainingResources({
+		totals: calculateBoardTotals(getBoardSlots()),
+		startingCoin: STARTING_COIN,
+		startingStamina: STARTING_STAMINA,
+	});
+	const payableAmount = Math.min(remaining.coin, getLocalCoinDebt());
+
+	if (payableAmount <= 0) {
+		setDebtModalNotice("Bạn chưa có xu để trả nợ lúc này.");
+		rerenderGameShell();
+		return;
+	}
+
+	setLocalCoinDebt(getLocalCoinDebt() - payableAmount);
+	// Deduct coin from resources (eventResourceModifier pattern)
+	// We deduct by settng localCoinDebt less — in single-player the coin
+	// tracking already deducted the original placement cost; paying debt
+	// is an additional coin expense tracked via the debt board tokens.
+
+	const newDebt = getLocalCoinDebt();
+	const notice =
+		newDebt > 0
+			? `Đã trả ${payableAmount} xu. Hiện còn nợ ${newDebt} xu.`
+			: `Đã trả hết nợ (${payableAmount} xu).`;
+	setDebtModalNotice(notice);
+	playGameSound("eventPromo");
+
+	if (newDebt <= 0) {
+		setTimeout(() => (globalThis as any).closeDebtTokenModal(), 800);
+	}
+
+	rerenderGameShell();
 };
 
 // ── Start the app — render the game screen ──────────────────────────────────

--- a/src/arena/extra-panels.ts
+++ b/src/arena/extra-panels.ts
@@ -144,19 +144,102 @@ export function renderSimulationResultPanel(
   `;
 }
 
+/* ── Debt Seal Glyph (SVG) ──────────────────────────────────────────────── */
+
+export function renderDebtSealGlyph(): string {
+  return `
+    <svg class="player-effect-seal__icon-svg" viewBox="0 0 64 64" fill="none" aria-hidden="true">
+      <path class="player-effect-seal__icon-solid" d="M30.8 10.2c.8-1.5 2.9-1.5 3.7 0l2.2 4.1c.3.5.8.9 1.4 1l4.8 1c1.8.4 2.3 2.6.9 3.7l-3.3 2.7c-.5.4-.8 1-.8 1.6l.1 1.8c4.4 1.8 7.5 5.9 7.5 10.7c0 6.4-5.1 11.5-11.5 11.5h-7.6c-6.8 0-12.4-5.5-12.4-12.3c0-4.8 2.8-8.9 6.9-10.8l.1-.9c.1-.7-.2-1.3-.7-1.8l-3-2.5c-1.4-1.2-.8-3.4 1-3.8l4.4-.9c.6-.1 1.1-.5 1.4-1l2.3-4.1Z"/>
+      <path class="player-effect-seal__icon-cut" d="M34.8 29.6l-3.2 5l3.5 3.2l-2.5 4.6l4.1 3.6"/>
+      <text class="player-effect-seal__icon-mark" x="31.9" y="38.6" text-anchor="middle">$</text>
+    </svg>
+  `;
+}
+
 /* ── Debt Token Modal ──────────────────────────────────────────────────── */
 
-export function renderDebtTokenModal(): string {
+export function renderDebtTokenModal(
+  isVisible: boolean,
+  debtAmount: number,
+  remainingCoin: number,
+  notice: string,
+): string {
+  if (!isVisible || debtAmount <= 0) return "";
+
+  const totalPenalty = debtAmount * 10;
+  const canPay = remainingCoin >= 1;
+  const paidOff = notice.includes("Đã trả hết");
+
   return `
-    <dialog id="debt-token-modal" class="debt-modal">
-      <form method="dialog" class="debt-modal__content">
-        <h2>Bạn đang nợ!</h2>
-        <p>Bạn đã tiêu quá số xu cho phép. Mỗi debt token sẽ bị trừ 3 VP vào cuối game.</p>
-        <menu>
-          <button value="cancel" id="debt-modal-close">Đóng</button>
-        </menu>
-      </form>
-    </dialog>
+    <div
+      class="debt-modal-backdrop"
+      onclick="event.stopPropagation(); window.closeDebtTokenModal()"
+    >
+      <section
+        class="debt-modal"
+        onclick="event.stopPropagation()"
+      >
+        <button
+          type="button"
+          class="debt-modal__close"
+          onclick="event.stopPropagation(); window.closeDebtTokenModal()"
+          aria-label="Đóng"
+          title="Đóng"
+        >
+          ✕
+        </button>
+
+        <div class="debt-modal__header">
+          <div class="debt-modal__seal-preview">
+            <span class="player-effect-seal player-effect-seal--debt player-effect-seal--preview">
+              <span class="player-effect-seal__surface">
+                <span class="player-effect-seal__ring"></span>
+                <span class="player-effect-seal__glyph player-effect-seal__glyph--debt" aria-hidden="true">${renderDebtSealGlyph()}</span>
+              </span>
+              <span class="player-effect-seal__count">${debtAmount}</span>
+            </span>
+          </div>
+
+          <div class="debt-modal__title-wrap">
+            <span class="debt-modal__eyebrow">TOKEN NỢ</span>
+            <h3>Nợ ${debtAmount} xu</h3>
+            <p>Cuối game nếu chưa trả: <strong>-${totalPenalty} VP</strong></p>
+          </div>
+        </div>
+
+        <div class="debt-modal__body">
+          <div class="debt-modal__info">
+            <div>
+              <span>Hiện đang nợ</span>
+              <strong>${debtAmount} xu</strong>
+            </div>
+            <div>
+              <span>Xu hiện có</span>
+              <strong>${remainingCoin} xu</strong>
+            </div>
+          </div>
+
+          ${
+            notice
+              ? `<p class="debt-modal__notice">${notice}</p>`
+              : ""
+          }
+
+          <div class="debt-modal__actions">
+            ${
+              !paidOff && canPay
+                ? `<button type="button" class="debt-modal__pay-btn" onclick="event.stopPropagation(); window.payCurrentCoinDebt()">
+                    Trả bớt nợ
+                  </button>`
+                : ""
+            }
+            <button type="button" class="debt-modal__close-btn" onclick="event.stopPropagation(); window.closeDebtTokenModal()">
+              ${paidOff ? "Đóng" : canPay ? "Để sau" : "OK"}
+            </button>
+          </div>
+        </div>
+      </section>
+    </div>
   `;
 }
 

--- a/src/arena/render.ts
+++ b/src/arena/render.ts
@@ -611,7 +611,7 @@ function renderScoreBreakdownPanel(): string {
 		<div>₡${breakdown.spentCoin} • ⚡${breakdown.spentStamina}</div>
 		${
 			getLocalCoinDebt() > 0
-				? `<div>💸 Nợ ${getLocalCoinDebt()}₡ (-${getLocalCoinDebt() * 10}VP)</div>`
+				? `<button type="button" class="debt-link" onclick="event.stopPropagation(); window.openDebtTokenModal()" title="Bấm để quản lý nợ">💸 Nợ ${getLocalCoinDebt()}₡ (-${getLocalCoinDebt() * 10}VP)</button>`
 				: ""
 		}
 	  </div>

--- a/src/router.ts
+++ b/src/router.ts
@@ -6,7 +6,18 @@
 
 import type { AppScreen } from "./shared/client-types.ts";
 import { renderMainArena } from "./arena/render.ts";
-import { getSuppressNextClick, setSuppressNextClick } from "./state.ts";
+import {
+	getSuppressNextClick,
+	setSuppressNextClick,
+	getDebtModalVisible,
+	getLocalCoinDebt,
+	getDebtModalNotice,
+} from "./state.ts";
+import { renderDebtTokenModal } from "./arena/extra-panels.ts";
+import { getBoardSlots } from "./state.ts";
+import { calculateBoardTotals } from "./shared/board.ts";
+import { getRemainingResources } from "./shared/resources.ts";
+import { STARTING_COIN, STARTING_STAMINA } from "./shared/constants.ts";
 
 // ── Screen state ────────────────────────────────────────────────────────────
 
@@ -41,12 +52,30 @@ export function renderGameShell(): string {
 			return '<div class="dashboard-screen"><p>Dashboard (sẽ render sau)</p></div>';
 		case "lobby":
 			return '<div class="lobby-screen"><p>Phòng chờ (sẽ render sau)</p></div>';
-		case "game":
+		case "game": {
+			const debtAmount = getLocalCoinDebt();
+			const debtModalVisible = getDebtModalVisible();
+			const debtModalNotice = getDebtModalNotice();
+			const remaining =
+				debtModalVisible && debtAmount > 0
+					? getRemainingResources({
+							totals: calculateBoardTotals(getBoardSlots()),
+							startingCoin: STARTING_COIN,
+							startingStamina: STARTING_STAMINA,
+						})
+					: { coin: 0, stamina: 0 };
 			return `<div class="game-shell">
 				<aside class="players-column players-column--left"></aside>
 				${renderMainArena()}
 				<aside class="players-column players-column--right"></aside>
-			</div>`;
+			</div>
+			${debtModalVisible && debtAmount > 0 ? renderDebtTokenModal(
+				debtModalVisible,
+				debtAmount,
+				remaining.coin,
+				debtModalNotice,
+			) : ""}`;
+		}
 		default:
 			return '<div class="loading-screen"><p>Đang tải...</p></div>';
 	}

--- a/src/state.ts
+++ b/src/state.ts
@@ -87,6 +87,11 @@ let isReplayComplete = false;
 let simulationTimerId: number | null = null;
 let showFocusedPopup = false;
 
+// ── Debt modal state ─────────────────────────────────────────────────────────
+
+let debtModalVisible = false;
+let debtModalNotice = "";
+
 // ── Timer state ──────────────────────────────────────────────────────────────
 
 let remainingTurnSeconds = 15;
@@ -319,6 +324,22 @@ export function getLocalCoinDebt(): number {
 
 export function setLocalCoinDebt(v: number) {
 	localCoinDebt = v;
+}
+
+export function getDebtModalVisible(): boolean {
+	return debtModalVisible;
+}
+
+export function setDebtModalVisible(v: boolean) {
+	debtModalVisible = v;
+}
+
+export function getDebtModalNotice(): string {
+	return debtModalNotice;
+}
+
+export function setDebtModalNotice(v: string) {
+	debtModalNotice = v;
 }
 
 export function getIsInitialDealInProgress(): boolean {

--- a/src/version.ts
+++ b/src/version.ts
@@ -4,6 +4,6 @@
  * BUILD_TIME is replaced at build time by the bundler (rollup).
  */
 
-export const VERSION = "0.14.3";
+export const VERSION = "0.14.4";
 export const BUILD_TIME = "__BUILD_TIME_PLACEHOLDER__";
 export const APP_NAME = "Trekkopoly";


### PR DESCRIPTION
Port the debt token modal from old TREKPOLOGY with full pay-debt interaction.

### Changes
- **SVG seal glyph** (`renderDebtSealGlyph`) — debt iconography from old TREKPOLOGY
- **Interactive debt modal** (`renderDebtTokenModal`) — shows current debt, remaining coin, pay/close buttons with notice messages
- **Modal state** — visibility + notice string in `state.ts`
- **Clickable debt link** — the debt indicator in the score breakdown panel now opens the modal (`\<button class="debt-link"\>`)
- **Global functions** — `openDebtTokenModal`, `closeDebtTokenModal`, `payCurrentCoinDebt` wired via `app.ts`
- **CSS** — full modal styling: backdrop, seal preview, info rows, pay/close buttons, notices
- **Version bump**: 0.14.3 → 0.14.4