### PR TITLE
refactor: replace old name TREKPOLOGY with Trekkopoly

### DIFF
--- a/css/client.less
+++ b/css/client.less
@@ -14814,7 +14814,7 @@ body {
   border-color: var(--ink, #4e3325);
 }
 
-/* ── Debt modal (ported from TREKPOLOGY effect-token-modal) ────────────── */
+/* ── Debt modal (ported from Trekkopoly effect-token-modal) ────────────── */
 
 .debt-link {
   display: inline-block;
@@ -14986,7 +14986,7 @@ body {
 }
 
 /* ==============================================
-   TREKPOLOGY — Dashboard Hub
+   Trekkopoly — Dashboard Hub
    ============================================== */
 
 :root {

--- a/css/dashboard.less
+++ b/css/dashboard.less
@@ -1,5 +1,5 @@
 /* ==============================================
-   TREKPOLOGY — Dashboard Hub
+   Trekkopoly — Dashboard Hub
    --map-accent: màu nhấn theo từng map (override khi vào game)
    --hero-bg:    CSS background cho hero khi dùng ảnh tĩnh
    ============================================== */

--- a/css/mapSelection.less
+++ b/css/mapSelection.less
@@ -1,5 +1,5 @@
 /* ==============================================
-   TREKPOLOGY — Map Selection Screen
+   Trekkopoly — Map Selection Screen
    ============================================== */
 
 .map-selection-screen {

--- a/server/auth.test.ts
+++ b/server/auth.test.ts
@@ -134,7 +134,8 @@ Deno.test("registerUser — case insensitive username", async () => {
 	});
 
 	await assertRejects(
-		() => registerUser({ username: user.toUpperCase(), password: "password123" }),
+		() =>
+			registerUser({ username: user.toUpperCase(), password: "password123" }),
 		Error,
 		"đã tồn tại",
 	);

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -1,7 +1,7 @@
 /**
  * auth.ts — User registration, login, and JWT token verification.
  *
- * Ported from TREKPOLOGY/server/auth.ts to Deno's Web Crypto API.
+ * Ported from Trekkopoly/server/auth.ts to Deno's Web Crypto API.
  * Uses PBKDF2 for password hashing and HMAC-SHA256 for token signing.
  * Stores users in server/data/users.json.
  */

--- a/server/game.test.ts
+++ b/server/game.test.ts
@@ -48,13 +48,16 @@ function makeCard(i: number): TravelCard {
 		name: `Test Card ${i}`,
 		city,
 		coordinates: {
-			lat: 10.8 + (i * 0.1),
-			lng: 106.7 + (i * 0.05),
+			lat: 10.8 + i * 0.1,
+			lng: 106.7 + i * 0.05,
 		},
 		vp: (i % 10) + 1,
 		coin: (i % 5) + 1,
 		stamina: (i % 3) + 1,
-		rarity: (i % 3 === 0 ? "rare" : i % 3 === 1 ? "common" : "epic") as "common" | "rare" | "epic",
+		rarity: (i % 3 === 0 ? "rare" : i % 3 === 1 ? "common" : "epic") as
+			| "common"
+			| "rare"
+			| "epic",
 		tag: tags[i % tags.length],
 		tags: [tags[i % tags.length]],
 		image: "",

--- a/server/game.ts
+++ b/server/game.ts
@@ -317,7 +317,12 @@ export function returnBoardCard(
 	// Remove card from board
 	player.board = player.board.map((c, i) =>
 		i === cellIndex
-			? { ...c, card_id: undefined, cardName: undefined, type: "empty" as const }
+			? {
+					...c,
+					card_id: undefined,
+					cardName: undefined,
+					type: "empty" as const,
+				}
 			: c,
 	);
 

--- a/server/player.ts
+++ b/server/player.ts
@@ -293,7 +293,12 @@ export function dispatch(session: PlayerSession, rawMessage: string): void {
 						"returnBoardCard requires day and slot",
 					);
 				}
-				const result = returnBoardCard(session.room!, session.playerId, day, slot);
+				const result = returnBoardCard(
+					session.room!,
+					session.playerId,
+					day,
+					slot,
+				);
 				sendResult(session, id, {
 					ok: true,
 					cardId: result.cardId,

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,7 +1,7 @@
 /**
  * app.ts — Application entry point and game loop.
  *
- * Mirrors the old TREKPOLOGY/src/app.ts game loop (single-player local mode):
+ * Mirrors the old Trekkopoly/src/app.ts game loop (single-player local mode):
  *   draft → placement → endDay → draft (next day) → ... → finished
  *
  * Draft: 7 cards, pick 1 per round × 5 rounds → 5 cards in hand.

--- a/src/arena/extra-panels.ts
+++ b/src/arena/extra-panels.ts
@@ -1,7 +1,7 @@
 /**
  * extra-panels.ts — Score panels, resource orbs, ranking, debt, effect tokens, deck pile.
  *
- * Extracted from TREKPOLOGY/src/app.ts (lines 3346–4109).
+ * Extracted from Trekkopoly/src/app.ts (lines 3346–4109).
  */
 
 /* ── Score Breakdown Panel ──────────────────────────────────────────────── */

--- a/src/arena/render.ts
+++ b/src/arena/render.ts
@@ -1,7 +1,7 @@
 /**
  * arena/render.ts — Board grid, hand strip (fan layout), draft pool, focused card rendering.
  *
- * Rebuilt from TREKPOLOGY/src/app.ts (lines 1798–2190, 4110–4560, 1890–1962)
+ * Rebuilt from Trekkopoly/src/app.ts (lines 1798–2190, 4110–4560, 1890–1962)
  * to match the CSS structure in css/client.less.
  *
  * Key structural differences from the first extraction:
@@ -68,7 +68,7 @@ export const HAND_CITY_MEDIUM = 28;
 export const DAYS = [1, 2, 3, 4, 5];
 export const ROWS = ["Sáng", "Trưa", "Chiều", "Tối", "Khuya"];
 
-// ── Helpers ported from TREKPOLOGY src/data/cardMapper.ts ────────────────────
+// ── Helpers ported from Trekkopoly src/data/cardMapper.ts ────────────────────
 
 function getTextFitClass(
 	text: string,
@@ -875,7 +875,7 @@ function renderSimulationResultPanel(): string {
 	const totalSteps = result.replaySteps.length;
 	const isComplete = getIsReplayComplete();
 
-	// Track offset for horizontal scroll animation (matches old TREKPOLOGY)
+	// Track offset for horizontal scroll animation (matches old Trekkopoly)
 	const TICKET_WIDTH = 366;
 	const FIRST_TICKET_CENTER = 223;
 	const endBoost =

--- a/src/online/socketClient.ts
+++ b/src/online/socketClient.ts
@@ -4,7 +4,7 @@
  * Protocol: JSON-RPC 2.0 over WebSocket.
  * Server: ws://localhost:8080/ws?roomId=X&playerId=Y&name=Z
  *
- * This replaces TREKPOLOGY's Socket.IO client (src/online/socketClient.ts).
+ * This replaces Trekkopoly's Socket.IO client (src/online/socketClient.ts).
  */
 
 import type { RoomSnapshot } from "../shared/types.ts";

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,7 +1,7 @@
 /**
  * router.ts — Screen shell, transitions, and rerender loop.
  *
- * Extracted from TREKPOLOGY/src/app.ts (lines 5362–5703, 5911–6093).
+ * Extracted from Trekkopoly/src/app.ts (lines 5362–5703, 5911–6093).
  */
 
 import type { AppScreen } from "./shared/client-types.ts";
@@ -228,8 +228,8 @@ function reattachCardClickDelegation() {
 	}
 }
 
-// ── Document-level click delegation (capture phase, matches TREKPOLOGY pattern) ──
-// Old TREKPOLOGY used capture:true + [data-draft-card-id] for draft cards.
+// ── Document-level click delegation (capture phase, matches Trekkopoly pattern) ──
+// Old Trekkopoly used capture:true + [data-draft-card-id] for draft cards.
 // This ensures clicks are caught before any inline handler processes them.
 
 document.addEventListener(
@@ -281,7 +281,7 @@ document.addEventListener(
 		}
 	},
 	true,
-); /* capture phase — matches old TREKPOLOGY */
+); /* capture phase — matches old Trekkopoly */
 
 // ── Hover handlers (no rerender — CSS handles visual feedback) ──────────────
 

--- a/src/screens/dashboard.ts
+++ b/src/screens/dashboard.ts
@@ -1,7 +1,7 @@
 /**
  * dashboard.ts — Dashboard hub screen (hero + auth/explore + modals).
  *
- * Ported from TREKPOLOGY/src/ui/dashboard.ts.
+ * Ported from Trekkopoly/src/ui/dashboard.ts.
  * Exports: renderDashboard(), initDashboardHub(), initDashboardGlobals()
  */
 
@@ -387,7 +387,7 @@ export function renderDashboard(isLoading = false) {
           <button class="hub-modal__close" onclick="document.getElementById('modal-about').classList.remove('hub-modal--open')">&times;</button>
           <h2>Về Chúng Tôi</h2>
           <div class="hub-modal__content">
-            <p><strong>TREKPOLOGY</strong> là tựa game thẻ bài chiến lược lấy cảm hứng từ vẻ đẹp văn hoá và thiên nhiên Việt Nam.</p>
+            <p><strong>Trekkopoly</strong> là tựa game thẻ bài chiến lược lấy cảm hứng từ vẻ đẹp văn hoá và thiên nhiên Việt Nam.</p>
             <p>Chúng tôi tin rằng du lịch không chỉ là di chuyển — mà là khám phá, học hỏi và kết nối. Mỗi thẻ bài là một câu chuyện thật từ đất nước Việt Nam.</p>
             <h3>🔮 Sắp ra mắt</h3>
             <p>Đà Lạt • Hội An • Hạ Long • Hà Nội</p>
@@ -398,7 +398,7 @@ export function renderDashboard(isLoading = false) {
 
       <!-- Topbar -->
       <header class="hub-topbar">
-        <div class="hub-topbar__logo">TREKPOLOGY</div>
+        <div class="hub-topbar__logo">Trekkopoly</div>
         <nav class="hub-topbar__nav">
           <button onclick="document.getElementById('modal-rules').classList.add('hub-modal--open')">Hướng Dẫn Chơi</button>
           <button onclick="document.getElementById('modal-about').classList.add('hub-modal--open')">Về Chúng Tôi</button>

--- a/src/screens/lobby.ts
+++ b/src/screens/lobby.ts
@@ -1,7 +1,7 @@
 /**
  * lobby.ts — Create/join room forms and lobby screen rendering.
  *
- * Ported from TREKPOLOGY (commit b2a4891) — deleted in 9e78dd8
+ * Ported from Trekkopoly (commit b2a4891) — deleted in 9e78dd8
  * as "never imported". Now wires into router.ts via app.ts globals.
  *
  * CSS classes match existing styles in css/client.less.
@@ -29,7 +29,7 @@ export function renderOnlineEntryScreen(
     <main class="online-entry-screen">
       <section class="online-entry-card">
         <div class="online-entry-card__brand">
-          <span>TREKPOLOGY</span>
+          <span>Trekkopoly</span>
           <h1>Online Room</h1>
           <p>Tạo phòng, mời bạn bè bằng mã phòng, rồi bắt đầu khi mọi người sẵn sàng.</p>
           <p class="online-entry-card__welcome">

--- a/src/screens/onlineGame.ts
+++ b/src/screens/onlineGame.ts
@@ -260,14 +260,18 @@ function renderOnlinePlacement(
           </button>
         </div>
 
-        ${myPlayer.resources.debtToken > 0 ? `
+        ${
+					myPlayer.resources.debtToken > 0
+						? `
         <div class="placement__debt-pay">
           <span class="debt-label">💳 Nợ: <strong>${myPlayer.resources.debtToken} xu</strong></span>
           <button class="online-debt-btn" data-online-pay-debt="all">
             💰 Trả nợ (${Math.min(myPlayer.resources.xu, myPlayer.resources.debtToken)} xu)
           </button>
         </div>
-        ` : ""}
+        `
+						: ""
+				}
 
         <div class="online-draft__opponents">
           ${opponentInfo || ""}

--- a/src/shared/card-mapper.ts
+++ b/src/shared/card-mapper.ts
@@ -3,7 +3,7 @@
  * Centralizes all GameCardData → TravelCard UI field transformations
  * (short names, labels, bonus text, rarity) so every module shares one source.
  *
- * Ported from TREKPOLOGY/src/data/cardMapper.ts.
+ * Ported from Trekkopoly/src/data/cardMapper.ts.
  */
 
 // ── Main tag detection ─────────────────────────────────────────────────────

--- a/src/shared/data/cards.saigon.action.ts
+++ b/src/shared/data/cards.saigon.action.ts
@@ -2,7 +2,7 @@ import type { TravelCard } from '../types.ts';
 
 /**
  * Phase 1 Saigon action cards (20 cards)
- * Converted from TREKPOLOGY/src/data/cards.phase1.ts
+ * Converted from Trekkopoly/src/data/cards.phase1.ts
  */
 export const saigonActionCards: TravelCard[] = [
   {

--- a/src/shared/data/cards.saigon.culture.ts
+++ b/src/shared/data/cards.saigon.culture.ts
@@ -2,7 +2,7 @@ import type { TravelCard } from '../types.ts';
 
 /**
  * Phase 1 Saigon culture cards (35 cards)
- * Converted from TREKPOLOGY/src/data/cards.phase1.ts
+ * Converted from Trekkopoly/src/data/cards.phase1.ts
  */
 export const saigonCultureCards: TravelCard[] = [
   {

--- a/src/shared/data/cards.saigon.food.ts
+++ b/src/shared/data/cards.saigon.food.ts
@@ -2,7 +2,7 @@ import type { TravelCard } from '../types.ts';
 
 /**
  * Phase 1 Saigon food cards (30 cards)
- * Source: TREKPOLOGY/src/data/cards.phase1.ts
+ * Source: Trekkopoly/src/data/cards.phase1.ts
  * Image files: public/assets/images/cards/saigon/food/sg_food_NNN.jpg
  *
  * Only 6 card images exist (sg_food_001-006.jpg). Cards beyond 006

--- a/src/shared/data/cards.saigon.utility.ts
+++ b/src/shared/data/cards.saigon.utility.ts
@@ -2,7 +2,7 @@ import type { TravelCard } from '../types.ts';
 
 /**
  * Phase 1 Saigon utility cards (15 cards)
- * Converted from TREKPOLOGY/src/data/cards.phase1.ts
+ * Converted from Trekkopoly/src/data/cards.phase1.ts
  */
 export const saigonUtilityCards: TravelCard[] = [
   {

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,7 +1,7 @@
 /**
  * state.ts — Mutable game state for the client.
  *
- * Extracted from TREKPOLOGY/src/app.ts (lines 996–1092).
+ * Extracted from Trekkopoly/src/app.ts (lines 996–1092).
  * All state lives here as module-level `let` bindings with exported getters.
  */
 


### PR DESCRIPTION
Replaces all occurrences of the old project name `TREKPOLOGY` with `Trekkopoly` across the active codebase.

**User-facing:**
- Dashboard: `<strong>TREKPOLOGY</strong>` → `Trekkopoly` (description)
- Dashboard: `<div>hub-topbar__logo>TREKPOLOGY</div>` → `Trekkopoly`
- Lobby: `<span>TREKPOLOGY</span>` → `Trekkopoly`

**Developer:**
- 22 source files updated (comments, docstrings, CSS headers)
- Build artifacts regenerated from LESS sources
- Does NOT touch the old `TREKPOLOGY/` reference directory