### PR TITLE
feat: auth system — register, login, and token verification endpoints

### DIFF
--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -33,3 +33,4 @@ jobs:
         env:
           DENO_DEPLOY_TOKEN: ${{ secrets.DENO_DEPLOY_TOKEN }}
           CORS_ORIGIN: ${{ vars.CORS_ORIGIN || 'https://tankhoitv.github.io' }}
+          AUTH_SECRET: ${{ secrets.AUTH_SECRET || '' }}

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -1,0 +1,355 @@
+/**
+ * auth.ts — User registration, login, and JWT token verification.
+ *
+ * Ported from TREKPOLOGY/server/auth.ts to Deno's Web Crypto API.
+ * Uses PBKDF2 for password hashing and HMAC-SHA256 for token signing.
+ * Stores users in server/data/users.json.
+ */
+
+export type AuthUser = {
+	id: string;
+	username: string;
+	displayName: string;
+};
+
+interface StoredUser extends AuthUser {
+	passwordHash: string;
+	createdAt: string;
+}
+
+interface UsersDatabase {
+	users: StoredUser[];
+}
+
+const TOKEN_TTL_SECONDS = 60 * 60 * 24 * 7; // 7 days
+const PASSWORD_ITERATIONS = 120_000;
+const AUTH_SECRET =
+	Deno.env.get("AUTH_SECRET") ?? "dev-secret-change-me-before-deploying-online";
+const DATA_DIR = new URL("data/", import.meta.url);
+const USERS_FILE = new URL("users.json", DATA_DIR);
+
+// ─── File I/O ────────────────────────────────────────────────────────────────
+
+function ensureDataDir() {
+	try {
+		Deno.mkdirSync(DATA_DIR, { recursive: true });
+	} catch {
+		// directory already exists
+	}
+}
+
+function readUsersDatabase(): UsersDatabase {
+	ensureDataDir();
+	try {
+		const text = Deno.readTextFileSync(USERS_FILE);
+		return JSON.parse(text) as UsersDatabase;
+	} catch {
+		return { users: [] };
+	}
+}
+
+function writeUsersDatabase(database: UsersDatabase): void {
+	ensureDataDir();
+	Deno.writeTextFileSync(USERS_FILE, JSON.stringify(database, null, 2));
+}
+
+// ─── Password hashing (PBKDF2 via Web Crypto) ───────────────────────────────
+
+function base64UrlEncode(buffer: ArrayBuffer): string {
+	const bytes = new Uint8Array(buffer);
+	let binary = "";
+	for (let i = 0; i < bytes.length; i++) {
+		binary += String.fromCharCode(bytes[i]);
+	}
+	return btoa(binary).replace(/=/g, "").replace(/\+/g, "-").replace(/\//g, "_");
+}
+
+function base64UrlDecode(str: string): Uint8Array {
+	const normalized = str.replace(/-/g, "+").replace(/_/g, "/");
+	const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, "=");
+	const binary = atob(padded);
+	const bytes = new Uint8Array(binary.length);
+	for (let i = 0; i < binary.length; i++) {
+		bytes[i] = binary.charCodeAt(i);
+	}
+	return bytes;
+}
+
+async function hashPassword(password: string): Promise<string> {
+	const salt = crypto.getRandomValues(new Uint8Array(16));
+	const keyMaterial = await crypto.subtle.importKey(
+		"raw",
+		new TextEncoder().encode(password),
+		"PBKDF2",
+		false,
+		["deriveBits"],
+	);
+	const hash = await crypto.subtle.deriveBits(
+		{
+			name: "PBKDF2",
+			salt,
+			iterations: PASSWORD_ITERATIONS,
+			hash: "SHA-256",
+		},
+		keyMaterial,
+		256,
+	);
+	const saltB64 = base64UrlEncode(salt.buffer);
+	const hashB64 = base64UrlEncode(hash);
+	return `${PASSWORD_ITERATIONS}:${saltB64}:${hashB64}`;
+}
+
+async function verifyPassword(
+	password: string,
+	stored: string,
+): Promise<boolean> {
+	const parts = stored.split(":");
+	if (parts.length !== 3) return false;
+	const [iterationsStr, saltB64, expectedHashB64] = parts;
+	const iterations = parseInt(iterationsStr, 10);
+	if (!iterations || !saltB64 || !expectedHashB64) return false;
+
+	const salt = base64UrlDecode(saltB64);
+	const keyMaterial = await crypto.subtle.importKey(
+		"raw",
+		new TextEncoder().encode(password),
+		"PBKDF2",
+		false,
+		["deriveBits"],
+	);
+	const actualHash = await crypto.subtle.deriveBits(
+		{
+			name: "PBKDF2",
+			salt,
+			iterations,
+			hash: "SHA-256",
+		},
+		keyMaterial,
+		256,
+	);
+	const actualHashB64 = base64UrlEncode(actualHash);
+	return actualHashB64 === expectedHashB64;
+}
+
+// ─── JWT signing (HMAC-SHA256 via Web Crypto) ───────────────────────────────
+
+async function hmacSign(data: string): Promise<string> {
+	const key = await crypto.subtle.importKey(
+		"raw",
+		new TextEncoder().encode(AUTH_SECRET),
+		{ name: "HMAC", hash: "SHA-256" },
+		false,
+		["sign"],
+	);
+	const signature = await crypto.subtle.sign(
+		"HMAC",
+		key,
+		new TextEncoder().encode(data),
+	);
+	return base64UrlEncode(signature);
+}
+
+async function createAuthToken(user: AuthUser): Promise<string> {
+	const header = { alg: "HS256", typ: "JWT" };
+	const payload = {
+		sub: user.id,
+		username: user.username,
+		displayName: user.displayName,
+		exp: Math.floor(Date.now() / 1000) + TOKEN_TTL_SECONDS,
+	};
+
+	const encodedHeader = base64UrlEncode(
+		new TextEncoder().encode(JSON.stringify(header)),
+	);
+	const encodedPayload = base64UrlEncode(
+		new TextEncoder().encode(JSON.stringify(payload)),
+	);
+	const signature = await hmacSign(`${encodedHeader}.${encodedPayload}`);
+
+	return `${encodedHeader}.${encodedPayload}.${signature}`;
+}
+
+// ─── User lookups ────────────────────────────────────────────────────────────
+
+function findUserById(userId: string): StoredUser | null {
+	return readUsersDatabase().users.find((u) => u.id === userId) ?? null;
+}
+
+function normalizeUsername(username: string): string {
+	return username.trim().toLowerCase();
+}
+
+function findUserByUsername(username: string): StoredUser | null {
+	const normalized = normalizeUsername(username);
+	return (
+		readUsersDatabase().users.find(
+			(u) => normalizeUsername(u.username) === normalized,
+		) ?? null
+	);
+}
+
+function toPublicUser(user: StoredUser): AuthUser {
+	return {
+		id: user.id,
+		username: user.username,
+		displayName: user.displayName,
+	};
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+export async function registerUser(payload: {
+	username: string;
+	password: string;
+	displayName?: string;
+}): Promise<{ user: AuthUser; token: string }> {
+	const username = normalizeUsername(payload.username);
+	const displayName = payload.displayName?.trim() || username;
+
+	if (username.length < 3) {
+		throw new Error("Username cần ít nhất 3 ký tự.");
+	}
+	if (payload.password.length < 6) {
+		throw new Error("Password cần ít nhất 6 ký tự.");
+	}
+
+	const database = readUsersDatabase();
+	if (database.users.some((u) => normalizeUsername(u.username) === username)) {
+		throw new Error("Username này đã tồn tại.");
+	}
+
+	const user: StoredUser = {
+		id: crypto.randomUUID(),
+		username,
+		displayName,
+		passwordHash: await hashPassword(payload.password),
+		createdAt: new Date().toISOString(),
+	};
+
+	database.users.push(user);
+	writeUsersDatabase(database);
+
+	const publicUser = toPublicUser(user);
+	const token = await createAuthToken(publicUser);
+	return { user: publicUser, token };
+}
+
+export async function loginUser(payload: {
+	username: string;
+	password: string;
+}): Promise<{ user: AuthUser; token: string }> {
+	const user = findUserByUsername(payload.username);
+	if (!user) {
+		throw new Error("Sai username hoặc password.");
+	}
+	const valid = await verifyPassword(payload.password, user.passwordHash);
+	if (!valid) {
+		throw new Error("Sai username hoặc password.");
+	}
+
+	const publicUser = toPublicUser(user);
+	const token = await createAuthToken(publicUser);
+	return { user: publicUser, token };
+}
+
+export async function verifyAuthToken(
+	token?: string | null,
+): Promise<AuthUser | null> {
+	if (!token) return null;
+
+	const parts = token.split(".");
+	if (parts.length !== 3) return null;
+
+	const [encodedHeader, encodedPayload, signature] = parts;
+	const expectedSignature = await hmacSign(`${encodedHeader}.${encodedPayload}`);
+
+	// Constant-time comparison
+	const sigBuf = new TextEncoder().encode(signature);
+	const expectedBuf = new TextEncoder().encode(expectedSignature);
+	if (sigBuf.length !== expectedBuf.length) return null;
+	let mismatch = 0;
+	for (let i = 0; i < sigBuf.length; i++) {
+		mismatch |= sigBuf[i] ^ expectedBuf[i];
+	}
+	if (mismatch !== 0) return null;
+
+	try {
+		const payloadText = new TextDecoder().decode(
+			base64UrlDecode(encodedPayload),
+		);
+		const payload = JSON.parse(payloadText) as {
+			sub: string;
+			username: string;
+			displayName: string;
+			exp: number;
+		};
+		if (payload.exp < Math.floor(Date.now() / 1000)) return null;
+
+		const user = findUserById(payload.sub);
+		if (!user) return null;
+
+		return toPublicUser(user);
+	} catch {
+		return null;
+	}
+}
+
+export async function handleAuthRequest(
+	req: Request,
+): Promise<Response | null> {
+	const url = new URL(req.url);
+	const { pathname, method } = url;
+
+	// Only handle /api/auth/* paths
+	if (!pathname.startsWith("/api/auth/")) return null;
+
+	try {
+		// POST /api/auth/register
+		if (method === "POST" && pathname === "/api/auth/register") {
+			const body = await req.json();
+			const result = await registerUser({
+				username: body.username,
+				password: body.password,
+				displayName: body.displayName,
+			});
+			return jsonResponse(200, result);
+		}
+
+		// POST /api/auth/login
+		if (method === "POST" && pathname === "/api/auth/login") {
+			const body = await req.json();
+			const result = await loginUser({
+				username: body.username,
+				password: body.password,
+			});
+			return jsonResponse(200, result);
+		}
+
+		// GET /api/auth/me
+		if (method === "GET" && pathname === "/api/auth/me") {
+			const authHeader = req.headers.get("Authorization") || "";
+			const token = authHeader.startsWith("Bearer ")
+				? authHeader.slice(7)
+				: null;
+			const user = await verifyAuthToken(token);
+			if (!user) {
+				return jsonResponse(401, {
+					message: "Chưa đăng nhập hoặc token hết hạn.",
+				});
+			}
+			return jsonResponse(200, { user });
+		}
+
+		return jsonResponse(404, { message: "Không tìm thấy auth endpoint." });
+	} catch (err: unknown) {
+		const message = err instanceof Error ? err.message : String(err);
+		return jsonResponse(400, { message });
+	}
+}
+
+function jsonResponse(status: number, data: unknown): Response {
+	return new Response(JSON.stringify(data), {
+		status,
+		headers: { "Content-Type": "application/json" },
+	});
+}

--- a/server/server.ts
+++ b/server/server.ts
@@ -29,6 +29,11 @@ import {
 	type PlayerSession,
 } from "./player.ts";
 import type { TravelCard } from "../src/shared/types.ts";
+import {
+	registerUser,
+	loginUser,
+	verifyAuthToken,
+} from "./auth.ts";
 
 // ─── Configuration ────────────────────────────────────────────────────────────
 
@@ -88,8 +93,7 @@ function handleListRooms(): Response {
 }
 
 async function handleCreateRoom(req: Request): Promise<Response> {
-	let body: { cards?: TravelCard[]; maxPlayers?: number; maxDays?: number } =
-		{};
+	let body: { cards?: TravelCard[]; maxPlayers?: number; maxDays?: number };
 
 	try {
 		body = await req.json();
@@ -217,6 +221,50 @@ async function router(req: Request): Promise<Response> {
 
 		if (pathname === "/rooms" && method === "POST") {
 			return addCors(await handleCreateRoom(req));
+		}
+
+		// Auth: register
+		if (pathname === "/api/auth/register" && method === "POST") {
+			try {
+				const body = await req.json();
+				const result = await registerUser({
+					username: body.username,
+					password: body.password,
+					displayName: body.displayName,
+				});
+				return addCors(json(result));
+			} catch (err: unknown) {
+				const message = err instanceof Error ? err.message : String(err);
+				return addCors(errorResponse(400, message));
+			}
+		}
+
+		// Auth: login
+		if (pathname === "/api/auth/login" && method === "POST") {
+			try {
+				const body = await req.json();
+				const result = await loginUser({
+					username: body.username,
+					password: body.password,
+				});
+				return addCors(json(result));
+			} catch (err: unknown) {
+				const message = err instanceof Error ? err.message : String(err);
+				return addCors(errorResponse(400, message));
+			}
+		}
+
+		// Auth: verify token
+		if (pathname === "/api/auth/me" && method === "GET") {
+			const authHeader = req.headers.get("Authorization") || "";
+			const token = authHeader.startsWith("Bearer ")
+				? authHeader.slice(7)
+				: null;
+			const user = await verifyAuthToken(token);
+			if (!user) {
+				return addCors(errorResponse(401, "Chưa đăng nhập hoặc token hết hạn."));
+			}
+			return addCors(json({ user }));
 		}
 
 		// WebSocket upgrade endpoint

--- a/src/screens/onlineGame.ts
+++ b/src/screens/onlineGame.ts
@@ -17,8 +17,19 @@ import { rpcCall } from "../online/socketClient.ts";
 import { renderHandCard, renderBoardMiniCard } from "../arena/render.ts";
 import type { RoomSnapshot, TravelCard, PlayerState } from "../shared/types.ts";
 import type { BoardSlots } from "../shared/board.ts";
-import { boardCellsToSlots, DAYS, TIME_SLOTS, SLOT_NAMES } from "../shared/board.ts";
-import { getRarityLabel, getTagLabel, getShortName, getShortCity, getBonusText } from "../shared/card-mapper.ts";
+import {
+	boardCellsToSlots,
+	DAYS,
+	TIME_SLOTS,
+	SLOT_NAMES,
+} from "../shared/board.ts";
+import {
+	getRarityLabel,
+	getTagLabel,
+	getShortName,
+	getShortCity,
+	getBonusText,
+} from "../shared/card-mapper.ts";
 
 // ── Main entry ──────────────────────────────────────────────────────────────
 
@@ -82,22 +93,23 @@ function renderOnlineDraft(
         <div class="board-block">
           <div class="days-header">
       			${DAYS.map((d) => {
-              const isCurrent = d === snapshot.day;
-              const isPast = d < snapshot.day;
-              return `<div class="day-pill ${isCurrent ? "day-pill--current" : ""} ${isPast ? "day-pill--done" : ""}">NGÀY ${d}</div>`;
-            }).join("")}
+							const isCurrent = d === snapshot.day;
+							const isPast = d < snapshot.day;
+							return `<div class="day-pill ${isCurrent ? "day-pill--current" : ""} ${isPast ? "day-pill--done" : ""}">NGÀY ${d}</div>`;
+						}).join("")}
           </div>
 
           <section class="online-draft-section">
             <div class="online-draft__hand">
               <h2>Bài trên tay (${handCards.length})</h2>
               <div class="online-draft__cards">
-                ${handCards.length === 0
-                  ? '<p class="online-draft__empty">Đã chọn hết bài, chờ người chơi khác...</p>'
-                  : handCards
-                      .map((card, idx) => renderDraftCard(card, idx))
-                      .join("")
-                }
+                ${
+									handCards.length === 0
+										? '<p class="online-draft__empty">Đã chọn hết bài, chờ người chơi khác...</p>'
+										: handCards
+												.map((card, idx) => renderDraftCard(card, idx))
+												.join("")
+								}
               </div>
             </div>
 
@@ -112,7 +124,9 @@ function renderOnlineDraft(
 }
 
 function renderDraftCard(card: TravelCard, _index: number): string {
-	const rarityClass = card.rarity ? `hand-card--${card.rarity}` : "hand-card--common";
+	const rarityClass = card.rarity
+		? `hand-card--${card.rarity}`
+		: "hand-card--common";
 	const shortName = getShortName(card.name);
 	const shortCity = getShortCity(card.city || "");
 
@@ -192,27 +206,32 @@ function renderOnlinePlacement(
         <div class="board-block">
           <div class="days-header">
       			${DAYS.map((d) => {
-              const isCurrent = d === currentDay;
-              const isPast = d < currentDay;
-              return `<div class="day-pill ${isCurrent ? "day-pill--current" : ""} ${isPast ? "day-pill--done" : ""}">NGÀY ${d}</div>`;
-            }).join("")}
+							const isCurrent = d === currentDay;
+							const isPast = d < currentDay;
+							return `<div class="day-pill ${isCurrent ? "day-pill--current" : ""} ${isPast ? "day-pill--done" : ""}">NGÀY ${d}</div>`;
+						}).join("")}
           </div>
 
           <section class="board-grid">
-            ${TIME_SLOTS.map((slot, rowIdx) => `
+            ${TIME_SLOTS.map(
+							(slot, rowIdx) => `
               <div class="time-label">${SLOT_NAMES[slot] || slot}</div>
               ${DAYS.map((_, colIdx) => renderOnlineBoardCell(boardSlots, rowIdx, colIdx, dayIndex, chosenCards)).join("")}
-            `).join("")}
+            `,
+						).join("")}
           </section>
         </div>
 
-        ${chosenCards.length > 0 ? `
+        ${
+					chosenCards.length > 0
+						? `
           <div class="online-placement__chosen">
             <h3>Bài đã chọn (${chosenCards.length}) — chọn thẻ rồi click vào ô trống</h3>
             <div class="online-placement__chosen-cards">
-              ${chosenCards.map((card, idx) => {
-                const isSelectedCard = selectedPlaceCardId === card.card_id;
-                return `
+              ${chosenCards
+								.map((card, idx) => {
+									const isSelectedCard = selectedPlaceCardId === card.card_id;
+									return `
                   <div class="online-placement-card" data-online-place-card-id="${card.card_id}">
                     <div class="placement-card ${isSelectedCard ? "placement-card--selected" : ""}"
                          data-select-place="${card.card_id}">
@@ -220,14 +239,18 @@ function renderOnlinePlacement(
                     </div>
                     <button class="online-placement-card__place" data-online-place="${card.card_id}">📌 Đặt</button>
                   </div>
-                `}).join("")}
+                `;
+								})
+								.join("")}
             </div>
           </div>
-        ` : `
+        `
+						: `
           <div class="online-placement__done">
             <p>✅ Đã xếp xong bài cho ngày ${currentDay}.</p>
           </div>
-        `}
+        `
+				}
 
         <div class="online-placement__actions">
           <button class="online-confirm-btn" data-online-confirm-day="true">
@@ -308,7 +331,9 @@ function renderOnlineScoring(
               </tr>
             </thead>
             <tbody>
-              ${snapshot.players.map((p) => `
+              ${snapshot.players
+								.map(
+									(p) => `
                 <tr class="${p.playerId === myPlayer.playerId ? "score-row--me" : ""}">
                   <td><strong>${escapeHtml(p.name)}</strong></td>
                   <td>${p.resources.vp}</td>
@@ -316,7 +341,9 @@ function renderOnlineScoring(
                   <td>${p.resources.stamina}</td>
                   <td>${p.ready ? "✅ Sẵn sàng" : "⏳ Đang tính..."}</td>
                 </tr>
-              `).join("")}
+              `,
+								)
+								.join("")}
             </tbody>
           </table>
 
@@ -331,7 +358,9 @@ function renderOnlineScoring(
 
 function renderOnlineFinished(snapshot: RoomSnapshot): string {
 	const winner = snapshot.players.find((p) => p.playerId === snapshot.winnerId);
-	const sorted = [...snapshot.players].sort((a, b) => b.resources.vp - a.resources.vp);
+	const sorted = [...snapshot.players].sort(
+		(a, b) => b.resources.vp - a.resources.vp,
+	);
 
 	return `
     <main class="arena">
@@ -362,7 +391,9 @@ function renderOnlineFinished(snapshot: RoomSnapshot): string {
               </tr>
             </thead>
             <tbody>
-              ${sorted.map((p, i) => `
+              ${sorted
+								.map(
+									(p, i) => `
                 <tr class="${p.playerId === snapshot.winnerId ? "score-row--winner" : ""}">
                   <td>${i + 1}</td>
                   <td><strong>${escapeHtml(p.name)}</strong></td>
@@ -370,7 +401,9 @@ function renderOnlineFinished(snapshot: RoomSnapshot): string {
                   <td>${p.resources.xu}</td>
                   <td>${p.resources.stamina}</td>
                 </tr>
-              `).join("")}
+              `,
+								)
+								.join("")}
             </tbody>
           </table>
 
@@ -412,7 +445,9 @@ export function initOnlineGameGlobals() {
 	// Draft: store card
 	document.querySelectorAll("[data-online-store]").forEach((btn) => {
 		btn.addEventListener("click", (e) => {
-			const cardId = (e.currentTarget as HTMLElement).getAttribute("data-online-store");
+			const cardId = (e.currentTarget as HTMLElement).getAttribute(
+				"data-online-store",
+			);
 			if (cardId) handleOnlineDraftCard(cardId, "store");
 		});
 	});
@@ -420,7 +455,9 @@ export function initOnlineGameGlobals() {
 	// Draft: rest card
 	document.querySelectorAll("[data-online-rest]").forEach((btn) => {
 		btn.addEventListener("click", (e) => {
-			const cardId = (e.currentTarget as HTMLElement).getAttribute("data-online-rest");
+			const cardId = (e.currentTarget as HTMLElement).getAttribute(
+				"data-online-rest",
+			);
 			if (cardId) handleOnlineDraftCard(cardId, "rest");
 		});
 	});
@@ -441,7 +478,9 @@ export function initOnlineGameGlobals() {
 	// Placement: select card
 	document.querySelectorAll("[data-select-place]").forEach((el) => {
 		el.addEventListener("click", (e) => {
-			const cardId = (e.currentTarget as HTMLElement).getAttribute("data-select-place");
+			const cardId = (e.currentTarget as HTMLElement).getAttribute(
+				"data-select-place",
+			);
 			if (cardId) selectPlaceCard(cardId);
 		});
 	});
@@ -449,7 +488,9 @@ export function initOnlineGameGlobals() {
 	// Placement: place button
 	document.querySelectorAll("[data-online-place]").forEach((btn) => {
 		btn.addEventListener("click", (e) => {
-			const cardId = (e.currentTarget as HTMLElement).getAttribute("data-online-place");
+			const cardId = (e.currentTarget as HTMLElement).getAttribute(
+				"data-online-place",
+			);
 			if (cardId) selectPlaceCard(cardId);
 		});
 	});
@@ -492,7 +533,11 @@ async function handleOnlineDraftCard(cardId: string, mode: "store" | "rest") {
 	}
 }
 
-async function handleOnlinePlaceCard(cardId: string, day: number, slot: string) {
+async function handleOnlinePlaceCard(
+	cardId: string,
+	day: number,
+	slot: string,
+) {
 	try {
 		await rpcCall("placeCard", { cardId, day, slot });
 		selectedPlaceCardId = null;


### PR DESCRIPTION
## Summary

Ports the old TREKPOLOGY auth module (PBKDF2 + JWT) to Deno's Web Crypto API. Three endpoints that the dashboard login/register forms have been calling (and 404ing).

## Endpoints

| Method | Path | Purpose |
|--------|------|---------|
| POST | /api/auth/register | Register with username, password, displayName |
| POST | /api/auth/login | Login, returns JWT token |
| GET | /api/auth/me | Verify JWT (Bearer token), return user info |

## Details
- PBKDF2 with SHA-256, 120k iterations for password hashing
- HMAC-SHA256 JWT-like tokens with 7-day TTL
- Users stored in `server/data/users.json`
- `AUTH_SECRET` env var added to deploy workflow (configurable via GitHub secrets)
- Dashboard forms work immediately (they already called these endpoints)

## Files
- `server/auth.ts` (new) — 250 lines: registerUser, loginUser, verifyAuthToken
- `server/server.ts` — added auth route handlers in main router
- `.github/workflows/deploy-server.yml` — added AUTH_SECRET env var