### PR TITLE
feat: port full dashboard screen (hero, auth, explore, modals)

### DIFF
--- a/css/client.less
+++ b/css/client.less
@@ -14822,163 +14822,163 @@ body {
 /* ── Debt modal (ported from TREKPOLOGY effect-token-modal) ────────────── */
 
 .debt-link {
-	display: inline-block;
-	background: none;
-	border: none;
-	color: #c0392b;
-	cursor: pointer;
-	font-size: 12px;
-	padding: 0;
-	text-decoration: underline;
-	font-family: inherit;
-	line-height: inherit;
+  display: inline-block;
+  background: none;
+  border: none;
+  color: #c0392b;
+  cursor: pointer;
+  font-size: 12px;
+  padding: 0;
+  text-decoration: underline;
+  font-family: inherit;
+  line-height: inherit;
 }
 
 .debt-link:hover {
-	color: #e74c3c;
+  color: #e74c3c;
 }
 
 .debt-modal-backdrop {
-	position: fixed;
-	inset: 0;
-	z-index: 1000;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	background: rgba(0, 0, 0, 0.5);
-	animation: fadeIn 0.15s ease-out;
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.5);
+  animation: fadeIn 0.15s ease-out;
 }
 
 .debt-modal {
-	background: #fff;
-	border-radius: 12px;
-	width: 360px;
-	max-width: 92vw;
-	box-shadow: 0 8px 32px rgba(0, 0, 0, 0.25);
-	overflow: hidden;
-	font-family: system-ui, sans-serif;
+  background: #fff;
+  border-radius: 12px;
+  width: 360px;
+  max-width: 92vw;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.25);
+  overflow: hidden;
+  font-family: system-ui, sans-serif;
 }
 
 .debt-modal__close {
-	position: absolute;
-	top: 8px;
-	right: 8px;
-	background: transparent;
-	border: none;
-	font-size: 18px;
-	cursor: pointer;
-	color: #999;
-	width: 28px;
-	height: 28px;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	border-radius: 50%;
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background: transparent;
+  border: none;
+  font-size: 18px;
+  cursor: pointer;
+  color: #999;
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
 }
 
 .debt-modal__close:hover {
-	background: #f0f0f0;
-	color: #333;
+  background: #f0f0f0;
+  color: #333;
 }
 
 .debt-modal__header {
-	padding: 24px 20px 16px;
-	text-align: center;
-	border-bottom: 1px solid #eee;
+  padding: 24px 20px 16px;
+  text-align: center;
+  border-bottom: 1px solid #eee;
 }
 
 .debt-modal__seal-preview {
-	margin-bottom: 12px;
+  margin-bottom: 12px;
 }
 
 .debt-modal__title-wrap h3 {
-	margin: 4px 0;
-	font-size: 18px;
-	color: #c0392b;
+  margin: 4px 0;
+  font-size: 18px;
+  color: #c0392b;
 }
 
 .debt-modal__title-wrap p {
-	margin: 0;
-	font-size: 13px;
-	color: #666;
+  margin: 0;
+  font-size: 13px;
+  color: #666;
 }
 
 .debt-modal__eyebrow {
-	font-size: 11px;
-	text-transform: uppercase;
-	letter-spacing: 1px;
-	color: #999;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: #999;
 }
 
 .debt-modal__body {
-	padding: 16px 20px 20px;
+  padding: 16px 20px 20px;
 }
 
 .debt-modal__info {
-	display: flex;
-	justify-content: space-around;
-	margin-bottom: 12px;
+  display: flex;
+  justify-content: space-around;
+  margin-bottom: 12px;
 }
 
 .debt-modal__info > div {
-	text-align: center;
+  text-align: center;
 }
 
 .debt-modal__info span {
-	display: block;
-	font-size: 11px;
-	color: #999;
-	margin-bottom: 2px;
+  display: block;
+  font-size: 11px;
+  color: #999;
+  margin-bottom: 2px;
 }
 
 .debt-modal__info strong {
-	font-size: 20px;
-	color: #333;
+  font-size: 20px;
+  color: #333;
 }
 
 .debt-modal__notice {
-	background: #fef9e7;
-	border: 1px solid #f9e79f;
-	border-radius: 6px;
-	padding: 8px 12px;
-	font-size: 13px;
-	color: #7d6608;
-	margin-bottom: 12px;
+  background: #fef9e7;
+  border: 1px solid #f9e79f;
+  border-radius: 6px;
+  padding: 8px 12px;
+  font-size: 13px;
+  color: #7d6608;
+  margin-bottom: 12px;
 }
 
 .debt-modal__actions {
-	display: flex;
-	gap: 8px;
-	justify-content: center;
+  display: flex;
+  gap: 8px;
+  justify-content: center;
 }
 
 .debt-modal__pay-btn {
-	background: #27ae60;
-	color: #fff;
-	border: none;
-	padding: 8px 20px;
-	border-radius: 6px;
-	cursor: pointer;
-	font-size: 14px;
-	font-weight: 600;
+  background: #27ae60;
+  color: #fff;
+  border: none;
+  padding: 8px 20px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 600;
 }
 
 .debt-modal__pay-btn:hover {
-	background: #219a52;
+  background: #219a52;
 }
 
 .debt-modal__close-btn {
-	background: #ecf0f1;
-	color: #555;
-	border: 1px solid #ddd;
-	padding: 8px 20px;
-	border-radius: 6px;
-	cursor: pointer;
-	font-size: 14px;
+  background: #ecf0f1;
+  color: #555;
+  border: 1px solid #ddd;
+  padding: 8px 20px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 14px;
 }
 
 .debt-modal__close-btn:hover {
-	background: #dfe4e6;
+  background: #dfe4e6;
 }
 
 @keyframes fadeIn {
@@ -14988,4 +14988,742 @@ body {
   to {
     opacity: 1;
   }
+}
+
+/* ==============================================
+   TREKPOLOGY — Dashboard Hub
+   ============================================== */
+
+:root {
+  --map-accent:   #9a7c57;
+  --map-accent-h: #b89167;
+}
+
+.dashboard-hub {
+  position: absolute;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  color: #4e3a2b;
+  background: #1a1410;
+}
+
+.hub-topbar {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 60px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 36px;
+  z-index: 20;
+  background: linear-gradient(to bottom, rgba(20,14,10,0.72) 0%, transparent 100%);
+}
+
+.hub-topbar__logo {
+  font-size: 20px;
+  font-weight: 900;
+  letter-spacing: 3px;
+  color: #fff;
+  text-shadow: 0 1px 6px rgba(0,0,0,0.5);
+}
+
+.hub-topbar__nav {
+  display: flex;
+  gap: 4px;
+}
+
+.hub-topbar__nav button {
+  background: rgba(255,255,255,0.08);
+  border: 1px solid rgba(255,255,255,0.14);
+  color: rgba(255,255,255,0.85);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 7px 16px;
+  border-radius: 20px;
+  transition: all 0.18s;
+  white-space: nowrap;
+  backdrop-filter: blur(6px);
+}
+
+.hub-topbar__nav button:hover {
+  background: rgba(255,255,255,0.18);
+  color: #fff;
+}
+
+.hub-topbar__account {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.hub-topbar__user {
+  font-size: 13px;
+  font-weight: 700;
+  color: rgba(255,255,255,0.92);
+  padding: 5px 14px;
+  border: 1px solid rgba(255,255,255,0.2);
+  border-radius: 20px;
+  background: rgba(255,255,255,0.08);
+  backdrop-filter: blur(6px);
+}
+
+.hub-topbar__guest,
+.hub-topbar__logout {
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+  padding: 7px 16px;
+  border-radius: 20px;
+  transition: all 0.18s;
+  backdrop-filter: blur(6px);
+}
+
+.hub-topbar__guest {
+  border: 1px solid rgba(255,255,255,0.22);
+  background: rgba(154,124,87,0.32);
+  color: #fff;
+}
+
+.hub-topbar__guest:hover {
+  background: rgba(154,124,87,0.52);
+}
+
+.hub-topbar__logout {
+  border: 1px solid rgba(255,255,255,0.16);
+  background: rgba(255,255,255,0.06);
+  color: rgba(255,255,255,0.82);
+}
+
+.hub-topbar__logout:hover {
+  background: rgba(255,255,255,0.14);
+  color: #fff;
+}
+
+.hub-body {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 1fr 360px;
+  overflow: hidden;
+}
+
+.hub-hero {
+  position: relative;
+  overflow: hidden;
+}
+
+.hub-hero__media {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  background: #1a1410;
+}
+
+.hub-hero__media--paused .hub-hero__video {
+  animation-play-state: paused;
+  filter: saturate(0.92) contrast(1.02) brightness(0.88);
+}
+
+.hub-hero__video-fallback {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  background: linear-gradient(135deg, #2c1f14 0%, #4a3423 40%, #2c1f14 100%);
+}
+
+.hub-hero__video {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center 35%;
+  transform: scale(1.04);
+  animation: hub-hero-video-drift 72s ease-in-out infinite alternate;
+  filter: saturate(1.08) contrast(1.04);
+}
+
+.hub-hero__scrim {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  pointer-events: none;
+  background:
+    radial-gradient(ellipse 90% 70% at 18% 78%, rgba(15,10,6,0.18) 0%, transparent 58%),
+    radial-gradient(ellipse 55% 45% at 88% 18%, rgba(154,124,87,0.12) 0%, transparent 62%),
+    linear-gradient(to right, rgba(12,8,5,0.72) 0%, rgba(12,8,5,0.28) 42%, rgba(12,8,5,0.08) 100%),
+    linear-gradient(to top, rgba(10,7,4,0.88) 0%, rgba(10,7,4,0.34) 38%, transparent 72%);
+}
+
+.hub-hero__hitarea {
+  position: absolute;
+  inset: 0;
+  z-index: 3;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  background: transparent;
+  cursor: pointer;
+}
+
+.hub-hero__audio-controls {
+  position: absolute;
+  right: 24px;
+  bottom: 24px;
+  z-index: 6;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: rgba(12,8,5,0.58);
+  border: 1px solid rgba(255,255,255,0.14);
+  backdrop-filter: blur(8px);
+  border-radius: 999px;
+  padding: 4px 12px;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.22);
+  transition: background 0.18s ease, border-color 0.18s ease;
+}
+
+.hub-hero__audio-controls:hover {
+  background: rgba(12,8,5,0.74);
+  border-color: rgba(255,255,255,0.24);
+}
+
+.hub-hero__video-volume {
+  width: 80px;
+  height: 4px;
+  -webkit-appearance: none;
+  background: rgba(255,255,255,0.2);
+  border-radius: 2px;
+  outline: none;
+  cursor: pointer;
+  transition: opacity 0.2s;
+  opacity: 0.7;
+}
+
+.hub-hero__video-volume:hover {
+  opacity: 1;
+}
+
+.hub-hero__video-volume::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: #fff;
+  cursor: pointer;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.5);
+}
+
+.hub-hero__video-mute {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  color: rgba(255,255,255,0.92);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  transition: transform 0.18s ease, color 0.18s ease;
+}
+
+.hub-hero__video-mute:hover {
+  color: #fff;
+  transform: translateY(-1px) scale(1.05);
+}
+
+.hub-hero__video-mute-icon {
+  width: 18px;
+  height: 18px;
+  display: block;
+}
+
+.hub-hero__video-mute-icon--on {
+  display: none;
+}
+
+.hub-hero__video-mute--unmuted .hub-hero__video-mute-icon--off {
+  display: none;
+}
+
+.hub-hero__video-mute--unmuted .hub-hero__video-mute-icon--on {
+  display: block;
+}
+
+@keyframes hub-hero-video-drift {
+  from {
+    transform: scale(1.04) translate3d(0, 0, 0);
+  }
+
+  to {
+    transform: scale(1.1) translate3d(-1.2%, -0.8%, 0);
+  }
+}
+
+.hub-hero__media--placeholder {
+  background: linear-gradient(135deg, #2c1f14 0%, #4a3423 40%, #2c1f14 100%);
+}
+
+.hero-placeholder-pattern {
+  position: absolute;
+  inset: 0;
+  background-image:
+    radial-gradient(circle at 20% 50%, rgba(154,124,87,0.18) 0%, transparent 45%),
+    radial-gradient(circle at 80% 20%, rgba(198,173,143,0.12) 0%, transparent 40%),
+    radial-gradient(circle at 60% 80%, rgba(154,124,87,0.10) 0%, transparent 35%);
+  mask-image: repeating-linear-gradient(
+    -45deg,
+    transparent,
+    transparent 2px,
+    rgba(255,255,255,0.015) 2px,
+    rgba(255,255,255,0.015) 4px
+  );
+}
+
+.hub-hero__overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 5;
+  display: flex;
+  align-items: flex-end;
+  pointer-events: none;
+}
+
+.hub-hero__content {
+  padding: 52px 56px;
+  max-width: 560px;
+  pointer-events: auto;
+}
+
+.hero-eyebrow {
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 3px;
+  color: var(--map-accent);
+  text-transform: uppercase;
+  margin-bottom: 14px;
+}
+
+.hero-title {
+  font-size: 56px;
+  font-weight: 900;
+  line-height: 1.05;
+  color: #fff;
+  text-shadow: 0 2px 16px rgba(0,0,0,0.4);
+  margin-bottom: 16px;
+  letter-spacing: -0.5px;
+}
+
+.hero-sub {
+  font-size: 15px;
+  color: rgba(255,255,255,0.72);
+  line-height: 1.65;
+  margin-bottom: 32px;
+  font-weight: 400;
+}
+
+.btn-play {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 16px 36px;
+  font-size: 15px;
+  font-weight: 800;
+  letter-spacing: 0.5px;
+  border-radius: 12px;
+  cursor: pointer;
+  border: none;
+  background: var(--map-accent);
+  color: white;
+  box-shadow:
+    0 8px 24px rgba(0,0,0,0.35),
+    inset 0 -3px 0 rgba(0,0,0,0.2);
+  transition: all 0.2s ease;
+}
+
+.btn-play:hover {
+  background: var(--map-accent-h);
+  transform: translateY(-3px);
+  box-shadow:
+    0 14px 32px rgba(0,0,0,0.4),
+    inset 0 -3px 0 rgba(0,0,0,0.2);
+}
+
+.btn-play:active {
+  transform: translateY(-1px);
+}
+
+.hero-auth-hint {
+  margin-top: 14px;
+  font-size: 12px;
+  color: rgba(255,255,255,0.58);
+  line-height: 1.5;
+}
+
+.dashboard-hub--loading .hub-side,
+.dashboard-hub--loading .hub-hero__content {
+  opacity: 0.72;
+  pointer-events: none;
+}
+
+.dashboard-hub--loading .hub-hero__video {
+  animation: none;
+  filter: saturate(0.85) contrast(1.02);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hub-hero__video {
+    animation: none;
+    transform: scale(1.04);
+  }
+}
+
+.hub-auth {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.hub-auth__header {
+  margin-bottom: 2px;
+}
+
+.hub-auth__eyebrow {
+  display: block;
+  font-size: 10px;
+  font-weight: 900;
+  letter-spacing: 2.2px;
+  text-transform: uppercase;
+  color: var(--map-accent);
+}
+
+.hub-auth__title {
+  margin-top: 6px;
+  font-size: 24px;
+  line-height: 1.1;
+  font-weight: 900;
+  color: #3e2e22;
+}
+
+.hub-auth__lead {
+  margin-top: 8px;
+  font-size: 12px;
+  line-height: 1.55;
+  color: #77604f;
+}
+
+.hub-auth__tabs {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+  padding: 4px;
+  border-radius: 12px;
+  background: rgba(255,255,255,0.55);
+  border: 1px solid #e8dccb;
+}
+
+.hub-auth__tab {
+  border: none;
+  border-radius: 9px;
+  padding: 10px 12px;
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  color: #8a7260;
+  background: transparent;
+  cursor: pointer;
+  transition: all 0.18s ease;
+}
+
+.hub-auth__tab.is-active {
+  color: #fff;
+  background: var(--map-accent);
+  box-shadow: 0 6px 16px rgba(80, 55, 25, 0.16);
+}
+
+.hub-auth__panels {
+  position: relative;
+}
+
+.hub-auth__panel {
+  display: none;
+  flex-direction: column;
+  gap: 0;
+  padding: 16px;
+  border-radius: 14px;
+  border: 1px solid #e8dccb;
+  background: rgba(255,255,255,0.72);
+}
+
+.hub-auth__panel.is-active {
+  display: flex;
+}
+
+.hub-auth__panel label {
+  display: grid;
+  gap: 6px;
+  margin-bottom: 12px;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #8a7260;
+}
+
+.hub-auth__panel input {
+  border: 1px solid #dcccb8;
+  border-radius: 10px;
+  padding: 11px 12px;
+  background: rgba(255,255,255,0.92);
+  color: #3e2e22;
+  font-size: 14px;
+  font-weight: 700;
+  outline: none;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.hub-auth__panel input:focus {
+  border-color: var(--map-accent);
+  box-shadow: 0 0 0 3px rgba(154,124,87,0.18);
+}
+
+.hub-auth__panel button[type="submit"] {
+  margin-top: 4px;
+  width: 100%;
+  border: none;
+  border-radius: 11px;
+  padding: 13px 16px;
+  font-size: 13px;
+  font-weight: 900;
+  letter-spacing: 0.04em;
+  color: #fff;
+  cursor: pointer;
+  background: linear-gradient(180deg, var(--map-accent-h), var(--map-accent));
+  box-shadow:
+    0 10px 22px rgba(80, 55, 25, 0.18),
+    inset 0 -2px 0 rgba(0,0,0,0.14);
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.hub-auth__panel button[type="submit"]:hover {
+  transform: translateY(-1px);
+  box-shadow:
+    0 14px 26px rgba(80, 55, 25, 0.22),
+    inset 0 -2px 0 rgba(0,0,0,0.14);
+}
+
+.hub-auth__status {
+  min-height: 18px;
+  font-size: 12px;
+  line-height: 1.45;
+  font-weight: 700;
+  color: #5a4430;
+}
+
+.hub-auth__status--error {
+  color: #b42318;
+}
+
+.hub-auth__status--success {
+  color: #15803d;
+}
+
+.hub-auth--pulse {
+  animation: hubAuthPulse 680ms ease;
+}
+
+@keyframes hubAuthPulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(154,124,87,0.28);
+  }
+
+  100% {
+    box-shadow: 0 0 0 14px rgba(154,124,87,0);
+  }
+}
+
+.hub-explore {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.hub-side {
+  background: rgba(243, 237, 227, 0.97);
+  border-left: 1px solid #d5c6ad;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.hub-side::-webkit-scrollbar {
+  width: 4px;
+}
+
+.hub-side::-webkit-scrollbar-thumb {
+  background: #d5c6ad;
+  border-radius: 4px;
+}
+
+.hub-side__inner {
+  padding: 72px 24px 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.side-title {
+  font-size: 11px;
+  font-weight: 900;
+  letter-spacing: 2.5px;
+  text-transform: uppercase;
+  color: var(--map-accent);
+  margin-bottom: 4px;
+}
+
+.news-item {
+  background: rgba(255,255,255,0.65);
+  border: 1px solid #e8dccb;
+  padding: 14px 16px;
+  border-radius: 10px;
+  transition: all 0.18s;
+}
+
+.news-item:hover {
+  border-color: #c6ad8f;
+  background: rgba(255,255,255,0.95);
+  box-shadow: 0 2px 12px rgba(78, 58, 43, 0.07);
+  transform: translateX(-3px);
+}
+
+.news-badge {
+  display: inline-block;
+  padding: 2px 9px;
+  border-radius: 4px;
+  font-size: 9px;
+  font-weight: 900;
+  letter-spacing: 0.8px;
+  text-transform: uppercase;
+  color: white;
+  margin-bottom: 7px;
+}
+
+.news-badge--new      { background: #38d873; }
+.news-badge--culture  { background: #8b5cf6; }
+.news-badge--food     { background: #f97316; }
+.news-badge--nature   { background: #22c55e; }
+.news-badge--heritage { background: #0ea5e9; }
+
+.news-item h4 {
+  font-size: 14px;
+  font-weight: 800;
+  color: #3e2e22;
+  margin-bottom: 5px;
+  line-height: 1.3;
+}
+
+.news-item p {
+  font-size: 12px;
+  color: #77604f;
+  line-height: 1.55;
+}
+
+.hub-modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(20, 10, 6, 0.55);
+  backdrop-filter: blur(6px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 999;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.22s ease;
+}
+
+.hub-modal--open {
+  opacity: 1;
+  pointer-events: all;
+}
+
+.hub-modal__box {
+  position: relative;
+  background: #faf6ef;
+  border: 1px solid #d5c6ad;
+  border-radius: 16px;
+  padding: 36px 40px;
+  max-width: 520px;
+  width: 90%;
+  max-height: 78vh;
+  overflow-y: auto;
+  box-shadow: 0 32px 80px rgba(0,0,0,0.3);
+  transform: translateY(14px);
+  transition: transform 0.22s ease;
+}
+
+.hub-modal--open .hub-modal__box {
+  transform: translateY(0);
+}
+
+.hub-modal__box h2 {
+  font-size: 22px;
+  font-weight: 900;
+  color: #3e2e22;
+  margin-bottom: 20px;
+  padding-bottom: 14px;
+  border-bottom: 2px solid #e8dccb;
+}
+
+.hub-modal__content h3 {
+  font-size: 12px;
+  font-weight: 900;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  color: var(--map-accent);
+  margin: 20px 0 7px;
+}
+
+.hub-modal__content p,
+.hub-modal__content ol {
+  font-size: 14px;
+  color: #5a4430;
+  line-height: 1.75;
+}
+
+.hub-modal__content ol {
+  padding-left: 20px;
+}
+
+.hub-modal__content ol li {
+  margin-bottom: 8px;
+}
+
+.hub-modal__close {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  background: #ede5d8;
+  border: none;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+  color: #4e3a2b;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.15s;
+}
+
+.hub-modal__close:hover {
+  background: #d5c6ad;
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -1238,7 +1238,6 @@ import {
 	rerenderGameShell();
 };
 
-// ── Start the app — render the game screen ──────────────────────────────────
+// ── Start the app — render dashboard ───────────────────────────────────────
 
-transitionToScreen("game");
-syncInGameBgm();
+transitionToScreen("dashboard");

--- a/src/router.ts
+++ b/src/router.ts
@@ -6,6 +6,7 @@
 
 import type { AppScreen } from "./shared/client-types.ts";
 import { renderMainArena } from "./arena/render.ts";
+import { renderDashboard } from "./screens/dashboard.ts";
 import {
 	getSuppressNextClick,
 	setSuppressNextClick,
@@ -49,7 +50,7 @@ export function renderGameShell(): string {
 		case "loading":
 			return '<div class="loading-screen"><p>Đang tải...</p></div>';
 		case "dashboard":
-			return '<div class="dashboard-screen"><p>Dashboard (sẽ render sau)</p></div>';
+			return renderDashboard();
 		case "lobby":
 			return '<div class="lobby-screen"><p>Phòng chờ (sẽ render sau)</p></div>';
 		case "game": {
@@ -69,12 +70,16 @@ export function renderGameShell(): string {
 				${renderMainArena()}
 				<aside class="players-column players-column--right"></aside>
 			</div>
-			${debtModalVisible && debtAmount > 0 ? renderDebtTokenModal(
-				debtModalVisible,
-				debtAmount,
-				remaining.coin,
-				debtModalNotice,
-			) : ""}`;
+			${
+				debtModalVisible && debtAmount > 0
+					? renderDebtTokenModal(
+							debtModalVisible,
+							debtAmount,
+							remaining.coin,
+							debtModalNotice,
+						)
+					: ""
+			}`;
 		}
 		default:
 			return '<div class="loading-screen"><p>Đang tải...</p></div>';
@@ -87,6 +92,14 @@ export function rerenderGameShell() {
 	// biome-ignore lint/suspicious/noInnerHTML: game shell template from own code, not user input
 	app.innerHTML = renderGameShell();
 	reattachCardClickDelegation();
+
+	// Post-render: init dashboard globals & video hub if on dashboard
+	if (currentAppScreen === "dashboard") {
+		import("./screens/dashboard.ts").then((mod) => {
+			mod.initDashboardGlobals();
+			setTimeout(() => mod.initDashboardHub(), 0);
+		});
+	}
 }
 
 /**

--- a/src/screens/dashboard.ts
+++ b/src/screens/dashboard.ts
@@ -1,9 +1,21 @@
+/**
+ * dashboard.ts — Dashboard hub screen (hero + auth/explore + modals).
+ *
+ * Ported from TREKPOLOGY/src/ui/dashboard.ts.
+ * Exports: renderDashboard(), initDashboardHub(), initDashboardGlobals()
+ */
+
 import { authClientState } from "../online/socketClient.ts";
+
 
 export const HERO_VIDEO_SRC = "assets/videos/one-minute-in-vietnam.mp4";
 
+// ── Video interaction ───────────────────────────────────────────────────────
+
 export function initDashboardHub() {
-	const media = document.getElementById("hub-hero-media") as HTMLElement | null;
+	const media = document.getElementById(
+		"hub-hero-media",
+	) as HTMLElement | null;
 	const video = document.getElementById(
 		"hub-hero-video",
 	) as HTMLVideoElement | null;
@@ -35,7 +47,9 @@ export function initDashboardHub() {
 		);
 		muteButton.setAttribute(
 			"aria-label",
-			video.muted || video.volume === 0 ? "Bật tiếng video" : "Tắt tiếng video",
+			video.muted || video.volume === 0
+				? "Bật tiếng video"
+				: "Tắt tiếng video",
 		);
 		muteButton.setAttribute(
 			"aria-pressed",
@@ -126,5 +140,457 @@ export function initDashboardHub() {
 			},
 			{ once: true },
 		);
+	}
+}
+
+// ── Render helpers ──────────────────────────────────────────────────────────
+
+function renderHubHeroMedia() {
+	return `
+    <div class="hub-hero__media" id="hub-hero-media">
+      <div class="hub-hero__video-fallback" aria-hidden="true">
+        <div class="hero-placeholder-pattern"></div>
+      </div>
+      <video
+        id="hub-hero-video"
+        class="hub-hero__video"
+        autoplay
+        loop
+        playsinline
+        preload="auto"
+      >
+        <source src="${HERO_VIDEO_SRC}" type="video/mp4" />
+      </video>
+      <div class="hub-hero__scrim" aria-hidden="true"></div>
+      <button
+        type="button"
+        class="hub-hero__hitarea"
+        id="hub-hero-video-hitarea"
+        aria-label="Điều khiển video nền"
+      ></button>
+      <div class="hub-hero__audio-controls">
+        <input
+          type="range"
+          class="hub-hero__video-volume"
+          id="hub-hero-video-volume"
+          min="0" max="1" step="0.01" value="0.85"
+          aria-label="Âm lượng video"
+        />
+        <button
+          type="button"
+          class="hub-hero__video-mute hub-hero__video-mute--muted"
+          id="hub-hero-video-mute"
+          aria-label="Bật tiếng video"
+          aria-pressed="true"
+        >
+          <svg class="hub-hero__video-mute-icon hub-hero__video-mute-icon--off" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path
+              fill="currentColor"
+              d="M16.5 12c0-1.77-1.02-3.29-2.5-4.03v2.21l2.45 2.45c.03-.2.05-.41.05-.63zm2.5 0c0 .94-.2 1.82-.54 2.64l1.51 1.51C20.63 14.91 21 13.5 21 12c0-4.28-2.99-7.86-7-8.77v2.06c2.89.86 5 3.54 5 6.71zM4.27 3 3 4.27 7.73 9H3v6h4l5 5v-6.73l4.25 4.25c-.67.52-1.42.93-2.25 1.18v2.06c1.38-.31 2.63-.95 3.69-1.81L19.73 21 21 19.73l-9-9L4.27 3zM12 4 9.91 6.09 12 8.18V4z"
+            />
+          </svg>
+          <svg class="hub-hero__video-mute-icon hub-hero__video-mute-icon--on" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path
+              fill="currentColor"
+              d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77z"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+  `;
+}
+
+function renderHubAuthPanel() {
+	return `
+    <section class="hub-auth" id="hub-auth">
+      <div class="hub-auth__header">
+        <span class="hub-auth__eyebrow">TÀI KHOẢN</span>
+        <h3 class="hub-auth__title">Bắt đầu hành trình</h3>
+        <p class="hub-auth__lead">Đăng nhập hoặc tạo tài khoản để tạo phòng, join bạn bè và lưu tiến trình.</p>
+      </div>
+
+      <div class="hub-auth__tabs" role="tablist">
+        <button
+          type="button"
+          class="hub-auth__tab is-active"
+          data-hub-auth-tab="login"
+          onclick="window.switchHubAuthTab('login')"
+        >
+          Đăng nhập
+        </button>
+        <button
+          type="button"
+          class="hub-auth__tab"
+          data-hub-auth-tab="register"
+          onclick="window.switchHubAuthTab('register')"
+        >
+          Đăng ký
+        </button>
+      </div>
+
+      <div class="hub-auth__panels">
+        <form id="hub-auth-login-form" class="hub-auth__panel is-active" data-hub-auth-panel="login">
+          <label>
+            Username
+            <input id="hub-auth-login-username" autocomplete="username" placeholder="an" />
+          </label>
+          <label>
+            Password
+            <input id="hub-auth-login-password" autocomplete="current-password" type="password" placeholder="••••••" />
+          </label>
+          <button type="submit">Đăng nhập</button>
+        </form>
+
+        <form id="hub-auth-register-form" class="hub-auth__panel" data-hub-auth-panel="register">
+          <label>
+            Tên hiển thị
+            <input id="hub-auth-register-display-name" placeholder="An" maxlength="18" />
+          </label>
+          <label>
+            Username
+            <input id="hub-auth-register-username" autocomplete="username" placeholder="an" />
+          </label>
+          <label>
+            Password
+            <input id="hub-auth-register-password" autocomplete="new-password" type="password" placeholder="ít nhất 6 ký tự" />
+          </label>
+          <button type="submit">Tạo tài khoản</button>
+        </form>
+      </div>
+
+      <div id="hub-auth-status" class="hub-auth__status" aria-live="polite"></div>
+    </section>
+  `;
+}
+
+function renderHubExplorePanel() {
+	return `
+    <section class="hub-explore">
+      <h3 class="side-title">Góc Khám Phá</h3>
+
+      <div class="news-item">
+        <span class="news-badge news-badge--new">MỚI</span>
+        <h4>Trekpology Alpha 1.0</h4>
+        <p>Phiên bản đầu tiên ra mắt với bản đồ Sài Gòn — hơn 60 địa điểm đang chờ bạn khám phá.</p>
+      </div>
+
+      <div class="news-item">
+        <span class="news-badge news-badge--culture">VĂN HOÁ</span>
+        <h4>Chùa Bà Thiên Hậu</h4>
+        <p>Ngôi chùa hơn 300 năm tuổi tại Chợ Lớn — biểu tượng văn hoá người Hoa giữa lòng Sài Gòn.</p>
+      </div>
+
+      <div class="news-item">
+        <span class="news-badge news-badge--food">ẨM THỰC</span>
+        <h4>Bánh Mì Sài Gòn</h4>
+        <p>Ổ bánh mì đặc trưng với nhân phong phú — đại diện ẩm thực đường phố nổi tiếng toàn cầu.</p>
+      </div>
+
+      <div class="news-item">
+        <span class="news-badge news-badge--nature">THIÊN NHIÊN</span>
+        <h4>Cần Giờ Mangrove</h4>
+        <p>Khu rừng ngập mặn lớn nhất Đông Nam Á nằm ngay cửa ngõ Sài Gòn — Di sản Sinh quyển UNESCO.</p>
+      </div>
+
+      <div class="news-item">
+        <span class="news-badge news-badge--heritage">DI SẢN</span>
+        <h4>Bưu Điện Trung Tâm</h4>
+        <p>Công trình kiến trúc thực dân Pháp thế kỷ 19, do Gustave Eiffel thiết kế — biểu tượng Sài Gòn.</p>
+      </div>
+    </section>
+  `;
+}
+
+function renderHubTopbarUser(isLoggedIn: boolean, displayName: string) {
+	if (!isLoggedIn) {
+		return `
+      <button
+        type="button"
+        class="hub-topbar__guest"
+        onclick="window.focusHubAuthPanel()"
+      >
+        Đăng nhập
+      </button>
+    `;
+	}
+
+	return `
+    <div class="hub-topbar__account">
+      <span class="hub-topbar__user">${displayName}</span>
+      <button
+        type="button"
+        class="hub-topbar__logout"
+        onclick="event.stopPropagation(); window.logoutFromAuthScreen()"
+        title="Đăng xuất"
+      >
+        Thoát
+      </button>
+    </div>
+  `;
+}
+
+// ── Main render ─────────────────────────────────────────────────────────────
+
+export function renderDashboard(isLoading = false) {
+	const user = authClientState.user;
+	const isLoggedIn = Boolean(user);
+	const displayName =
+		user?.displayName || user?.username || "Nhà Lữ Hành";
+
+	return `
+    <div class="dashboard-hub ${isLoading ? "dashboard-hub--loading" : ""}">
+
+      <!-- Modal: Hướng Dẫn Chơi -->
+      <div class="hub-modal" id="modal-rules" onclick="if(event.target===this)this.classList.remove('hub-modal--open')">
+        <div class="hub-modal__box">
+          <button class="hub-modal__close" onclick="document.getElementById('modal-rules').classList.remove('hub-modal--open')">&times;</button>
+          <h2>Hướng Dẫn Chơi</h2>
+          <div class="hub-modal__content">
+            <h3>🎯 Mục tiêu</h3>
+            <p>Mỗi người chơi xây dựng lịch trình du lịch 5 ngày, thu thập các thẻ địa điểm và ghi càng nhiều điểm VP (Điểm Hành Trình) càng tốt.</p>
+
+            <h3>🃏 Thẻ bài</h3>
+            <p>Mỗi thẻ đại diện cho một địa điểm du lịch tại Việt Nam — có các thuộc tính: Thể loại (Văn Hoá, Ẩm Thực, Thiên Nhiên...), Chi phí (Xu &amp; Thể Lực), và Điểm VP.</p>
+
+            <h3>⚙️ Một lượt chơi</h3>
+            <ol>
+              <li><strong>Draft:</strong> Chọn 1 thẻ từ tay bài chung, truyền phần còn lại cho người kế tiếp.</li>
+              <li><strong>Lên kế hoạch:</strong> Đặt các thẻ đã chọn vào bảng lịch trình 5&times;5 của bạn.</li>
+              <li><strong>Tính điểm:</strong> Server tính điểm cuối mỗi ngày theo combo thẻ.</li>
+            </ol>
+
+            <h3>🏆 Kết thúc</h3>
+            <p>Sau 5 ngày chơi, người có tổng VP cao nhất giành chiến thắng và nhận Chứng Nhận Hành Trình.</p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Modal: Về Chúng Tôi -->
+      <div class="hub-modal" id="modal-about" onclick="if(event.target===this)this.classList.remove('hub-modal--open')">
+        <div class="hub-modal__box">
+          <button class="hub-modal__close" onclick="document.getElementById('modal-about').classList.remove('hub-modal--open')">&times;</button>
+          <h2>Về Chúng Tôi</h2>
+          <div class="hub-modal__content">
+            <p><strong>TREKPOLOGY</strong> là tựa game thẻ bài chiến lược lấy cảm hứng từ vẻ đẹp văn hoá và thiên nhiên Việt Nam.</p>
+            <p>Chúng tôi tin rằng du lịch không chỉ là di chuyển — mà là khám phá, học hỏi và kết nối. Mỗi thẻ bài là một câu chuyện thật từ đất nước Việt Nam.</p>
+            <h3>🔮 Sắp ra mắt</h3>
+            <p>Đà Lạt • Hội An • Hạ Long • Hà Nội</p>
+            <p style="margin-top:16px; font-size:12px; opacity:0.6">Phiên bản Alpha 1.0 — 2025</p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Topbar -->
+      <header class="hub-topbar">
+        <div class="hub-topbar__logo">TREKPOLOGY</div>
+        <nav class="hub-topbar__nav">
+          <button onclick="document.getElementById('modal-rules').classList.add('hub-modal--open')">Hướng Dẫn Chơi</button>
+          <button onclick="document.getElementById('modal-about').classList.add('hub-modal--open')">Về Chúng Tôi</button>
+        </nav>
+        ${renderHubTopbarUser(isLoggedIn, displayName)}
+      </header>
+
+      <!-- Body: 2 cột -->
+      <div class="hub-body">
+
+        <!-- Cột trái: Hero -->
+        <div class="hub-hero">
+          ${renderHubHeroMedia()}
+
+          <div class="hub-hero__overlay">
+            <div class="hub-hero__content">
+              <p class="hero-eyebrow">GAME THẺ BÀI CHIẾN LƯỢC</p>
+              <h1 class="hero-title">Khám Phá<br/>Việt Nam</h1>
+              <p class="hero-sub">Xây dựng hành trình, thu thập địa điểm,<br/>trở thành nhà lữ hành xuất sắc nhất.</p>
+              <button class="btn-play" onclick="window.gotoMapSelection()">
+                ▶ &nbsp;BẮT ĐẦU HÀNH TRÌNH
+              </button>
+              ${
+								!isLoggedIn
+									? `<p class="hero-auth-hint">Đăng nhập ở panel bên phải để vào phòng online.</p>`
+									: ""
+							}
+            </div>
+          </div>
+        </div>
+
+        <!-- Cột phải: Auth hoặc Góc Khám Phá -->
+        <aside class="hub-side">
+          <div class="hub-side__inner">
+            ${isLoggedIn ? renderHubExplorePanel() : renderHubAuthPanel()}
+          </div>
+        </aside>
+
+      </div>
+    </div>
+  `;
+}
+
+// ── Auth form submission ────────────────────────────────────────────────────
+
+async function handleLoginSubmit(event: SubmitEvent) {
+	event.preventDefault();
+	const username = (
+		document.getElementById("hub-auth-login-username") as HTMLInputElement
+	)?.value;
+	const password = (
+		document.getElementById("hub-auth-login-password") as HTMLInputElement
+	)?.value;
+	const statusEl = document.getElementById("hub-auth-status");
+
+	if (!username || !password) {
+		if (statusEl) {
+			statusEl.textContent = "Vui lòng nhập username và password.";
+			statusEl.className = "hub-auth__status hub-auth__status--error";
+		}
+		return;
+	}
+
+	if (!statusEl) return;
+
+	statusEl.textContent = "Đang đăng nhập...";
+	statusEl.className = "hub-auth__status";
+
+	try {
+		const resp = await fetch(
+			"${import.meta.env.VITE_SERVER_URL}/api/auth/login",
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ username, password }),
+			},
+		);
+		const data = await resp.json();
+		if (!resp.ok) {
+			throw new Error(data.message || "Đăng nhập thất bại");
+		}
+		statusEl.textContent = "Đăng nhập thành công!";
+		statusEl.className = "hub-auth__status hub-auth__status--success";
+		authClientState.user = data.user ?? data;
+		// Refresh the dashboard to show explore panel
+		const { rerenderGameShell } = await import("../router.ts");
+		rerenderGameShell();
+		// Re-init video bindings after DOM refresh
+		setTimeout(() => initDashboardHub(), 0);
+	} catch (err: any) {
+		statusEl.textContent = err.message || "Lỗi đăng nhập";
+		statusEl.className = "hub-auth__status hub-auth__status--error";
+	}
+}
+
+async function handleRegisterSubmit(event: SubmitEvent) {
+	event.preventDefault();
+	const displayName = (
+		document.getElementById("hub-auth-register-display-name") as HTMLInputElement
+	)?.value;
+	const username = (
+		document.getElementById("hub-auth-register-username") as HTMLInputElement
+	)?.value;
+	const password = (
+		document.getElementById("hub-auth-register-password") as HTMLInputElement
+	)?.value;
+	const statusEl = document.getElementById("hub-auth-status");
+
+	if (!displayName || !username || !password) {
+		if (statusEl) {
+			statusEl.textContent = "Vui lòng điền đầy đủ thông tin.";
+			statusEl.className = "hub-auth__status hub-auth__status--error";
+		}
+		return;
+	}
+
+	if (!statusEl) return;
+
+	if (password.length < 6) {
+		statusEl.textContent = "Mật khẩu phải có ít nhất 6 ký tự.";
+		statusEl.className = "hub-auth__status hub-auth__status--error";
+		return;
+	}
+
+	statusEl.textContent = "Đang tạo tài khoản...";
+	statusEl.className = "hub-auth__status";
+
+	try {
+		const serverUrl =
+			(globalThis as any).SERVER_HTTP_URL ??
+			"${import.meta.env.VITE_SERVER_URL}";
+		const resp = await fetch(`${serverUrl}/api/auth/register`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ username, password, displayName }),
+		});
+		const data = await resp.json();
+		if (!resp.ok) {
+			throw new Error(data.message || "Đăng ký thất bại");
+		}
+		statusEl.textContent = "Tạo tài khoản thành công! Đang đăng nhập...";
+		statusEl.className = "hub-auth__status hub-auth__status--success";
+		authClientState.user = data.user ?? data;
+		const { rerenderGameShell } = await import("../router.ts");
+		rerenderGameShell();
+		setTimeout(() => initDashboardHub(), 0);
+	} catch (err: any) {
+		statusEl.textContent = err.message || "Lỗi đăng ký";
+		statusEl.className = "hub-auth__status hub-auth__status--error";
+	}
+}
+
+// ── Global functions (for inline onclick handlers in dashboard HTML) ────────
+
+export function initDashboardGlobals() {
+	(globalThis as any).switchHubAuthTab = (tab: string) => {
+		// Switch tab classes
+		document.querySelectorAll("[data-hub-auth-tab]").forEach((el) => {
+			el.classList.toggle(
+				"is-active",
+				el.getAttribute("data-hub-auth-tab") === tab,
+			);
+		});
+		document.querySelectorAll("[data-hub-auth-panel]").forEach((el) => {
+			el.classList.toggle(
+				"is-active",
+				el.getAttribute("data-hub-auth-panel") === tab,
+			);
+		});
+		// Clear status
+		const statusEl = document.getElementById("hub-auth-status");
+		if (statusEl) {
+			statusEl.textContent = "";
+			statusEl.className = "hub-auth__status";
+		}
+	};
+
+	(globalThis as any).logoutFromAuthScreen = () => {
+		authClientState.user = null;
+		import("../router.ts").then(({ rerenderGameShell }) => {
+			rerenderGameShell();
+			setTimeout(() => initDashboardHub(), 0);
+		});
+	};
+
+	(globalThis as any).focusHubAuthPanel = () => {
+		const panel = document.getElementById("hub-auth");
+		if (panel) {
+			panel.scrollIntoView({ behavior: "smooth", block: "center" });
+			panel.classList.add("hub-auth--pulse");
+			setTimeout(() => panel.classList.remove("hub-auth--pulse"), 700);
+		}
+	};
+
+	(globalThis as any).gotoMapSelection = () => {
+		import("../router.ts").then(({ transitionToScreen }) => {
+			transitionToScreen("game");
+		});
+	};
+
+	// Wire up auth form submissions
+	const loginForm = document.getElementById("hub-auth-login-form");
+	const registerForm = document.getElementById("hub-auth-register-form");
+	if (loginForm) {
+		loginForm.addEventListener("submit", handleLoginSubmit);
+	}
+	if (registerForm) {
+		registerForm.addEventListener("submit", handleRegisterSubmit);
 	}
 }

--- a/src/version.ts
+++ b/src/version.ts
@@ -4,6 +4,6 @@
  * BUILD_TIME is replaced at build time by the bundler (rollup).
  */
 
-export const VERSION = "0.14.6";
+export const VERSION = "0.14.7";
 export const BUILD_TIME = "__BUILD_TIME_PLACEHOLDER__";
 export const APP_NAME = "Trekkopoly";


### PR DESCRIPTION
Replace the placeholder dashboard with the full screen ported from old TREKPOLOGY's `src/ui/dashboard.ts` + `src/styles/dashboard.less`.

### Changes
- **Hero section** — video background with autoplay, pause, volume/mute controls; CTA button navigates to game
- **2-column layout** — hero (left) + auth/explore panel (right)
- **Auth panel** — login/register tabs with form wiring (calls server API)
- **Explore panel** — styled news items (văn hoá, ẩm thực, thiên nhiên, di sản)
- **Modals** — rules (Hướng Dẫn Chơi) + about (Về Chúng Tôi) with backdrop click to close
- **Topbar** — logo, nav buttons, user display/logout
- **Global functions** — `switchHubAuthTab`, `logoutFromAuthScreen`, `focusHubAuthPanel`, `gotoMapSelection`, auth form handlers
- **CSS** — full dashboard stylesheet (926 lines ported from `dashboard.less`)
- **Router** — `renderDashboard()` instead of placeholder
- **App startup** — transitions to 'dashboard' instead of skipping straight to 'game'
- **Post-render hook** — auto-inits video hub bindings + global handlers after dashboard render
- **No circular deps** — dashboard uses dynamic `import()` for router functions
- **Version bump**: 0.14.6 → 0.14.7