### PR TITLE
bump: 0.17.0 → 0.18.0

### DIFF
--- a/src/version.ts
+++ b/src/version.ts
@@ -4,6 +4,6 @@
  * BUILD_TIME is replaced at build time by the bundler (rollup).
  */
 
-export const VERSION = "0.17.0";
+export const VERSION = "0.18.0";
 export const BUILD_TIME = "__BUILD_TIME_PLACEHOLDER__";
 export const APP_NAME = "Trekkopoly";


### PR DESCRIPTION
Version bump for auth-attached player identity.