### PR TITLE
fix: correct deploy-server path filter scr/shared/ → src/shared/

### DIFF
--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
     paths:
       - "server/**"
-      - "scr/shared/**"
+      - "src/shared/**"
       - ".github/workflows/deploy-server.yml"
 
   # Manual trigger from Actions tab


### PR DESCRIPTION
After the `src/shared` rename in commit `accaf56`, the deploy-server workflow's path trigger still referenced the old `scr/shared/` directory. Server deploys wouldn't trigger on changes to shared game logic files. Fixes the path to track the current `src/shared/` directory.