### PR TITLE
feat: online debt payment and return board card RPCs

### DIFF
--- a/css/client.less
+++ b/css/client.less
@@ -15774,3 +15774,54 @@ body {
 .hub-modal__close:hover {
   background: #d5c6ad;
 }
+
+/* ── Online game: debt payment ─────────────────── */
+.placement__debt-pay {
+  margin: 12px 0;
+  padding: 8px 14px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.debt-label {
+  font-size: 14px;
+  font-weight: 600;
+  color: #c0392b;
+}
+
+.online-debt-btn {
+  padding: 6px 16px;
+  border: 1px solid #9a7c57;
+  border-radius: 6px;
+  background: #ede5d8;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 600;
+  color: #4e3a2b;
+  transition: background 0.15s;
+}
+.online-debt-btn:hover {
+  background: #d5c6ad;
+}
+
+/* ── Online game: return board card button ─────── */
+.board-cell__return {
+  position: absolute;
+  bottom: 2px;
+  right: 2px;
+  border: none;
+  background: rgba(78, 58, 43, 0.7);
+  color: #fff;
+  border-radius: 4px;
+  font-size: 11px;
+  padding: 1px 4px;
+  cursor: pointer;
+  line-height: 1.2;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+.board-cell--occupied:hover .board-cell__return {
+  opacity: 1;
+}

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -261,7 +261,9 @@ export async function verifyAuthToken(
 	if (parts.length !== 3) return null;
 
 	const [encodedHeader, encodedPayload, signature] = parts;
-	const expectedSignature = await hmacSign(`${encodedHeader}.${encodedPayload}`);
+	const expectedSignature = await hmacSign(
+		`${encodedHeader}.${encodedPayload}`,
+	);
 
 	// Constant-time comparison
 	const sigBuf = new TextEncoder().encode(signature);

--- a/server/game.ts
+++ b/server/game.ts
@@ -243,6 +243,96 @@ function beginDraftingPhase(room: Room): void {
 }
 
 /**
+ * Pay down debt using available xu.
+ */
+export function payDebt(
+	room: Room,
+	playerId: string,
+	amount?: number,
+): PayDebtResult {
+	const player = getPlayer(room, playerId);
+	const currentDebt = player.resources.debtToken;
+
+	if (currentDebt <= 0) {
+		throw new Error("Không có nợ để trả.");
+	}
+
+	const requestedAmount = Math.max(1, Math.floor(amount ?? currentDebt));
+	const payableAmount = Math.min(
+		player.resources.xu,
+		currentDebt,
+		requestedAmount,
+	);
+
+	if (payableAmount <= 0) {
+		throw new Error(
+			`Không đủ xu để trả nợ. Đang nợ ${currentDebt} xu, có ${player.resources.xu} xu.`,
+		);
+	}
+
+	player.resources.xu -= payableAmount;
+	player.resources.debtToken -= payableAmount;
+
+	room.log.push(
+		`${player.name} paid ${payableAmount} debt (${player.resources.debtToken} remaining).`,
+	);
+
+	room.broadcast(room);
+	return { paid: payableAmount, remainingDebt: player.resources.debtToken };
+}
+
+/**
+ * Return a placed card from the board back to the player's chosen cards.
+ * Only allowed for cards on the current day.
+ */
+export function returnBoardCard(
+	room: Room,
+	playerId: string,
+	day: number,
+	slot: string,
+): ReturnCardResult {
+	const player = getPlayer(room, playerId);
+
+	if (day !== room.day) {
+		throw new Error(`Chỉ được rút bài của ngày hiện tại (ngày ${room.day}).`);
+	}
+
+	// Find the cell at this position
+	const cellIndex = player.board.findIndex(
+		(c) => c.day === day && c.slot === slot,
+	);
+	if (cellIndex === -1 || !player.board[cellIndex].card_id) {
+		throw new Error("Ô này không có bài để rút.");
+	}
+
+	const cell = player.board[cellIndex];
+
+	// Don't allow returning debt/lock tokens
+	if (cell.type === "debt" || cell.type === "lock" || cell.locked) {
+		throw new Error("Không thể rút token nợ/khóa về tay.");
+	}
+
+	const cardId = cell.card_id!;
+
+	// Remove card from board
+	player.board = player.board.map((c, i) =>
+		i === cellIndex
+			? { ...c, card_id: undefined, cardName: undefined, type: "empty" as const }
+			: c,
+	);
+
+	// Return to chosen so it can be re-placed
+	player.chosen.push(cardId);
+
+	room.log.push(
+		`${player.name} returned card ${cardId} from board (day ${day} ${slot}).`,
+	);
+
+	room.broadcast(room);
+	return { cardId };
+}
+
+/**
  * A player picks a card from their hand — either stores it (chosen) or
  * discards it for a rest bonus.
  */

--- a/server/player.ts
+++ b/server/player.ts
@@ -20,6 +20,8 @@ import {
 	skipSlot,
 	confirmDay,
 	toggleReady,
+	payDebt,
+	returnBoardCard,
 	exportSnapshot,
 	type Room,
 } from "./game.ts";
@@ -262,6 +264,39 @@ export function dispatch(session: PlayerSession, rawMessage: string): void {
 				confirmDay(session.room!, session.playerId);
 				sendResult(session, id, {
 					ok: true,
+					snapshot: exportSnapshot(session.room!, session.playerId),
+				});
+				break;
+			}
+
+			// ── Debt / board management ──────────────────────────────────────────
+
+			case "payDebt": {
+				requireRoom(session);
+				const { amount } = params as { amount?: number };
+				const result = payDebt(session.room!, session.playerId, amount);
+				sendResult(session, id, {
+					ok: true,
+					paid: result.paid,
+					remainingDebt: result.remainingDebt,
+					snapshot: exportSnapshot(session.room!, session.playerId),
+				});
+				break;
+			}
+
+			case "returnBoardCard": {
+				requireRoom(session);
+				const { day, slot } = params as { day: number; slot: string };
+				if (day == null || !slot) {
+					throw rpcError(
+						RPC_ERRORS.INVALID_PARAMS.code,
+						"returnBoardCard requires day and slot",
+					);
+				}
+				const result = returnBoardCard(session.room!, session.playerId, day, slot);
+				sendResult(session, id, {
+					ok: true,
+					cardId: result.cardId,
 					snapshot: exportSnapshot(session.room!, session.playerId),
 				});
 				break;

--- a/server/server.ts
+++ b/server/server.ts
@@ -29,11 +29,7 @@ import {
 	type PlayerSession,
 } from "./player.ts";
 import type { TravelCard } from "../src/shared/types.ts";
-import {
-	registerUser,
-	loginUser,
-	verifyAuthToken,
-} from "./auth.ts";
+import { registerUser, loginUser, verifyAuthToken } from "./auth.ts";
 
 // ─── Configuration ────────────────────────────────────────────────────────────
 
@@ -262,7 +258,9 @@ async function router(req: Request): Promise<Response> {
 				: null;
 			const user = await verifyAuthToken(token);
 			if (!user) {
-				return addCors(errorResponse(401, "Chưa đăng nhập hoặc token hết hạn."));
+				return addCors(
+					errorResponse(401, "Chưa đăng nhập hoặc token hết hạn."),
+				);
 			}
 			return addCors(json({ user }));
 		}

--- a/src/online/lobbyClient.ts
+++ b/src/online/lobbyClient.ts
@@ -250,6 +250,31 @@ function leaveRoomFromLobby() {
 	gotoOnlineLobby();
 }
 
+// ── Debt payment ──────────────────────────────────────────────────────────
+
+export async function sendPayDebt(amount?: number): Promise<void> {
+	try {
+		await rpcCall("payDebt", amount ? { amount } : {});
+	} catch (err: unknown) {
+		const message = err instanceof Error ? err.message : String(err);
+		console.warn("[lobby] payDebt failed:", message);
+	}
+}
+
+// ── Return board card ───────────────────────────────────────────────────────
+
+export async function sendReturnBoardCard(
+	day: number,
+	slot: string,
+): Promise<void> {
+	try {
+		await rpcCall("returnBoardCard", { day, slot });
+	} catch (err: unknown) {
+		const message = err instanceof Error ? err.message : String(err);
+		console.warn("[lobby] returnBoardCard failed:", message);
+	}
+}
+
 // ── Ready toggle ───────────────────────────────────────────────────────────
 
 async function toggleReadyFromLobby() {

--- a/src/screens/onlineGame.ts
+++ b/src/screens/onlineGame.ts
@@ -12,6 +12,8 @@ import {
 	getCurrentGameSnapshot,
 	getCurrentCards,
 	getCurrentPlayerId,
+	sendPayDebt,
+	sendReturnBoardCard,
 } from "../online/lobbyClient.ts";
 import { rpcCall } from "../online/socketClient.ts";
 import { renderHandCard, renderBoardMiniCard } from "../arena/render.ts";
@@ -258,6 +260,15 @@ function renderOnlinePlacement(
           </button>
         </div>
 
+        ${myPlayer.resources.debtToken > 0 ? `
+        <div class="placement__debt-pay">
+          <span class="debt-label">💳 Nợ: <strong>${myPlayer.resources.debtToken} xu</strong></span>
+          <button class="online-debt-btn" data-online-pay-debt="all">
+            💰 Trả nợ (${Math.min(myPlayer.resources.xu, myPlayer.resources.debtToken)} xu)
+          </button>
+        </div>
+        ` : ""}
+
         <div class="online-draft__opponents">
           ${opponentInfo || ""}
         </div>
@@ -274,15 +285,17 @@ function renderOnlineBoardCell(
 	chosenCards: TravelCard[],
 ): string {
 	const card = boardSlots[rowIdx]?.[colIdx] ?? null;
+	const day = DAYS[colIdx];
+	const slot = TIME_SLOTS[rowIdx];
 	const isCurrentDay = colIdx === currentDayIndex;
 	const canPlace = isCurrentDay && card === null && chosenCards.length > 0;
 
 	if (!card) {
 		return `
       <div class="board-cell board-cell--empty ${!isCurrentDay ? "board-cell--not-current-day" : ""} ${canPlace ? "board-cell--placeable" : ""}"
-           data-online-slot="${DAYS[colIdx]}-${TIME_SLOTS[rowIdx]}"
-           data-day="${DAYS[colIdx]}"
-           data-slot="${TIME_SLOTS[rowIdx]}"
+           data-online-slot="${day}-${slot}"
+           data-day="${day}"
+           data-slot="${slot}"
            title="${isCurrentDay ? "Đặt thẻ vào ô này" : "Không phải ngày hiện tại"}">
         <span class="empty-plus" ${canPlace ? 'style="cursor:pointer"' : ""}>+</span>
       </div>
@@ -290,9 +303,10 @@ function renderOnlineBoardCell(
 	}
 
 	return `
-    <div class="board-cell board-cell--occupied board-cell--clickable"
+    <div class="board-cell board-cell--occupied"
          title="${card.name}">
       ${renderBoardMiniCard(card)}
+      ${isCurrentDay ? `<button class="board-cell__return" data-online-return-card="${day}|${slot}" title="Trả bài về tay">↩️</button>` : ""}
     </div>
   `;
 }
@@ -506,6 +520,28 @@ export function initOnlineGameGlobals() {
 	if (leaveBtn) {
 		leaveBtn.addEventListener("click", () => handleOnlineLeaveGame());
 	}
+
+	// Placement: pay debt
+	document.querySelectorAll("[data-online-pay-debt]").forEach((btn) => {
+		btn.addEventListener("click", () => {
+			handleOnlinePayDebt();
+		});
+	});
+
+	// Placement: return board card
+	document.querySelectorAll("[data-online-return-card]").forEach((btn) => {
+		btn.addEventListener("click", (e) => {
+			e.stopPropagation();
+			const val = (e.currentTarget as HTMLElement).getAttribute(
+				"data-online-return-card",
+			);
+			if (val) {
+				const [dayStr, slot] = val.split("|");
+				const day = parseInt(dayStr, 10);
+				if (day > 0 && slot) handleOnlineReturnBoardCard(day, slot);
+			}
+		});
+	});
 }
 
 // ── Action handlers ─────────────────────────────────────────────────────────
@@ -566,4 +602,12 @@ async function handleOnlineLeaveGame() {
 	// Navigate to lobby entry
 	const { transitionToScreen } = await import("../router.ts");
 	transitionToScreen("lobby");
+}
+
+async function handleOnlinePayDebt() {
+	await sendPayDebt();
+}
+
+async function handleOnlineReturnBoardCard(day: number, slot: string) {
+	await sendReturnBoardCard(day, slot);
 }


### PR DESCRIPTION
## Summary

Adds two missing RPCs needed for full online game flow: debt payment during placement, and returning a placed card from the board back to chosen.

## Server
- `payDebt(room, playerId, amount?)` — pays down `debtToken` using available `xu`, broadcasts updated snapshot
- `returnBoardCard(room, playerId, day, slot)` — removes a placed card from the board, returns it to `chosen`. Only allowed for current day cells, rejects debt/lock cells

## Client
- `sendPayDebt()` / `sendReturnBoardCard()` in lobbyClient.ts
- UI: debt payment section in placement phase (shows debt amount, pay button)
- UI: ↩️ return button on placed cells (hover reveal, stops propagation)
- CSS: styles for all new elements in client.less