### PR TITLE
Feat/auth-attached player identity for WebSocket sessions

### DIFF
--- a/server/player.ts
+++ b/server/player.ts
@@ -69,19 +69,28 @@ const RPC_ERRORS = {
 
 // ─── Player session ───────────────────────────────────────────────────────────
 
+export interface AuthUser {
+	id: string;
+	username: string;
+	displayName: string;
+}
+
 export interface PlayerSession {
 	playerId: string;
 	name: string;
 	socket: WebSocket;
 	room: Room | null;
+	/** The authenticated user linked to this session, if any. */
+	user: AuthUser | null;
 }
 
 export function createPlayerSession(
 	playerId: string,
 	name: string,
 	socket: WebSocket,
+	user: AuthUser | null = null,
 ): PlayerSession {
-	return { playerId, name, socket, room: null };
+	return { playerId, name, socket, room: null, user };
 }
 
 // ─── Send helpers ─────────────────────────────────────────────────────────────

--- a/server/server.ts
+++ b/server/server.ts
@@ -121,11 +121,28 @@ async function handleCreateRoom(req: Request): Promise<Response> {
 
 // ─── WebSocket handler ────────────────────────────────────────────────────────
 
-function handleWebSocket(req: Request): Response {
+async function handleWebSocket(req: Request): Promise<Response> {
 	const url = new URL(req.url);
 	const roomId = url.searchParams.get("roomId");
 	const playerId = url.searchParams.get("playerId") ?? crypto.randomUUID();
-	const name = url.searchParams.get("name") ?? `Player-${playerId.slice(0, 4)}`;
+	let name = url.searchParams.get("name") ?? `Player-${playerId.slice(0, 4)}`;
+	const token = url.searchParams.get("token") ?? null;
+
+	// Validate auth token if provided — use authenticated user's display name
+	let authUser: import("./player.ts").AuthUser | null = null;
+	if (token) {
+		const validated = await verifyAuthToken(token).catch(() => null);
+		if (validated) {
+			authUser = validated;
+			// Prefer the authenticated user's display name over the query param
+			name = authUser.displayName;
+		} else {
+			// Token is invalid — still allow connection but without auth
+			console.warn(
+				`[ws] Invalid token provided for player ${playerId} in room ${roomId}`,
+			);
+		}
+	}
 
 	if (!roomId) {
 		return errorResponse(400, "Missing roomId query parameter");
@@ -149,7 +166,7 @@ function handleWebSocket(req: Request): Response {
 		return errorResponse(400, `WebSocket upgrade failed: ${msg}`);
 	}
 
-	const session = createPlayerSession(playerId, name, socket);
+	const session = createPlayerSession(playerId, name, socket, authUser);
 	session.room = room;
 	sessions.set(playerId, session);
 
@@ -281,7 +298,7 @@ async function router(req: Request): Promise<Response> {
 		// Deno.upgradeWebSocket() handles the upgrade internally regardless;
 		// if the request is not a valid upgrade it throws, which we catch below.
 		if (pathname === "/ws" && method === "GET") {
-			return handleWebSocket(req);
+			return await handleWebSocket(req);
 		}
 
 		return addCors(errorResponse(404, `Not found: ${method} ${pathname}`));

--- a/src/app.ts
+++ b/src/app.ts
@@ -79,7 +79,7 @@ import {
 	getOpponentPlayerIds,
 	addDiscardedResourceBonus,
 } from "./state.ts";
-import { isConnected } from "./online/socketClient.ts";
+import { isConnected, loadAuthSession } from "./online/socketClient.ts";
 import "./online/lobbyClient.ts"; // Side-effect: binds lobby globals
 import type { PlayerId } from "./shared/client-types.ts";
 import type { TravelCard } from "./shared/types.ts";
@@ -1385,6 +1385,10 @@ import {
 };
 
 // ── Start the app — render dashboard ───────────────────────────────────────
+
+// Load saved auth session (JWT + user info) from localStorage so the
+// dashboard and lobby can show the logged-in user's name.
+loadAuthSession();
 
 transitionToScreen("dashboard");
 

--- a/src/online/lobbyClient.ts
+++ b/src/online/lobbyClient.ts
@@ -14,6 +14,7 @@ import {
 	disconnectFromRoom,
 	setOnRoomSnapshot,
 	setOnDisconnect,
+	getAuthDisplayName,
 } from "./socketClient.ts";
 import type { RoomSnapshot, TravelCard } from "../shared/types.ts";
 import { getCardsByPhasePool } from "../shared/data/cards.all.ts";
@@ -132,7 +133,9 @@ async function createRoomFromLobby() {
 	const nameInput = document.getElementById(
 		"lobby-create-name",
 	) as HTMLInputElement | null;
-	const playerName = nameInput?.value?.trim() || "Player";
+	// Use logged-in display name if available (overrides input)
+	const displayName = getAuthDisplayName();
+	const playerName = (displayName ?? nameInput?.value?.trim()) || "Player";
 
 	try {
 		// Register callbacks BEFORE connecting so initial snapshot isn't lost
@@ -174,7 +177,8 @@ async function joinRoomFromLobby() {
 	const codeInput = document.getElementById(
 		"lobby-room-code",
 	) as HTMLInputElement | null;
-	const playerName = nameInput?.value?.trim() || "Player";
+	const displayName = getAuthDisplayName();
+	const playerName = (displayName ?? nameInput?.value?.trim()) || "Player";
 	const roomId = codeInput?.value?.trim().toUpperCase();
 
 	if (!roomId) {

--- a/src/online/socketClient.ts
+++ b/src/online/socketClient.ts
@@ -31,7 +31,7 @@ let wsBaseUrl = isProduction
 	? "wss://trekkopoly.compthink-2026.deno.net"
 	: "ws://localhost:8080";
 
-// ── Public API ──────────────────────────────────────────────────────────────
+// ── Auth state ────────────────────────────────────────────────────────────
 
 export type AuthUser = {
 	id: string;
@@ -39,15 +39,81 @@ export type AuthUser = {
 	displayName: string;
 };
 
-export type AuthClientState = {
+export interface AuthClientState {
 	isReady: boolean;
 	user: AuthUser | null;
-};
+	token: string | null;
+}
 
 export const authClientState: AuthClientState = {
 	isReady: false,
 	user: null,
+	token: null,
 };
+
+const AUTH_TOKEN_KEY = "trekkopoly_auth_token";
+const AUTH_USER_KEY = "trekkopoly_auth_user";
+
+/** Load saved auth session from localStorage (called once at startup). */
+export function loadAuthSession(): void {
+	try {
+		const token = localStorage.getItem(AUTH_TOKEN_KEY);
+		const userRaw = localStorage.getItem(AUTH_USER_KEY);
+		if (token && userRaw) {
+			authClientState.token = token;
+			authClientState.user = JSON.parse(userRaw) as AuthUser;
+			authClientState.isReady = true;
+		}
+	} catch {
+		// Corrupted storage — ignore
+	}
+}
+
+/** Save auth token + user to state and localStorage. */
+export function saveAuthSession(token: string, user: AuthUser): void {
+	authClientState.token = token;
+	authClientState.user = user;
+	authClientState.isReady = true;
+	try {
+		localStorage.setItem(AUTH_TOKEN_KEY, token);
+		localStorage.setItem(AUTH_USER_KEY, JSON.stringify(user));
+	} catch {
+		// Storage full or unavailable
+	}
+}
+
+/** Clear auth session from state and localStorage. */
+export function clearAuthSession(): void {
+	authClientState.token = null;
+	authClientState.user = null;
+	authClientState.isReady = false;
+	try {
+		localStorage.removeItem(AUTH_TOKEN_KEY);
+		localStorage.removeItem(AUTH_USER_KEY);
+	} catch {
+		// ignore
+	}
+}
+
+/** Get the auth token for WebSocket connections. */
+export function getAuthToken(): string | null {
+	return authClientState.token;
+}
+
+/**
+ * Get the display name of the logged-in user, or null if not logged in.
+ */
+export function getAuthDisplayName(): string | null {
+	return authClientState.user?.displayName ?? null;
+}
+
+/**
+ * Get the saved auth token or null if no active session.
+ * Kept for backward compatibility — prefer getAuthToken().
+ */
+export function getToken(): string | null {
+	return authClientState.token;
+}
 
 export function configureServerUrls(httpUrl: string, wsUrl: string) {
 	serverBaseUrl = httpUrl;
@@ -73,6 +139,8 @@ export function isConnected(): boolean {
 /**
  * Connect to a game room via WebSocket.
  * Automatically sends joinRoom after the connection opens.
+ * If the user is logged in, the auth token is passed as a query param
+ * so the server can link the WebSocket session to the authenticated user.
  */
 export function connectToRoom(
 	roomId: string,
@@ -85,7 +153,12 @@ export function connectToRoom(
 			socket = null;
 		}
 
-		const url = `${wsBaseUrl}/ws?roomId=${encodeURIComponent(roomId)}&playerId=${encodeURIComponent(playerId)}&name=${encodeURIComponent(name)}`;
+		// Append auth token if logged in
+		const token = getAuthToken();
+		let url = `${wsBaseUrl}/ws?roomId=${encodeURIComponent(roomId)}&playerId=${encodeURIComponent(playerId)}&name=${encodeURIComponent(name)}`;
+		if (token) {
+			url += `&token=${encodeURIComponent(token)}`;
+		}
 		socket = new WebSocket(url);
 
 		socket.onopen = () => {

--- a/src/router.ts
+++ b/src/router.ts
@@ -19,6 +19,7 @@ import {
 	getCurrentRoomId,
 	getCurrentGameSnapshot,
 } from "./online/lobbyClient.ts";
+import { getAuthDisplayName } from "./online/socketClient.ts";
 import {
 	getSuppressNextClick,
 	setSuppressNextClick,
@@ -70,7 +71,7 @@ export function renderGameShell(): string {
 		case "lobby": {
 			const snapshot = getCurrentLobbySnapshot();
 			const savedSession = getSavedSession();
-			const displayName = getCurrentPlayerName() || "Nhà Lữ Hành";
+			const displayName = getCurrentPlayerName() || getAuthDisplayName() || "Nhà Lữ Hành";
 
 			if (snapshot && snapshot.phase === "lobby") {
 				return renderOnlineLobbyRoomScreen(

--- a/src/screens/dashboard.ts
+++ b/src/screens/dashboard.ts
@@ -5,7 +5,7 @@
  * Exports: renderDashboard(), initDashboardHub(), initDashboardGlobals()
  */
 
-import { authClientState } from "../online/socketClient.ts";
+import { authClientState, saveAuthSession, clearAuthSession } from "../online/socketClient.ts";
 
 export const HERO_VIDEO_SRC = "assets/videos/chuyencanh.mp4";
 
@@ -485,7 +485,7 @@ async function handleLoginSubmit(event: SubmitEvent) {
 		}
 		statusEl.textContent = "Đăng nhập thành công!";
 		statusEl.className = "hub-auth__status hub-auth__status--success";
-		authClientState.user = data.user ?? data;
+		saveAuthSession(data.token, data.user ?? data);
 		// Refresh the dashboard to show explore panel
 		const { rerenderGameShell } = await import("../router.ts");
 		rerenderGameShell();
@@ -546,7 +546,7 @@ async function handleRegisterSubmit(event: SubmitEvent) {
 		}
 		statusEl.textContent = "Tạo tài khoản thành công! Đang đăng nhập...";
 		statusEl.className = "hub-auth__status hub-auth__status--success";
-		authClientState.user = data.user ?? data;
+		saveAuthSession(data.token, data.user ?? data);
 		const { rerenderGameShell } = await import("../router.ts");
 		rerenderGameShell();
 		initDashboardHubWithCleanup();
@@ -582,7 +582,7 @@ export function initDashboardGlobals() {
 	};
 
 	(globalThis as any).logoutFromAuthScreen = () => {
-		authClientState.user = null;
+		clearAuthSession();
 		import("../router.ts").then(({ rerenderGameShell }) => {
 			rerenderGameShell();
 			initDashboardHubWithCleanup();


### PR DESCRIPTION
## Summary

Link authenticated user identities to WebSocket game sessions. When a user logs in via the dashboard auth forms, their JWT token and display name are now passed through to the game server, which validates and attaches the identity.

## Changes

### Server
- **`PlayerSession`** gains optional `user: AuthUser | null` field containing `{id, username, displayName}`
- **`createPlayerSession()`** accepts optional `user` parameter
- **`handleWebSocket()`** reads `?token=` query param, validates via `verifyAuthToken()`, overrides name with auth user's display name
- Invalid token: logs a warning but still allows anonymous connection (graceful degradation)

### Client
- **`AuthClientState`** extended with `token: string | null` field
- **`saveAuthSession()`** / **`loadAuthSession()`** / **`clearAuthSession()`** — persist JWT + user info to localStorage, auto-load at app startup
- **`connectToRoom()`** appends `&token=JWT` query param when logged in
- **`createRoomFromLobby()` / `joinRoomFromLobby()`** — use authenticated display name (overrides input field)
- **`handleLoginSubmit` / `handleRegisterSubmit` / `logoutFromAuthScreen`** — use `saveAuthSession()` / `clearAuthSession()`
- **Lobby entry screen** falls back to `getAuthDisplayName()` if no active session

## How to Test

1. Log in via dashboard auth form → auth token saved to localStorage
2. Navigate to online lobby → name pre-filled with display name
3. Create/join room → WebSocket URL includes `?token=JWT`
4. Server validates and links session to authenticated user

## Testing
- All 35 server tests pass
- LSP diagnostics clean on all 7 modified files

Closes #44 (playtest findings — auth identity)