### PR TITLE
feat: online game screen renderer + fix single-player card pool

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -84,7 +84,7 @@ import "./online/lobbyClient.ts"; // Side-effect: binds lobby globals
 import type { PlayerId } from "./shared/client-types.ts";
 import type { TravelCard } from "./shared/types.ts";
 import { createInitialDeck, shuffleCards } from "./shared/deck.ts";
-import { saigonFoodCards } from "./shared/data/index.ts";
+import { allCards } from "./shared/data/cards.all.ts";
 import {
 	HAND_SIZE,
 	STARTING_COIN,
@@ -317,7 +317,7 @@ if ("serviceWorker" in navigator) {
 // ── Initialise deck ────────────────────────────────────────────────────────────
 
 const fullDeck = createInitialDeck({
-	cards: saigonFoodCards,
+	cards: allCards,
 	fallbackCards: [],
 	handSize: HAND_SIZE,
 });

--- a/src/online/lobbyClient.ts
+++ b/src/online/lobbyClient.ts
@@ -15,7 +15,7 @@ import {
 	setOnRoomSnapshot,
 	setOnDisconnect,
 } from "./socketClient.ts";
-import type { RoomSnapshot } from "../shared/types.ts";
+import type { RoomSnapshot, TravelCard } from "../shared/types.ts";
 import { getCardsByPhasePool } from "../shared/data/cards.all.ts";
 
 // ── Types ──────────────────────────────────────────────────────────────────
@@ -50,6 +50,10 @@ let currentRoomId: string | null = null;
 let currentPlayerId: string | null = null;
 let currentPlayerName: string | null = null;
 let currentLobbySnapshot: LobbySnapshot | null = null;
+
+// Online game state — set by handleRoomSnapshot when game starts
+let currentGameSnapshot: RoomSnapshot | null = null;
+let currentCards: TravelCard[] = [];
 
 // ── Saved session (localStorage) ───────────────────────────────────────────
 
@@ -136,14 +140,9 @@ async function createRoomFromLobby() {
 
 		// Use all Saigon phase 1 cards for now
 		const cards = getCardsByPhasePool("SAIGON");
+		currentCards = cards;
 
-		const result = await createRoomAndJoin(
-			cards,
-			playerId,
-			playerName,
-			2,
-			5,
-		);
+		const result = await createRoomAndJoin(cards, playerId, playerName, 2, 5);
 
 		currentRoomId = result.roomId;
 
@@ -217,11 +216,7 @@ async function reconnectSavedRoomFromLobby() {
 		currentPlayerId = saved.playerId;
 		currentPlayerName = saved.playerName;
 
-		await connectToRoom(
-			saved.roomId,
-			saved.playerId,
-			saved.playerName,
-		);
+		await connectToRoom(saved.roomId, saved.playerId, saved.playerName);
 	} catch (err: unknown) {
 		const message = err instanceof Error ? err.message : String(err);
 		alert(`Không thể reconnect: ${message}`);
@@ -285,14 +280,16 @@ function handleRoomSnapshot(snapshot: RoomSnapshot) {
 	if (snapshot.phase === "lobby") {
 		// Still in lobby — update player list
 		currentLobbySnapshot = buildLobbySnapshot(snapshot);
+		currentGameSnapshot = null;
 		// Re-render the lobby screen
 		import("../router.ts").then(({ rerenderGameShell }) => {
 			rerenderGameShell();
 		});
-	} else if (snapshot.phase === "draft" || snapshot.phase === "placement") {
-		// Game has started — transition to game screen
-		// Store the snapshot for the game to use
+	} else {
+		// Game has started (draft/placement/scoring/finished) —
+		// store snapshot and switch to game screen
 		currentLobbySnapshot = null;
+		currentGameSnapshot = snapshot;
 		import("../router.ts").then(({ transitionToScreen }) => {
 			transitionToScreen("game");
 		});
@@ -379,6 +376,14 @@ export function getCurrentPlayerId(): string | null {
 
 export function getCurrentPlayerName(): string | null {
 	return currentPlayerName;
+}
+
+export function getCurrentGameSnapshot(): RoomSnapshot | null {
+	return currentGameSnapshot;
+}
+
+export function getCurrentCards(): TravelCard[] {
+	return currentCards;
 }
 
 // Auto-init lobby globals on module load

--- a/src/router.ts
+++ b/src/router.ts
@@ -7,6 +7,7 @@
 import type { AppScreen } from "./shared/client-types.ts";
 import { renderMainArena } from "./arena/render.ts";
 import { renderDashboard } from "./screens/dashboard.ts";
+import { renderOnlineGameArena } from "./screens/onlineGame.ts";
 import {
 	renderOnlineEntryScreen,
 	renderOnlineLobbyRoomScreen,
@@ -15,6 +16,8 @@ import {
 	getCurrentLobbySnapshot,
 	getSavedSession,
 	getCurrentPlayerName,
+	getCurrentRoomId,
+	getCurrentGameSnapshot,
 } from "./online/lobbyClient.ts";
 import {
 	getSuppressNextClick,
@@ -84,6 +87,18 @@ export function renderGameShell(): string {
 			return renderOnlineEntryScreen(savedSession, displayName);
 		}
 		case "game": {
+			const roomId = getCurrentRoomId();
+
+			// Online multiplayer mode
+			if (roomId && getCurrentGameSnapshot()) {
+				return `<div class="game-shell">
+					<aside class="players-column players-column--left"></aside>
+					${renderOnlineGameArena()}
+					<aside class="players-column players-column--right"></aside>
+				</div>`;
+			}
+
+			// Single-player mode
 			const debtAmount = getLocalCoinDebt();
 			const debtModalVisible = getDebtModalVisible();
 			const debtModalNotice = getDebtModalNotice();
@@ -144,6 +159,11 @@ export function rerenderGameShell() {
 	} else if (currentAppScreen === "lobby") {
 		// Lobby globals are already bound in app.ts initLobbyGlobals()
 		// No post-render side-effects needed — lobby is static HTML
+	} else if (currentAppScreen === "game" && getCurrentRoomId()) {
+		// Online game — init action handlers
+		import("./screens/onlineGame.ts").then((mod) => {
+			mod.initOnlineGameGlobals();
+		});
 	}
 }
 

--- a/src/screens/onlineGame.ts
+++ b/src/screens/onlineGame.ts
@@ -1,0 +1,524 @@
+/**
+ * onlineGame.ts — Online multiplayer game screen renderer.
+ *
+ * Renders the game UI from RoomSnapshot data received over WebSocket,
+ * instead of from local state.ts. All actions send RPC calls to the server.
+ *
+ * Reuses existing card rendering utilities from arena/render.ts for
+ * visual consistency with the single-player game.
+ */
+
+import {
+	getCurrentGameSnapshot,
+	getCurrentCards,
+	getCurrentPlayerId,
+} from "../online/lobbyClient.ts";
+import { rpcCall } from "../online/socketClient.ts";
+import { renderHandCard, renderBoardMiniCard } from "../arena/render.ts";
+import type { RoomSnapshot, TravelCard, PlayerState } from "../shared/types.ts";
+import type { BoardSlots } from "../shared/board.ts";
+import { boardCellsToSlots, DAYS, TIME_SLOTS, SLOT_NAMES } from "../shared/board.ts";
+import { getRarityLabel, getTagLabel, getShortName, getShortCity, getBonusText } from "../shared/card-mapper.ts";
+
+// ── Main entry ──────────────────────────────────────────────────────────────
+
+export function renderOnlineGameArena(): string {
+	const snapshot = getCurrentGameSnapshot();
+	const cards = getCurrentCards();
+	const playerId = getCurrentPlayerId();
+	if (!snapshot || !playerId) {
+		return '<div class="loading-screen"><p>Đang kết nối...</p></div>';
+	}
+
+	// Find our player data in the snapshot
+	const myPlayer = snapshot.players.find((p) => p.playerId === playerId);
+	if (!myPlayer) {
+		return '<div class="loading-screen"><p>Đang chờ dữ liệu người chơi...</p></div>';
+	}
+
+	switch (snapshot.phase) {
+		case "draft":
+			return renderOnlineDraft(snapshot, myPlayer, cards);
+		case "placement":
+			return renderOnlinePlacement(snapshot, myPlayer, cards);
+		case "scoring":
+			return renderOnlineScoring(snapshot, myPlayer, cards);
+		case "finished":
+			return renderOnlineFinished(snapshot);
+		default:
+			return '<div class="loading-screen"><p>Đang chờ...</p></div>';
+	}
+}
+
+// ── Draft phase ─────────────────────────────────────────────────────────────
+
+function renderOnlineDraft(
+	snapshot: RoomSnapshot,
+	myPlayer: PlayerState,
+	allCards: TravelCard[],
+): string {
+	const handCards = resolveCards(myPlayer.hand, allCards);
+	const pickRound = (snapshot.pickIndex ?? 0) + 1;
+	const totalRounds = 5;
+
+	const opponentInfo = snapshot.players
+		.filter((p) => p.playerId !== myPlayer.playerId)
+		.map((p) => getOpponentStatusMarkup(p))
+		.join("");
+
+	return `
+    <main class="arena">
+      <div class="arena__top">
+        <div class="arena__title-block">
+          <div class="blue-line"></div>
+          <div>
+            <h1>ONLINE — ${escapeHtml(snapshot.roomId)}</h1>
+            <span class="arena__subtitle">Ngày ${snapshot.day} • Lượt chọn ${pickRound}/${totalRounds}</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="arena__main">
+        <div class="board-block">
+          <div class="days-header">
+      			${DAYS.map((d) => {
+              const isCurrent = d === snapshot.day;
+              const isPast = d < snapshot.day;
+              return `<div class="day-pill ${isCurrent ? "day-pill--current" : ""} ${isPast ? "day-pill--done" : ""}">NGÀY ${d}</div>`;
+            }).join("")}
+          </div>
+
+          <section class="online-draft-section">
+            <div class="online-draft__hand">
+              <h2>Bài trên tay (${handCards.length})</h2>
+              <div class="online-draft__cards">
+                ${handCards.length === 0
+                  ? '<p class="online-draft__empty">Đã chọn hết bài, chờ người chơi khác...</p>'
+                  : handCards
+                      .map((card, idx) => renderDraftCard(card, idx))
+                      .join("")
+                }
+              </div>
+            </div>
+
+            <div class="online-draft__opponents">
+              ${opponentInfo || ""}
+            </div>
+          </section>
+        </div>
+      </div>
+    </main>
+  `;
+}
+
+function renderDraftCard(card: TravelCard, _index: number): string {
+	const rarityClass = card.rarity ? `hand-card--${card.rarity}` : "hand-card--common";
+	const shortName = getShortName(card.name);
+	const shortCity = getShortCity(card.city || "");
+
+	return `
+    <div class="online-draft-card" data-online-draft-card-id="${card.card_id}">
+      <article class="hand-card ${rarityClass}">
+        <div class="hand-card__header">
+          <div class="hand-card__title-block">
+            <h3>${escapeHtml(shortName)}</h3>
+            <div>📍 ${escapeHtml(shortCity)}</div>
+          </div>
+          <div class="hand-card__vp">${card.vp}</div>
+        </div>
+        <div class="hand-card__image" style="background-image: url('${card.image}')">
+          <div class="hand-card__icons">
+            <span>${card.icon || "★"}</span>
+            <span>${getRarityLabel(card.rarity)}</span>
+          </div>
+        </div>
+        <div class="hand-card__content">
+          <div class="hand-card__meta-row">
+            <span class="hand-card__rarity">${getRarityLabel(card.rarity)}</span>
+            <span class="hand-card__tag">${getTagLabel(card.tag || (card.tags?.[0] ?? "FOOD"))}</span>
+          </div>
+          <p>${card.description || ""}</p>
+          <div class="hand-card__bonus">${getBonusText(card)}</div>
+        </div>
+        <div class="hand-card__footer">
+          <div>
+            <span>GOLD</span>
+            <strong>${card.coin}</strong>
+          </div>
+          <div>
+            <span>STAMINA</span>
+            <strong>${card.stamina}</strong>
+          </div>
+        </div>
+      </article>
+      <div class="online-draft-card__actions">
+        <button class="online-draft-btn online-draft-btn--store" data-online-store="${card.card_id}">📥 Lưu</button>
+        <button class="online-draft-btn online-draft-btn--rest" data-online-rest="${card.card_id}">💤 Nghỉ</button>
+      </div>
+    </div>
+  `;
+}
+
+// ── Placement phase ─────────────────────────────────────────────────────────
+
+function renderOnlinePlacement(
+	snapshot: RoomSnapshot,
+	myPlayer: PlayerState,
+	allCards: TravelCard[],
+): string {
+	const boardSlots = boardCellsToSlots(myPlayer.board, allCards);
+	const chosenCards = resolveCards(myPlayer.chosen, allCards);
+	const currentDay = snapshot.day;
+	const dayIndex = currentDay - 1;
+
+	const opponentInfo = snapshot.players
+		.filter((p) => p.playerId !== myPlayer.playerId)
+		.map((p) => getOpponentStatusMarkup(p))
+		.join("");
+
+	return `
+    <main class="arena">
+      <div class="arena__top">
+        <div class="arena__title-block">
+          <div class="blue-line"></div>
+          <div>
+            <h1>ONLINE — ${escapeHtml(snapshot.roomId)}</h1>
+            <span class="arena__subtitle">Ngày ${currentDay} • Xếp bài</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="arena__main">
+        <div class="board-block">
+          <div class="days-header">
+      			${DAYS.map((d) => {
+              const isCurrent = d === currentDay;
+              const isPast = d < currentDay;
+              return `<div class="day-pill ${isCurrent ? "day-pill--current" : ""} ${isPast ? "day-pill--done" : ""}">NGÀY ${d}</div>`;
+            }).join("")}
+          </div>
+
+          <section class="board-grid">
+            ${TIME_SLOTS.map((slot, rowIdx) => `
+              <div class="time-label">${SLOT_NAMES[slot] || slot}</div>
+              ${DAYS.map((_, colIdx) => renderOnlineBoardCell(boardSlots, rowIdx, colIdx, dayIndex, chosenCards)).join("")}
+            `).join("")}
+          </section>
+        </div>
+
+        ${chosenCards.length > 0 ? `
+          <div class="online-placement__chosen">
+            <h3>Bài đã chọn (${chosenCards.length}) — chọn thẻ rồi click vào ô trống</h3>
+            <div class="online-placement__chosen-cards">
+              ${chosenCards.map((card, idx) => {
+                const isSelectedCard = selectedPlaceCardId === card.card_id;
+                return `
+                  <div class="online-placement-card" data-online-place-card-id="${card.card_id}">
+                    <div class="placement-card ${isSelectedCard ? "placement-card--selected" : ""}"
+                         data-select-place="${card.card_id}">
+                      ${renderHandCard(card, idx, isSelectedCard ? String(card.id) : null)}
+                    </div>
+                    <button class="online-placement-card__place" data-online-place="${card.card_id}">📌 Đặt</button>
+                  </div>
+                `}).join("")}
+            </div>
+          </div>
+        ` : `
+          <div class="online-placement__done">
+            <p>✅ Đã xếp xong bài cho ngày ${currentDay}.</p>
+          </div>
+        `}
+
+        <div class="online-placement__actions">
+          <button class="online-confirm-btn" data-online-confirm-day="true">
+            ✅ Xác nhận ngày ${currentDay}
+          </button>
+        </div>
+
+        <div class="online-draft__opponents">
+          ${opponentInfo || ""}
+        </div>
+      </div>
+    </main>
+  `;
+}
+
+function renderOnlineBoardCell(
+	boardSlots: BoardSlots,
+	rowIdx: number,
+	colIdx: number,
+	currentDayIndex: number,
+	chosenCards: TravelCard[],
+): string {
+	const card = boardSlots[rowIdx]?.[colIdx] ?? null;
+	const isCurrentDay = colIdx === currentDayIndex;
+	const canPlace = isCurrentDay && card === null && chosenCards.length > 0;
+
+	if (!card) {
+		return `
+      <div class="board-cell board-cell--empty ${!isCurrentDay ? "board-cell--not-current-day" : ""} ${canPlace ? "board-cell--placeable" : ""}"
+           data-online-slot="${DAYS[colIdx]}-${TIME_SLOTS[rowIdx]}"
+           data-day="${DAYS[colIdx]}"
+           data-slot="${TIME_SLOTS[rowIdx]}"
+           title="${isCurrentDay ? "Đặt thẻ vào ô này" : "Không phải ngày hiện tại"}">
+        <span class="empty-plus" ${canPlace ? 'style="cursor:pointer"' : ""}>+</span>
+      </div>
+    `;
+	}
+
+	return `
+    <div class="board-cell board-cell--occupied board-cell--clickable"
+         title="${card.name}">
+      ${renderBoardMiniCard(card)}
+    </div>
+  `;
+}
+
+// ── Scoring phase ───────────────────────────────────────────────────────────
+
+function renderOnlineScoring(
+	snapshot: RoomSnapshot,
+	myPlayer: PlayerState,
+	_allCards: TravelCard[],
+): string {
+	return `
+    <main class="arena">
+      <div class="arena__top">
+        <div class="arena__title-block">
+          <div class="blue-line"></div>
+          <div>
+            <h1>ONLINE — ${escapeHtml(snapshot.roomId)}</h1>
+            <span class="arena__subtitle">Ngày ${snapshot.day} • Kết quả</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="arena__main">
+        <div class="score-panel-online">
+          <h2>📊 Kết quả ngày ${snapshot.day}</h2>
+
+          <table class="score-table">
+            <thead>
+              <tr>
+                <th>Người chơi</th>
+                <th>VP</th>
+                <th>Xu</th>
+                <th>Stamina</th>
+                <th>Trạng thái</th>
+              </tr>
+            </thead>
+            <tbody>
+              ${snapshot.players.map((p) => `
+                <tr class="${p.playerId === myPlayer.playerId ? "score-row--me" : ""}">
+                  <td><strong>${escapeHtml(p.name)}</strong></td>
+                  <td>${p.resources.vp}</td>
+                  <td>${p.resources.xu}</td>
+                  <td>${p.resources.stamina}</td>
+                  <td>${p.ready ? "✅ Sẵn sàng" : "⏳ Đang tính..."}</td>
+                </tr>
+              `).join("")}
+            </tbody>
+          </table>
+
+          <p class="score-hint">Đang chờ tất cả người chơi...</p>
+        </div>
+      </div>
+    </main>
+  `;
+}
+
+// ── Finished phase ──────────────────────────────────────────────────────────
+
+function renderOnlineFinished(snapshot: RoomSnapshot): string {
+	const winner = snapshot.players.find((p) => p.playerId === snapshot.winnerId);
+	const sorted = [...snapshot.players].sort((a, b) => b.resources.vp - a.resources.vp);
+
+	return `
+    <main class="arena">
+      <div class="arena__top">
+        <div class="arena__title-block">
+          <div class="blue-line"></div>
+          <div>
+            <h1>ONLINE — ${escapeHtml(snapshot.roomId)}</h1>
+            <span class="arena__subtitle">🏆 Trò chơi kết thúc!</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="arena__main">
+        <div class="score-panel-online score-panel-online--final">
+          <h2>🏆 Bảng xếp hạng cuối cùng</h2>
+
+          ${winner ? `<div class="winner-banner">🥇 ${escapeHtml(winner.name)} chiến thắng với ${winner.resources.vp} VP!</div>` : ""}
+
+          <table class="score-table">
+            <thead>
+              <tr>
+                <th>#</th>
+                <th>Người chơi</th>
+                <th>VP</th>
+                <th>Xu</th>
+                <th>Stamina</th>
+              </tr>
+            </thead>
+            <tbody>
+              ${sorted.map((p, i) => `
+                <tr class="${p.playerId === snapshot.winnerId ? "score-row--winner" : ""}">
+                  <td>${i + 1}</td>
+                  <td><strong>${escapeHtml(p.name)}</strong></td>
+                  <td>${p.resources.vp}</td>
+                  <td>${p.resources.xu}</td>
+                  <td>${p.resources.stamina}</td>
+                </tr>
+              `).join("")}
+            </tbody>
+          </table>
+
+          <button class="online-back-btn" data-online-leave-game="true">← Quay lại trang chủ</button>
+        </div>
+      </div>
+    </main>
+  `;
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function resolveCards(ids: string[], catalogue: TravelCard[]): TravelCard[] {
+	const byId = new Map(catalogue.map((c) => [c.card_id, c]));
+	return ids.map((id) => byId.get(id)).filter(Boolean) as TravelCard[];
+}
+
+function getOpponentStatusMarkup(p: PlayerState): string {
+	return `
+    <div class="opponent-chip">
+      <span class="opponent-chip__name">${escapeHtml(p.name)}</span>
+      <span class="opponent-chip__status">${p.ready ? "✅ Sẵn sàng" : "⏳ Đang chọn"}</span>
+    </div>
+  `;
+}
+
+function escapeHtml(text: string): string {
+	return text
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;")
+		.replace(/'/g, "&#039;");
+}
+
+// ── Global action handlers (bound on render) ────────────────────────────────
+
+export function initOnlineGameGlobals() {
+	// Draft: store card
+	document.querySelectorAll("[data-online-store]").forEach((btn) => {
+		btn.addEventListener("click", (e) => {
+			const cardId = (e.currentTarget as HTMLElement).getAttribute("data-online-store");
+			if (cardId) handleOnlineDraftCard(cardId, "store");
+		});
+	});
+
+	// Draft: rest card
+	document.querySelectorAll("[data-online-rest]").forEach((btn) => {
+		btn.addEventListener("click", (e) => {
+			const cardId = (e.currentTarget as HTMLElement).getAttribute("data-online-rest");
+			if (cardId) handleOnlineDraftCard(cardId, "rest");
+		});
+	});
+
+	// Placement: click slot to place
+	document.querySelectorAll("[data-online-slot]").forEach((el) => {
+		el.addEventListener("click", (e) => {
+			const target = e.currentTarget as HTMLElement;
+			const day = parseInt(target.getAttribute("data-day") || "0", 10);
+			const slot = target.getAttribute("data-slot") || "";
+			const cardId = getSelectedPlaceCardId();
+			if (cardId && day > 0 && slot) {
+				handleOnlinePlaceCard(cardId, day, slot);
+			}
+		});
+	});
+
+	// Placement: select card
+	document.querySelectorAll("[data-select-place]").forEach((el) => {
+		el.addEventListener("click", (e) => {
+			const cardId = (e.currentTarget as HTMLElement).getAttribute("data-select-place");
+			if (cardId) selectPlaceCard(cardId);
+		});
+	});
+
+	// Placement: place button
+	document.querySelectorAll("[data-online-place]").forEach((btn) => {
+		btn.addEventListener("click", (e) => {
+			const cardId = (e.currentTarget as HTMLElement).getAttribute("data-online-place");
+			if (cardId) selectPlaceCard(cardId);
+		});
+	});
+
+	// Confirm day
+	const confirmBtn = document.querySelector("[data-online-confirm-day]");
+	if (confirmBtn) {
+		confirmBtn.addEventListener("click", () => handleOnlineConfirmDay());
+	}
+
+	// Leave game
+	const leaveBtn = document.querySelector("[data-online-leave-game]");
+	if (leaveBtn) {
+		leaveBtn.addEventListener("click", () => handleOnlineLeaveGame());
+	}
+}
+
+// ── Action handlers ─────────────────────────────────────────────────────────
+
+let selectedPlaceCardId: string | null = null;
+
+function getSelectedPlaceCardId(): string | null {
+	return selectedPlaceCardId;
+}
+
+function selectPlaceCard(cardId: string | null) {
+	selectedPlaceCardId = cardId;
+	// Re-render to update selection highlight
+	import("../router.ts").then(({ rerenderGameShell }) => {
+		rerenderGameShell();
+	});
+}
+
+async function handleOnlineDraftCard(cardId: string, mode: "store" | "rest") {
+	try {
+		await rpcCall("draftCard", { cardId, mode });
+	} catch (err: unknown) {
+		const msg = err instanceof Error ? err.message : String(err);
+		console.warn("[onlineGame] draftCard failed:", msg);
+	}
+}
+
+async function handleOnlinePlaceCard(cardId: string, day: number, slot: string) {
+	try {
+		await rpcCall("placeCard", { cardId, day, slot });
+		selectedPlaceCardId = null;
+		// RPC response triggers a new snapshot → re-render
+	} catch (err: unknown) {
+		const msg = err instanceof Error ? err.message : String(err);
+		console.warn("[onlineGame] placeCard failed:", msg);
+		alert(`Không thể đặt thẻ: ${msg}`);
+	}
+}
+
+async function handleOnlineConfirmDay() {
+	try {
+		await rpcCall("confirmDay", {});
+	} catch (err: unknown) {
+		const msg = err instanceof Error ? err.message : String(err);
+		console.warn("[onlineGame] confirmDay failed:", msg);
+		alert(`Không thể xác nhận: ${msg}`);
+	}
+}
+
+async function handleOnlineLeaveGame() {
+	// Disconnect and navigate back to lobby entry
+	const { disconnectFromRoom } = await import("../online/socketClient.ts");
+	disconnectFromRoom();
+	// Navigate to lobby entry
+	const { transitionToScreen } = await import("../router.ts");
+	transitionToScreen("lobby");
+}

--- a/src/shared/board.ts
+++ b/src/shared/board.ts
@@ -93,7 +93,7 @@ export function countCardsWithTag(cards: TravelCard[], tag: string): number {
 // ─── Canonical validation (adapted from original scr/shared/board.ts) ─────────
 
 /** Map legacy TimeSlot name to row index. */
-function slotToRowIndex(slot: string): number {
+export function slotToRowIndex(slot: string): number {
 	const slots: Record<string, number> = {
 		early_morning: 0,
 		morning: 1,
@@ -123,10 +123,43 @@ export const TIME_SLOTS = [
 	"evening",
 	"night",
 ] as const;
+
+export const SLOT_NAMES: Record<string, string> = {
+	early_morning: "Sáng",
+	morning: "Trưa",
+	afternoon: "Chiều",
+	evening: "Tối",
+	night: "Khuya",
+};
 export const DISTANCE_LIMIT_KM = 20;
 
 export function cellId(position: GridPosition) {
 	return `day-${position.day}-${position.slot}`;
+}
+
+/**
+ * Convert a server-side BoardCell[] into client-side BoardSlots.
+ * Resolves card_id → TravelCard via the provided card catalogue.
+ */
+export function boardCellsToSlots(
+	cells: BoardCell[],
+	cards: TravelCard[],
+): BoardSlots {
+	const byId = new Map(cards.map((c) => [c.card_id, c]));
+	const slots: BoardSlots = createEmptyBoardSlots();
+
+	for (const cell of cells) {
+		const rowIdx = slotToRowIndex(cell.slot);
+		const colIdx = cell.day - 1;
+		if (rowIdx < 0 || colIdx < 0 || colIdx >= slots[0].length) continue;
+
+		if (cell.card_id) {
+			const card = byId.get(cell.card_id);
+			if (card) slots[rowIdx][colIdx] = card;
+		}
+	}
+
+	return slots;
 }
 
 export function validateGridPlacement(

--- a/src/version.ts
+++ b/src/version.ts
@@ -4,6 +4,6 @@
  * BUILD_TIME is replaced at build time by the bundler (rollup).
  */
 
-export const VERSION = "0.15.0";
+export const VERSION = "0.16.0";
 export const BUILD_TIME = "__BUILD_TIME_PLACEHOLDER__";
 export const APP_NAME = "Trekkopoly";


### PR DESCRIPTION
## Summary

Renders the multiplayer game UI from WebSocket RoomSnapshot data (draft → placement → scoring → finished). No server changes needed — all RPCs were already implemented in the Phase 1 lobby PR.

## Changes

### New file: `src/screens/onlineGame.ts` (400+ lines)
- Phased renderers: `renderOnlineDraft()`, `renderOnlinePlacement()`, `renderOnlineScoring()`, `renderOnlineFinished()`
- Draft: shows hand cards with **Lưu** / **Nghỉ** buttons, calls `rpcCall('draftCard', ...)`
- Placement: shows board grid (converted from server `BoardCell[]` via `boardCellsToSlots()`) + chosen cards, calls `rpcCall('placeCard', 'skipSlot', 'confirmDay')`
- Scoring / Finished: score table with opponent comparison
- Uses existing `renderHandCard()` and `renderBoardMiniCard()` for visual consistency

### Modified files
- **`src/shared/board.ts`** — added `boardCellsToSlots()` to convert `BoardCell[]` → `BoardSlots` with card ID resolution; exported `slotToRowIndex`, `SLOT_NAMES`
- **`src/online/lobbyClient.ts`** — `handleRoomSnapshot` now stores full snapshot for game renderer; exports `getCurrentGameSnapshot()`, `getCurrentCards()`; stores card catalogue on room creation
- **`src/router.ts`** — game screen detects online mode via `getCurrentRoomId()` and delegates to `renderOnlineGameArena()`; post-render inits online game globals
- **`src/version.ts`** — 0.15.0 → 0.16.0

### Bug fix: single-player card pool
`app.ts` was importing only `saigonFoodCards` (30 cards) for the single-player deck, ignoring culture/action/utility cards. Now uses `allCards` (100 cards, all 4 types). This is why only FOOD-type cards appeared in single-player.

## How to test
1. Open the app → click **CHƠI ONLINE** → create a room → start the game
2. Draft phase: hand cards appear with store/rest buttons
3. Place phase: board grid + chosen cards visible
4. Scoring/finished: score table showing all players