### PR TITLE
fix: remove duplicate @keyframes fadeIn block

### DIFF
--- a/css/client.less
+++ b/css/client.less
@@ -14989,10 +14989,3 @@ body {
     opacity: 1;
   }
 }
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-}


### PR DESCRIPTION
Fix CSS build error introduced in #108. The Less compiler found an orphaned keyframe body without a preceding `@keyframes fadeIn` header — leftover from an edit that only removed one of two duplicate declarations.

```
ParseError: Unrecognised input. Possibly missing opening '{'
  in css/client.less on line 14998, column 1:
14997   }
14998  }
```