### PR TITLE
feat: add discard zone for hand cards via drag-and-drop

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -74,6 +74,7 @@ import {
 	setDebtModalVisible,
 	getDebtModalNotice,
 	setDebtModalNotice,
+	addDiscardedResourceBonus,
 } from "./state.ts";
 import type { TravelCard } from "./shared/types.ts";
 import { createInitialDeck, shuffleCards } from "./shared/deck.ts";
@@ -725,6 +726,7 @@ function clearBoardDragState() {
 	dragState?.clone?.remove();
 	setHandPointerDragState(null);
 	setDraggedHandCardId(null);
+	clearDeckDiscardHoverClass();
 	document
 		.querySelectorAll(".board-cell--drag-hover, .board-cell--drag-invalid")
 		.forEach((el) => {
@@ -739,6 +741,50 @@ function clearBoardDragState() {
 function getDropCellFromPointer(event: PointerEvent): HTMLElement | null {
 	const el = document.elementFromPoint(event.clientX, event.clientY);
 	return el?.closest('[data-board-cell="true"]') as HTMLElement | null;
+}
+
+function getDeckDiscardTargetFromPointer(
+	event: PointerEvent,
+): HTMLElement | null {
+	const el = document.elementFromPoint(event.clientX, event.clientY);
+	return el?.closest(
+		'[data-discard-drop-zone="true"]',
+	) as HTMLElement | null;
+}
+
+function canDiscardHandCard(): boolean {
+	const phase = getGamePhase();
+	return phase !== "draft" && phase !== "simulation" && !getIsInitialDealInProgress();
+}
+
+function clearDeckDiscardHoverClass() {
+	document
+		.querySelectorAll(".deck-pile-panel--discard-hover")
+		.forEach((el) => el.classList.remove("deck-pile-panel--discard-hover"));
+}
+
+function discardHandCardToDeck(cardId: string) {
+	if (!canDiscardHandCard()) return;
+
+	const hand = getPlayerHand();
+	const handIndex = hand.findIndex((c) => c.id === cardId);
+	if (handIndex === -1) return;
+
+	const card = hand[handIndex];
+	playGameSound("returnDeck");
+
+	hand.splice(handIndex, 1);
+	setPlayerHand(hand);
+
+	addDiscardedResourceBonus(card.coin, card.stamina);
+
+	setSelectedHandCardId(null);
+	setDraggedHandCardId(null);
+	setFocusedHandCardId(null);
+	setFocusedBoardCard(null);
+	setSuppressNextClick(false);
+
+	rerenderGameShell();
 }
 
 (globalThis as any).startHandPointerDrag = (
@@ -832,12 +878,20 @@ function handleHandPointerMove(event: PointerEvent) {
 	updateHandCardDragPosition(event);
 
 	// Clear old hover states
+	clearDeckDiscardHoverClass();
 	document
 		.querySelectorAll(".board-cell--drag-hover, .board-cell--drag-invalid")
 		.forEach((el) => {
 			el.classList.remove("board-cell--drag-hover");
 			el.classList.remove("board-cell--drag-invalid");
 		});
+
+	// Check discard zone hover first
+	const discardTarget = getDeckDiscardTargetFromPointer(event);
+	if (discardTarget && canDiscardHandCard()) {
+		discardTarget.classList.add("deck-pile-panel--discard-hover");
+		return;
+	}
 
 	const dropCell = getDropCellFromPointer(event);
 	if (!dropCell) return;
@@ -871,14 +925,22 @@ function handleHandPointerUp(event: PointerEvent) {
 
 	if (wasDragging) {
 		const dropCell = getDropCellFromPointer(event);
+		const discardTarget = getDeckDiscardTargetFromPointer(event);
 		const rowIndex = Number(dropCell?.dataset.rowIndex);
 		const colIndex = Number(dropCell?.dataset.colIndex);
 		const currentDay = getCurrentDayIndex();
+		const cardId = dragState.id;
 
 		clearBoardDragState();
 
 		setSuppressNextClick(true);
 		setTimeout(() => setSuppressNextClick(false), 0);
+
+		// Check discard zone first
+		if (discardTarget && canDiscardHandCard()) {
+			discardHandCardToDeck(cardId);
+			return;
+		}
 
 		if (
 			dropCell &&
@@ -887,7 +949,7 @@ function handleHandPointerUp(event: PointerEvent) {
 			colIndex === currentDay &&
 			getBoardSlots()[rowIndex]?.[colIndex] === null
 		) {
-			placeHandCardOnBoard(dragState.id, rowIndex, colIndex);
+			placeHandCardOnBoard(cardId, rowIndex, colIndex);
 			return;
 		}
 

--- a/src/arena/render.ts
+++ b/src/arena/render.ts
@@ -34,6 +34,8 @@ import {
 	getDeck,
 	getLocalCoinDebt,
 	currentPlayerId,
+	getDiscardedResourceCoinBonus,
+	getDiscardedResourceStaminaBonus,
 } from "../state.ts";
 import {
 	getRarityLabel,
@@ -364,12 +366,14 @@ export function renderHandCard(
 	const titleClass = getHandTitleClass(shortName);
 	const cityClass = getHandCityClass(shortCity);
 
-	// Resource affordability
+	// Resource affordability (includes discard bonus)
 	const boardTotals = calculateBoardTotals(getBoardSlots());
 	const remaining = getRemainingResources({
 		totals: boardTotals,
 		startingCoin: STARTING_COIN,
 		startingStamina: STARTING_STAMINA,
+		discardBonusCoin: getDiscardedResourceCoinBonus(),
+		discardBonusStamina: getDiscardedResourceStaminaBonus(),
 	});
 	const affordability = getCardAffordability({ card, remaining });
 	const affordabilityClass = !affordability.canAfford
@@ -510,7 +514,11 @@ function renderDeckCardStack(): string {
 	if (sim || phase === "simulation" || phase === "finished") return "";
 
 	return `
-    <section class="deck-pile-panel">
+    <section
+      class="deck-pile-panel"
+      data-discard-drop-zone="true"
+      title="Kéo thả lá bài trên tay vào đây để discard và nhận lại Xu/Thể lực bằng chi phí của lá."
+    >
       <div class="deck-pile-panel__visual">
         <div class="deck-card-stack">
           <div class="deck-card-stack__card deck-card-stack__card--back-3"></div>
@@ -629,6 +637,8 @@ function renderResourceOrbs(): string {
 		totals,
 		startingCoin: STARTING_COIN,
 		startingStamina: STARTING_STAMINA,
+		discardBonusCoin: getDiscardedResourceCoinBonus(),
+		discardBonusStamina: getDiscardedResourceStaminaBonus(),
 	});
 	const debt = getLocalCoinDebt();
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -18,6 +18,10 @@ import { renderDebtTokenModal } from "./arena/extra-panels.ts";
 import { getBoardSlots } from "./state.ts";
 import { calculateBoardTotals } from "./shared/board.ts";
 import { getRemainingResources } from "./shared/resources.ts";
+import {
+	getDiscardedResourceCoinBonus,
+	getDiscardedResourceStaminaBonus,
+} from "./state.ts";
 import { STARTING_COIN, STARTING_STAMINA } from "./shared/constants.ts";
 
 // ── Screen state ────────────────────────────────────────────────────────────
@@ -63,6 +67,8 @@ export function renderGameShell(): string {
 							totals: calculateBoardTotals(getBoardSlots()),
 							startingCoin: STARTING_COIN,
 							startingStamina: STARTING_STAMINA,
+							discardBonusCoin: getDiscardedResourceCoinBonus?.() ?? 0,
+							discardBonusStamina: getDiscardedResourceStaminaBonus?.() ?? 0,
 						})
 					: { coin: 0, stamina: 0 };
 			return `<div class="game-shell">

--- a/src/shared/resources.ts
+++ b/src/shared/resources.ts
@@ -16,6 +16,8 @@ export type GetRemainingResourcesParams = {
   totals: BoardTotals;
   startingCoin: number;
   startingStamina: number;
+  discardBonusCoin?: number;
+  discardBonusStamina?: number;
 };
 
 export type GetCardAffordabilityParams = {
@@ -27,10 +29,12 @@ export function getRemainingResources({
   totals,
   startingCoin,
   startingStamina,
+  discardBonusCoin = 0,
+  discardBonusStamina = 0,
 }: GetRemainingResourcesParams): ResourceState {
   return {
-    coin: Math.max(0, startingCoin - totals.coin),
-    stamina: Math.max(0, startingStamina - totals.stamina),
+    coin: Math.max(0, startingCoin - totals.coin + discardBonusCoin),
+    stamina: Math.max(0, startingStamina - totals.stamina + discardBonusStamina),
   };
 }
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -390,4 +390,30 @@ export function setSimulationAdvanceTimeoutId(id: number | null) {
 	simulationAdvanceTimeoutId = id;
 }
 
+// ── Discard resource bonus (refunded from discarded hand cards) ────────────
+
+let discardedResourceCoinBonus = 0;
+let discardedResourceStaminaBonus = 0;
+
+export function getDiscardedResourceCoinBonus(): number {
+	return discardedResourceCoinBonus;
+}
+
+export function setDiscardedResourceCoinBonus(v: number) {
+	discardedResourceCoinBonus = v;
+}
+
+export function getDiscardedResourceStaminaBonus(): number {
+	return discardedResourceStaminaBonus;
+}
+
+export function setDiscardedResourceStaminaBonus(v: number) {
+	discardedResourceStaminaBonus = v;
+}
+
+export function addDiscardedResourceBonus(coin: number, stamina: number) {
+	discardedResourceCoinBonus += coin;
+	discardedResourceStaminaBonus += stamina;
+}
+
 export { currentPlayerId, playerIds };

--- a/src/version.ts
+++ b/src/version.ts
@@ -4,6 +4,6 @@
  * BUILD_TIME is replaced at build time by the bundler (rollup).
  */
 
-export const VERSION = "0.14.7";
+export const VERSION = "0.14.8";
 export const BUILD_TIME = "__BUILD_TIME_PLACEHOLDER__";
 export const APP_NAME = "Trekkopoly";


### PR DESCRIPTION
Port the discard zone interaction from old TREKPOLOGY.

### Changes
- **Discard drop zone** — `data-discard-drop-zone="true"` on `deck-pile-panel`; dragging a hand card onto it discards the card and refunds its coin/stamina cost
- **Discard resource bonus** — new state trackers in state.ts (`discardedResourceCoinBonus`, `discardedResourceStaminaBonus`) for accumulated refunds
- **Drag handler updates** — `handleHandPointerMove` checks discard zone before board cells (shows `.deck-pile-panel--discard-hover` CSS); `handleHandPointerUp` handles discard zone drop
- **Helper functions** — `getDeckDiscardTargetFromPointer`, `canDiscardHandCard`, `clearDeckDiscardHoverClass`, `discardHandCardToDeck`
- **Resource display** — `getRemainingResources` accepts optional `discardBonusCoin`/`discardBonusStamina` params; wired into resource orbs, hand card affordability, debt modal
- **CSS** — `.deck-pile-panel--discard-hover` already existed in client.less (port from previous pass)
- No circular deps, TypeScript clean
- **Version bump**: 0.14.7 → 0.14.8