### PR TITLE
Fix playtest bugs: modals blocking nav, disconnect detection

### DIFF
--- a/src/online/lobbyClient.ts
+++ b/src/online/lobbyClient.ts
@@ -102,12 +102,20 @@ export function initLobbyGlobals() {
 // ── Navigation ─────────────────────────────────────────────────────────────
 
 function gotoOnlineLobby() {
+	// Close any open dashboard modals before leaving
+	document.querySelectorAll(".hub-modal--open").forEach((m) =>
+		m.classList.remove("hub-modal--open"),
+	);
 	import("../router.ts").then(({ transitionToScreen }) => {
 		transitionToScreen("lobby");
 	});
 }
 
 function gotoDashboard() {
+	// Close any open modals before leaving
+	document.querySelectorAll(".hub-modal--open").forEach((m) =>
+		m.classList.remove("hub-modal--open"),
+	);
 	disconnectFromRoom();
 	currentRoomId = null;
 	currentPlayerId = null;
@@ -376,10 +384,10 @@ function handleDisconnect() {
 	currentPlayerName = null;
 	currentLobbySnapshot = null;
 
-	// If on lobby screen, re-render to show entry
+	// If on lobby screen (entry or room), re-render to show entry
 	if (
-		window.location.pathname.includes("lobby") ||
-		document.querySelector(".online-lobby-screen")
+		document.querySelector(".online-lobby-screen") ||
+		document.querySelector(".online-entry-screen")
 	) {
 		gotoOnlineLobby();
 	}


### PR DESCRIPTION
## What

Three playtest findings addressed:

1. **WebSocket blocked on Deno Deploy** (CRITICAL — already deployed in previous commit)
2. **ServiceWorker hangs POST/WebSocket** (CRITICAL — already deployed in previous commit)
3. **Modal interference with lobby navigation** (fixed here)
   - `gotoOnlineLobby()` now closes open dashboard modals before transitioning
   - `gotoDashboard()` also closes modals before leaving
   - `handleDisconnect()` now checks for `.online-entry-screen` in addition to `.online-lobby-screen`

## Testing limitation

`agent-browser`'s Chromium blocks ALL WebSocket connections (even `wss://echo.websocket.org`). Server-side multiplayer verified end-to-end via Deno WebSocket client (room creation, 2-player connect, ready, game start, draft phase all work).

## Verification

- [x] Server tests: 35/35 pass