### PR TITLE
fix: defer single-player game init until user clicks Play

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -316,19 +316,31 @@ if ("serviceWorker" in navigator) {
 
 // ── Initialise deck ────────────────────────────────────────────────────────────
 
-const fullDeck = createInitialDeck({
-	cards: allCards,
-	fallbackCards: [],
-	handSize: HAND_SIZE,
-});
+// ── Lazy single-player game init ──────────────────────────────────────────
+// DON'T start the game on module load — it runs under dashboard/online too.
+// Defer until user clicks single-player "Chơi".
 
-setDeck(shuffleCards(fullDeck));
-setPlayerHand([]);
-setCurrentDayIndex(0);
+let singlePlayerStarted = false;
 
-// ── Start Day 1 draft ─────────────────────────────────────────────────────────
+function startSinglePlayerGame() {
+	if (singlePlayerStarted) return;
+	singlePlayerStarted = true;
 
-startDailyDraft();
+	const fullDeck = createInitialDeck({
+		cards: allCards,
+		fallbackCards: [],
+		handSize: HAND_SIZE,
+	});
+
+	setDeck(shuffleCards(fullDeck));
+	setPlayerHand([]);
+	setCurrentDayIndex(0);
+
+	startDailyDraft();
+}
+
+// Expose globally so dashboard.ts's gotoMapSelection can call it
+(globalThis as any).startSinglePlayerGame = startSinglePlayerGame;
 
 // ── Global game loop functions ────────────────────────────────────────────
 

--- a/src/screens/dashboard.ts
+++ b/src/screens/dashboard.ts
@@ -603,6 +603,8 @@ export function initDashboardGlobals() {
 	};
 
 	(globalThis as any).gotoMapSelection = () => {
+		// Init single-player state lazily (only when user clicks Play)
+		(globalThis as any).startSinglePlayerGame?.();
 		import("../router.ts").then(({ transitionToScreen }) => {
 			transitionToScreen("game");
 		});


### PR DESCRIPTION
## Bug

The single-player game engine started at module load — before the dashboard, lobby, or online screens rendered. This caused:

1. Draft timers counting down under any screen
2. Game state (phase, hand, pool) initialized even when playing online
3. Potential `autoPickDraftCard()` firing if draft timer expired while user was on dashboard

## Fix

Wrapped deck creation, shuffle, deal, and `startDailyDraft()` into `startSinglePlayerGame()`, called lazily from `gotoMapSelection` (the Play button). A guard flag prevents double-init on re-entry.

## Files
- `src/app.ts` — removed module-level init, added lazy wrapper
- `src/screens/dashboard.ts` — calls `startSinglePlayerGame()` before transition