### PR TITLE
Feat/unified Room+bot game engine for singleplayer

### DIFF
--- a/server/bot.ts
+++ b/server/bot.ts
@@ -1,0 +1,243 @@
+/**
+ * bot.ts — Auto-play logic for bot players in the server Room FSM.
+ *
+ * Provides bot player creation and turn-scheduling so that rooms with
+ * bot players (e.g. single-player mode with 3 bots + 1 human) advance
+ * through all game phases without requiring a human to play every seat.
+ *
+ * Usage:
+ *   import { createBotPlayer, scheduleBotTurns } from "./bot.ts";
+ *
+ *   // Add bots to room
+ *   for (let i = 0; i < numBots; i++) {
+ *     const bot = createBotPlayer(i, "bot-");
+ *     addPlayer(room, bot.playerId, bot.name);
+ *   }
+ *
+ *   // After startGame, schedule bots to auto-play
+ *   scheduleBotTurns(room, 500);
+ */
+
+import { draftCard, placeCard, confirmDay, type Room } from "./game.ts";
+import type {
+	PlayerState,
+	GridPosition,
+	TimeSlot,
+} from "../src/shared/types.ts";
+import { STARTING_RESOURCES } from "../src/shared/rules.ts";
+import { createBoardCells } from "../src/shared/board.ts";
+
+// ─── Bot name pool ───────────────────────────────────────────────────────────
+
+const BOT_NAMES = [
+	"Bot Alpha",
+	"Bot Beta",
+	"Bot Gamma",
+	"Bot Delta",
+	"Bot Epsilon",
+	"Bot Zeta",
+	"Bot Eta",
+	"Bot Theta",
+	"Bot Iota",
+	"Bot Kappa",
+];
+
+// ─── Player factory ──────────────────────────────────────────────────────────
+
+/**
+ * Create a bot PlayerState with a generated name and default resources.
+ * The playerId is constructed as `${prefix}${index}` (e.g. "bot-0", "bot-1").
+ */
+export function createBotPlayer(
+	index: number,
+	playerIdPrefix = "bot-",
+): PlayerState {
+	const name = BOT_NAMES[index % BOT_NAMES.length];
+	return {
+		playerId: `${playerIdPrefix}${index}`,
+		name,
+		board: createBoardCells(),
+		hand: [],
+		chosen: [],
+		storage: [],
+		resources: { ...STARTING_RESOURCES },
+		ready: false,
+	};
+}
+
+// ─── Bot turn execution ─────────────────────────────────────────────────────
+
+/**
+ * Execute one bot turn based on the current room phase.
+ *
+ * - draft: pick the first card in the bot's hand with "store" mode.
+ *   If hand is empty, the bot has nothing to do this round.
+ *
+ * - placement: iterate through the bot's chosen cards and place each into
+ *   the first available (non-occupied, non-locked, non-skipped) cell on the
+ *   current day. When all chosen cards are placed (or none remain), confirm
+ *   the day.
+ *
+ * - All other phases: no action needed (scoring/finished are server-driven).
+ *
+ * Returns true if the bot performed an action, false if idle.
+ */
+export function runBotTurn(room: Room, playerId: string): boolean {
+	if (room.phase === "draft") {
+		return autoDraft(room, playerId);
+	}
+	if (room.phase === "placement") {
+		return autoPlace(room, playerId);
+	}
+	return false;
+}
+
+/**
+ * Schedule all non-ready bot players in the room to execute their turns
+ * after `delayMs` milliseconds. Bots that are already ready are skipped.
+ *
+ * Returns an array of setTimeout IDs so the caller can cancel if needed.
+ */
+export function scheduleBotTurns(room: Room, delayMs = 500): number[] {
+	const timers: number[] = [];
+
+	for (const player of room.players) {
+		// Skip non-bots (bots have "Bot " prefix in name)
+		if (!isBotPlayer(player)) continue;
+		// Skip bots that already have their turn ready
+		if (player.ready) continue;
+
+		// Skip bots with empty hand in draft (nothing to do)
+		if (room.phase === "draft" && player.hand.length === 0) continue;
+
+		const id = setTimeout(() => {
+			try {
+				runBotTurn(room, player.playerId);
+			} catch (err: unknown) {
+				const message = err instanceof Error ? err.message : String(err);
+				console.warn(`[bot] ${player.name} turn failed: ${message}`);
+			}
+		}, delayMs) as unknown as number;
+
+		timers.push(id);
+	}
+
+	return timers;
+}
+
+// ─── Draft auto-play ─────────────────────────────────────────────────────────
+
+/**
+ * Auto-draft: pick the first card in the bot's hand with "store" mode.
+ * The bot always stores — it never discards for rest resources.
+ */
+function autoDraft(room: Room, playerId: string): boolean {
+	if (room.phase !== "draft") return false;
+
+	const player = getPlayerOrNull(room, playerId);
+	if (!player || player.hand.length === 0) return false;
+
+	const cardId = player.hand[0];
+	try {
+		draftCard(room, playerId, cardId, "store");
+		return true;
+	} catch {
+		// If the first card fails (e.g. cost issue), try the rest
+		for (const cId of player.hand.slice(1)) {
+			try {
+				draftCard(room, playerId, cId, "store");
+				return true;
+			} catch {
+				// Try next card
+			}
+		}
+		return false;
+	}
+}
+
+// ─── Placement auto-play ─────────────────────────────────────────────────────
+
+/**
+ * Auto-place: place the bot's chosen cards sequentially into available cells
+ * on the current day. Slots are filled from early_morning → night.
+ * When all chosen are placed (or none left), confirm the day.
+ */
+function autoPlace(room: Room, playerId: string): boolean {
+	if (room.phase !== "placement") return false;
+
+	const player = getPlayerOrNull(room, playerId);
+	if (!player) return false;
+
+	// If nothing to place, confirm and return
+	if (player.chosen.length === 0) {
+		try {
+			confirmDay(room, playerId);
+			return true;
+		} catch {
+			return false;
+		}
+	}
+
+	// Find available (empty, unlocked, unskipped) cells on current day
+	const availableCells = player.board.filter(
+		(cell) =>
+			cell.day === room.day && !cell.card_id && !cell.locked && !cell.skipped,
+	);
+
+	if (availableCells.length === 0) {
+		// No space — discard remaining chosen by confirming
+		try {
+			confirmDay(room, playerId);
+			return true;
+		} catch {
+			return false;
+		}
+	}
+
+	// Place as many cards as we have space for, in order
+	const cardsToPlace = player.chosen.slice(0, availableCells.length);
+	let placed = 0;
+
+	for (let i = 0; i < cardsToPlace.length; i++) {
+		const cardId = cardsToPlace[i];
+		const cell = availableCells[i];
+
+		try {
+			const position: GridPosition = {
+				day: room.day,
+				slot: cell.slot as TimeSlot,
+			};
+			placeCard(room, playerId, cardId, position);
+			placed++;
+		} catch {
+			// If one card fails to place, skip it and try the next
+			continue;
+		}
+	}
+
+	// If we placed everything (or nothing to place), confirm day
+	if (placed === 0 || player.chosen.length === 0) {
+		try {
+			confirmDay(room, playerId);
+			return true;
+		} catch {
+			return false;
+		}
+	}
+
+	return placed > 0;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function getPlayerOrNull(room: Room, playerId: string): PlayerState | null {
+	return room.players.find((p) => p.playerId === playerId) ?? null;
+}
+
+/**
+ * Check if a player is a bot by name prefix.
+ * Bot names always start with "Bot ".
+ */
+export function isBotPlayer(player: PlayerState): boolean {
+	return player.name.startsWith("Bot ");
+}

--- a/src/app.ts
+++ b/src/app.ts
@@ -83,8 +83,8 @@ import { isConnected, loadAuthSession } from "./online/socketClient.ts";
 import "./online/lobbyClient.ts"; // Side-effect: binds lobby globals
 import type { PlayerId } from "./shared/client-types.ts";
 import type { TravelCard } from "./shared/types.ts";
-import { createInitialDeck, shuffleCards } from "./shared/deck.ts";
-import { allCards } from "./shared/data/cards.all.ts";
+import { shuffleCards } from "./shared/deck.ts";
+import { startBotGame } from "./online/spAdapter.ts";
 import {
 	HAND_SIZE,
 	STARTING_COIN,
@@ -326,17 +326,8 @@ function startSinglePlayerGame() {
 	if (singlePlayerStarted) return;
 	singlePlayerStarted = true;
 
-	const fullDeck = createInitialDeck({
-		cards: allCards,
-		fallbackCards: [],
-		handSize: HAND_SIZE,
-	});
-
-	setDeck(shuffleCards(fullDeck));
-	setPlayerHand([]);
-	setCurrentDayIndex(0);
-
-	startDailyDraft();
+	// Use the unified Room+bot game engine instead of the old app.ts loop
+	startBotGame("p1", "Nhà Lữ Hành", 3);
 }
 
 // Expose globally so dashboard.ts's gotoMapSelection can call it

--- a/src/online/localRoom.ts
+++ b/src/online/localRoom.ts
@@ -1,0 +1,247 @@
+/**
+ * localRoom.ts — Local game room for single-player mode.
+ *
+ * Creates a server Room with N bots (default 3) + 1 human player.
+ * Runs the game FSM entirely in-process (no HTTP/WebSocket).
+ * Broadcasts snapshots → snapshotAdapter → local state → render.
+ *
+ * BotManager auto-plays all bot turns. Human player actions
+ * call game.ts functions directly (same as server RPCs).
+ *
+ * Usage (in app.ts or dashboard.ts):
+ *   import { initLocalGame } from "./online/localRoom.ts";
+ *   initLocalGame(humanPlayerId, numBots, cards);
+ */
+
+import {
+	createRoom,
+	addPlayer,
+	startGame,
+	toggleReady,
+	draftCard,
+	placeCard,
+	confirmDay,
+	exportSnapshot,
+	type Room,
+} from "../../server/game.ts";
+import {
+	createBotPlayer,
+	scheduleBotTurns,
+} from "../../server/bot.ts";
+import type { TravelCard, TimeSlot } from "../shared/types.ts";
+import { applySnapshotToState } from "./snapshotAdapter.ts";
+import { rerenderGameShell } from "../router.ts";
+import { playGameSound } from "../audio/gameAudio.ts";
+import {
+	setIsInitialDealInProgress,
+} from "../state.ts";
+import { getCardsByPhasePool } from "../shared/data/cards.all.ts";
+
+// ─── State ──────────────────────────────────────────────────────────────────
+
+let localRoom: Room | null = null;
+let localPlayerId: string | null = null;
+let localCards: TravelCard[] = [];
+let botTimerIds: number[] = [];
+
+// ─── Public API ─────────────────────────────────────────────────────────────
+
+/**
+ * Initialize a local game room with bots.
+ * Call this when the user clicks "BẮT ĐẦU HÀNH TRÌNH".
+ *
+ * @param playerId - The human player's ID (e.g. "p1")
+ * @param playerName - The human player's display name
+ * @param numBots - Number of bot opponents (default 3)
+ * @param cards - Card catalogue (default: Saigon cards)
+ */
+export function initLocalGame(
+	playerId = "p1",
+	playerName = "Nhà Lữ Hành",
+	numBots = 3,
+	cards?: TravelCard[],
+): void {
+	// Clean up any previous local game
+	cleanupLocalGame();
+
+	const deck = cards ?? getCardsByPhasePool("SAIGON");
+	localCards = deck;
+	localPlayerId = playerId;
+
+	// Create room with players + bots
+	const room = createRoom("LOCAL", deck, handleLocalBroadcast, 1 + numBots);
+	localRoom = room;
+
+	// Add human player first (host/slot 0)
+	addPlayer(room, playerId, playerName);
+
+	// Add bot players
+	for (let i = 0; i < numBots; i++) {
+		const bot = createBotPlayer(i, "bot-");
+		// Add directly to room (bypasses WebSocket)
+		try {
+			addPlayer(room, bot.playerId, bot.name);
+		} catch {
+			// Room might be full — skip
+			break;
+		}
+	}
+
+	// Auto-toggle ready for all players (including human for now)
+	// In the future, the UI will show a ready button
+	for (const p of room.players) {
+		try {
+			toggleReady(room, p.playerId);
+		} catch {
+			// Already ready or other issue
+		}
+	}
+
+	// Start the game
+	try {
+		startGame(room, playerId);
+	} catch (err: unknown) {
+		const msg = err instanceof Error ? err.message : String(err);
+		console.error("[localRoom] Failed to start game:", msg);
+	}
+
+	// Initial render
+	applySnapshotAndRender();
+
+	// Schedule bot turns
+	scheduleBots();
+}
+
+/**
+ * Clean up any running local game.
+ */
+export function cleanupLocalGame(): void {
+	// Clear bot timers
+	for (const id of botTimerIds) {
+		clearTimeout(id);
+	}
+	botTimerIds = [];
+	localRoom = null;
+	localPlayerId = null;
+}
+
+/**
+ * Get the current local room (for direct game function calls).
+ */
+export function getLocalRoom(): Room | null {
+	return localRoom;
+}
+
+/**
+ * Get the local player's ID.
+ */
+export function getLocalPlayerId(): string | null {
+	return localPlayerId;
+}
+
+/**
+ * Handle a human player's action by calling the appropriate game function.
+ * These mirror the RPC calls the WebSocket client would make.
+ */
+
+export function localDraftCard(cardId: string, mode: "store" | "rest"): void {
+	if (!localRoom || !localPlayerId) return;
+	try {
+		draftCard(localRoom, localPlayerId, cardId, mode);
+		applySnapshotAndRender();
+		scheduleBots();
+	} catch (err: unknown) {
+		const msg = err instanceof Error ? err.message : String(err);
+		console.warn("[localRoom] draftCard failed:", msg);
+	}
+}
+
+export function localPlaceCard(cardId: string, day: number, slot: TimeSlot): void {
+	if (!localRoom || !localPlayerId) return;
+	try {
+		placeCard(localRoom, localPlayerId, cardId, { day, slot });
+		applySnapshotAndRender();
+		scheduleBots();
+	} catch (err: unknown) {
+		const msg = err instanceof Error ? err.message : String(err);
+		console.warn("[localRoom] placeCard failed:", msg);
+	}
+}
+
+export function localConfirmDay(): void {
+	if (!localRoom || !localPlayerId) return;
+	try {
+		confirmDay(localRoom, localPlayerId);
+		applySnapshotAndRender();
+		scheduleBots();
+	} catch (err: unknown) {
+		const msg = err instanceof Error ? err.message : String(err);
+		console.warn("[localRoom] confirmDay failed:", msg);
+	}
+}
+
+// ─── Internal ───────────────────────────────────────────────────────────────
+
+/**
+ * The broadcast callback for the local Room.
+ * Called by game.ts whenever room state changes.
+ * We apply the snapshot to local state and re-render.
+ */
+function handleLocalBroadcast(_room: Room): void {
+	if (!localPlayerId) return;
+	applySnapshotAndRender();
+}
+
+/**
+ * Take the current Room snapshot and apply it to local state,
+ * then trigger a re-render.
+ */
+function applySnapshotAndRender(): void {
+	if (!localRoom || !localPlayerId) return;
+
+	const snapshot = exportSnapshot(localRoom, localPlayerId);
+	applySnapshotToState(snapshot, localCards, localPlayerId);
+
+	// Update local state with draft animation triggers
+	if (snapshot.phase === "draft") {
+		const isFirstPick = !document.querySelector(".player-hand--draft .hand-card");
+		if (isFirstPick) {
+			playGameSound("deal");
+			setIsInitialDealInProgress(true);
+			setTimeout(() => {
+				setIsInitialDealInProgress(false);
+			}, 500);
+		}
+	}
+
+	rerenderGameShell();
+}
+
+/**
+ * Schedule bot turns after the current state settles.
+ * BotManager picks appropriate actions based on the room phase.
+ */
+function scheduleBots(): void {
+	// Clear previous bot timers
+	for (const id of botTimerIds) {
+		clearTimeout(id);
+	}
+	botTimerIds = [];
+
+	if (!localRoom) return;
+
+	// Schedule new bot turns with a small delay so the human player
+	// can see what happened before bots move
+	const timers = scheduleBotTurns(localRoom, 400);
+	botTimerIds = timers;
+
+	// After bot turns complete, apply snapshot + re-render
+	// scheduleBotTurns returns setTimeout IDs; we chain a final
+	// applySnapshotAndRender after the longest bot delay
+	if (timers.length > 0) {
+		const finalTimer = setTimeout(() => {
+			applySnapshotAndRender();
+		}, 600 + timers.length * 100);
+		botTimerIds.push(finalTimer as unknown as number);
+	}
+}

--- a/src/online/snapshotAdapter.ts
+++ b/src/online/snapshotAdapter.ts
@@ -1,0 +1,146 @@
+/**
+ * snapshotAdapter.ts — Bridge between server RoomSnapshot and single-player state.
+ *
+ * The single-player rendering (renderMainArena in arena/render.ts) reads from
+ * module-level getters in state.ts. This adapter populates those getters from
+ * a RoomSnapshot so the same polished renderer works for BOTH modes.
+ *
+ * Usage:
+ *   import { applySnapshotToState } from "./online/snapshotAdapter.ts";
+ *   applySnapshotToState(snapshot, cards, myPlayerId);
+ *   renderMainArena(); // renders identically for SP and MP
+ */
+
+import {
+	setBoardSlots,
+	setPlayerHand,
+	setGamePhase,
+	setCurrentDayIndex,
+	setDeck,
+	setDraftPool,
+	setDraftRound,
+	setPlayerChosenCards,
+	setAccumulatedVP,
+	setOpponentPlayers,
+	setCurrentPlayerName,
+	setRemainingTurnSeconds,
+	setDraftPickSecondsLeft,
+} from "../state.ts";
+import { boardCellsToSlots } from "../shared/board.ts";
+import type { RoomSnapshot, TravelCard } from "../shared/types.ts";
+import type { PlayerState } from "../shared/types.ts";
+
+/**
+ * Convert a single player's state from snapshot into the local state getters.
+ * Call this before renderMainArena() so the arena renders identically for
+ * singleplayer and multiplayer.
+ *
+ * @param snapshot - RoomSnapshot from server/localRoom
+ * @param cards - Full card catalogue (for resolving card IDs to TravelCard objects)
+ * @param myPlayerId - The local player's ID (null for non-player view)
+ */
+export function applySnapshotToState(
+	snapshot: RoomSnapshot,
+	cards: TravelCard[],
+	myPlayerId: string | null,
+): void {
+	const myPlayer = myPlayerId
+		? snapshot.players.find((p) => p.playerId === myPlayerId)
+		: null;
+
+	if (!myPlayer) {
+		// No viewing player — still set phase/day for opponent viewing
+		setGamePhase(phaseToLocal(snapshot.phase));
+		setCurrentDayIndex(snapshot.day - 1);
+		setBoardSlots(createEmptySlots());
+		return;
+	}
+
+	// ── Phase mapping ────────────────────────────────────────────────────────
+	setGamePhase(phaseToLocal(snapshot.phase));
+
+	// ── Day (0-based for local state) ─────────────────────────────────────────
+	setCurrentDayIndex(snapshot.day - 1);
+
+	// ── Board (convert BoardCell[] → BoardSlots) ──────────────────────────────
+	const slots = boardCellsToSlots(myPlayer.board, cards);
+	setBoardSlots(slots);
+
+	// ── Hand (for draft phase) ────────────────────────────────────────────────
+	const handCards = myPlayer.hand
+		.map((cardId) => cards.find((c) => c.card_id === cardId))
+		.filter((c): c is TravelCard => c !== undefined);
+	setPlayerHand(handCards);
+
+	// Also populate chosen cards so placement knows what's available
+	const chosenCards = myPlayer.chosen
+		.map((cardId) => cards.find((c) => c.card_id === cardId))
+		.filter((c): c is TravelCard => c !== undefined);
+	setPlayerChosenCards(chosenCards);
+
+	// ── Draft pool ────────────────────────────────────────────────────────────
+	// In snapshot, the player's hand IS the draft pool (the set of cards to
+	// pick from in this round). Since snapshot hides other players' hands,
+	// the local player only sees their own hand.
+	if (snapshot.phase === "draft") {
+		setDraftPool(handCards);
+		setDraftRound(snapshot.pickIndex + 1); // 0-based → 1-based
+	} else {
+		setDraftPool([]);
+	}
+
+	// ── Deck (from full card catalogue for display) ───────────────────────────
+	setDeck(cards);
+
+	// ── VP ───────────────────────────────────────────────────────────────────
+	setAccumulatedVP(myPlayer.resources.vp);
+
+	// ── Opponent players (for sidebar display) ────────────────────────────────
+	const opponents = snapshot.players.filter((p) => p.playerId !== myPlayerId);
+	setOpponentPlayers(opponents);
+
+	// ── Player name ──────────────────────────────────────────────────────────
+	setCurrentPlayerName(myPlayer.name);
+
+	// ── Timer (default values; real timer comes from server) ──────────────────
+	setRemainingTurnSeconds(60);
+	setDraftPickSecondsLeft(10);
+}
+
+/**
+ * Convert a player's hand (card IDs) to TravelCard[] for display.
+ */
+export function handToCards(
+	cardIds: string[],
+	cards: TravelCard[],
+): TravelCard[] {
+	return cardIds
+		.map((id) => cards.find((c) => c.card_id === id))
+		.filter((c): c is TravelCard => c !== undefined);
+}
+
+// ─── Local phase mapping ──────────────────────────────────────────────────────
+
+const PHASE_MAP: Record<string, string> = {
+	lobby: "draft", // fallback — lobby shouldn't reach arena
+	draft: "draft",
+	placement: "placement",
+	scoring: "simulation", // map server scoring to local simulation
+	finished: "finished",
+};
+
+/**
+ * Map server GamePhase to local state GamePhase.
+ * Server uses "scoring" which includes both simulation and scoring;
+ * local state calls this phase "simulation".
+ */
+function phaseToLocal(phase: string): "draft" | "placement" | "simulation" | "finished" {
+	return (PHASE_MAP[phase] as "draft" | "placement" | "simulation" | "finished") || "draft";
+}
+
+/**
+ * Create empty 5x5 board slots.
+ */
+function createEmptySlots(): (TravelCard | null)[][] {
+	return Array.from({ length: 5 }, () => Array(5).fill(null));
+}

--- a/src/online/spAdapter.ts
+++ b/src/online/spAdapter.ts
@@ -1,0 +1,172 @@
+/**
+ * spAdapter.ts — Single-player global action adapter for bot-based Room.
+ *
+ * Binds the global functions that RPG.html inline onclick handlers call
+ * (selectHandCard, handleBoardCellClick, endCurrentDay, etc.) to the
+ * localRoom.ts game functions, so the polished single-player renderer
+ * works with the server game FSM + bots.
+ *
+ * Usage:
+ *   import { initSPGlobals, startBotGame } from "./online/spAdapter.ts";
+ *   startBotGame("p1", "Nhà Lữ Hành", 3);
+ *
+ * This replaces the old app.ts game loop (startDailyDraft → selectHandCard
+ * → placeCard → confirmDay) with a Room-based flow where bots auto-play.
+ */
+
+import {
+	initLocalGame,
+	localDraftCard,
+	localPlaceCard,
+	localConfirmDay,
+	getLocalRoom,
+	getLocalPlayerId,
+} from "./localRoom.ts";
+import {
+	setSelectedHandCardId,
+	getSelectedHandCardId,
+	getGamePhase,
+	getCurrentDayIndex,
+	setFocusedHandCardId,
+	getPlayerChosenCards,
+} from "../state.ts";
+import { TIME_SLOTS } from "../shared/board.ts";
+import type { TravelCard, TimeSlot } from "../shared/types.ts";
+
+// ─── Module-level state ──────────────────────────────────────────────────────
+
+let globalsBound = false;
+
+// ─── Public API ─────────────────────────────────────────────────────────────
+
+/**
+ * Start a bot-based single-player game and bind all global action handlers.
+ *
+ * @param playerId - Human player ID (default "p1")
+ * @param playerName - Human player name (default "Nhà Lữ Hành")
+ * @param numBots - Number of bot opponents (default 3)
+ * @param cards - Optional card catalogue override
+ */
+export function startBotGame(
+	playerId = "p1",
+	playerName = "Nhà Lữ Hành",
+	numBots = 3,
+	cards?: TravelCard[],
+): void {
+	// Initialize the local Room with bots
+	initLocalGame(playerId, playerName, numBots, cards);
+
+	// Bind globals (idempotent)
+	initSPGlobals();
+}
+
+/**
+ * Bind all global game action handlers.
+ * Safe to call multiple times — re-binding is idempotent.
+ */
+export function initSPGlobals(): void {
+	if (globalsBound) return;
+	globalsBound = true;
+
+	// ── Draft: select a card from the pool ───────────────────────────────────
+	(globalThis as any).selectHandCard = (cardId: string) => {
+		const phase = getGamePhase();
+
+		if (phase === "draft") {
+			// In draft mode, picking a card = drafting it (store = keep)
+			localDraftCard(cardId, "store");
+			return;
+		}
+
+		if (phase === "placement") {
+			// In placement mode, picking a card = select it for placing
+			setSelectedHandCardId(cardId);
+			return;
+		}
+
+		console.warn("[spAdapter] selectHandCard ignored — phase:", phase);
+	};
+
+	// ── Board cell click: place selected card ────────────────────────────────
+	(globalThis as any).handleBoardCellClick = (row: number, _col: number) => {
+		const phase = getGamePhase();
+		if (phase !== "placement") return;
+
+		const selectedId = getSelectedHandCardId();
+		if (!selectedId) {
+			// No card selected — nothing to place
+			return;
+		}
+
+		// Derive slot from row index (0 = early_morning … 4 = night)
+		const slotName = TIME_SLOTS[row] as TimeSlot | undefined;
+		if (!slotName) {
+			console.warn("[spAdapter] Invalid row index:", row);
+			return;
+		}
+
+		const day = getCurrentDayIndex() + 1; // Current day (1-based)
+
+		try {
+			localPlaceCard(selectedId, day, slotName);
+			// Clear selection after successful placement
+			setSelectedHandCardId(null);
+		} catch (err: unknown) {
+			const msg = err instanceof Error ? err.message : String(err);
+			console.warn("[spAdapter] placeCard failed:", msg);
+		}
+	};
+
+	// ── End day: confirm all placements are done ──────────────────────────────
+	(globalThis as any).endCurrentDay = () => {
+		// Check that the player has no unplaced chosen cards
+		const unplaced = getPlayerChosenCards();
+		if (unplaced.length > 0) {
+			console.warn(
+				`[spAdapter] ${unplaced.length} cards remain unplaced — confirm anyway?`,
+			);
+			// The server game.ts's confirmDay will succeed regardless;
+			// leftover chosen are discarded in scoring
+		}
+		localConfirmDay();
+	};
+
+	// ── Clear card selection ────────────────────────────────────────────────
+	(globalThis as any).clearSelectedHandCard = () => {
+		setSelectedHandCardId(null);
+	};
+
+	// ── Hold-to-focus handlers ──────────────────────────────────────────────
+	(globalThis as any).startHoldHandCard = (cardId: string) => {
+		setFocusedHandCardId(cardId);
+	};
+
+	(globalThis as any).cancelHoldHandCard = () => {
+		setFocusedHandCardId(null);
+	};
+
+	// ── Focused card overlay close ──────────────────────────────────────────
+	(globalThis as any).closeFocusedCard = () => {
+		setFocusedHandCardId(null);
+	};
+
+	console.log("[spAdapter] Global action handlers bound.");
+}
+
+/**
+ * Unbind globals (for cleanup before online mode).
+ */
+export function teardownSPGlobals(): void {
+	if (!globalsBound) return;
+	globalsBound = false;
+
+	delete (globalThis as any).selectHandCard;
+	delete (globalThis as any).handleBoardCellClick;
+	delete (globalThis as any).endCurrentDay;
+	delete (globalThis as any).clearSelectedHandCard;
+	delete (globalThis as any).startHoldHandCard;
+	delete (globalThis as any).cancelHoldHandCard;
+	delete (globalThis as any).closeFocusedCard;
+
+	console.log("[spAdapter] Global action handlers unbound.");
+}

--- a/src/state.ts
+++ b/src/state.ts
@@ -55,12 +55,29 @@ export function setCurrentPlayerBoard(nextBoard: BoardSlots) {
 	playerBoards[currentPlayerId] = nextBoard;
 }
 
+/** Direct setter used by snapshotAdapter to replace board for any player. */
+export function setBoardSlots(slots: BoardSlots) {
+	playerBoards[currentPlayerId] = slots;
+}
+
 export function getBoardSlots(): BoardSlots {
 	return getCurrentPlayerBoard();
 }
 
 export function getOpponentPlayerIds(): PlayerId[] {
 	return playerIds.filter((id) => id !== currentPlayerId);
+}
+
+// ── Opponent display state (from snapshot) ─────────────────────────────────--
+
+let opponentPlayers: import("./shared/types.ts").PlayerState[] = [];
+
+export function setOpponentPlayers(players: import("./shared/types.ts").PlayerState[]) {
+	opponentPlayers = players;
+}
+
+export function getOpponentPlayers(): import("./shared/types.ts").PlayerState[] {
+	return opponentPlayers;
 }
 
 // ── Phase state ──────────────────────────────────────────────────────────────
@@ -148,6 +165,27 @@ export function getPlayerHand(): TravelCard[] {
 
 export function setPlayerHand(hand: TravelCard[]) {
 	playerHand = hand;
+}
+
+// ── Chosen cards & player name (for snapshot-based rendering) ───────────────--
+
+let playerChosenCards: TravelCard[] = [];
+let currentPlayerName = "";
+
+export function getPlayerChosenCards(): TravelCard[] {
+	return playerChosenCards;
+}
+
+export function setPlayerChosenCards(cards: TravelCard[]) {
+	playerChosenCards = cards;
+}
+
+export function getCurrentPlayerName(): string {
+	return currentPlayerName;
+}
+
+export function setCurrentPlayerName(name: string) {
+	currentPlayerName = name;
 }
 
 export function getCurrentDayIndex(): number {


### PR DESCRIPTION
## Summary

Unifies singleplayer and multiplayer game logic under the server Room FSM. Bots auto-play (draft/place/confirm) so singleplayer now uses the same engine with 3 bot opponents.

## Architecture

```
server/game.ts  ←  server/bot.ts (new)
     │                 │
     ├─ Multiplayer ───┤ (remote WebSocket clients)
     └─ Singleplayer ──┤ (src/online/localRoom.ts, new)
                        │
                   snapshotAdapter.ts → state.ts → renderMainArena()
```

## New Files

| File | Purpose |
|------|---------|
| `server/bot.ts` | Bot auto-play: `createBotPlayer()`, `runBotTurn()` (draft/place/confirm), `scheduleBotTurns()` |
| `src/online/localRoom.ts` | Wraps `Room` for in-process use: `initLocalGame()`, `localDraftCard()`, `localPlaceCard()`, `localConfirmDay()` |
| `src/online/snapshotAdapter.ts` | `applySnapshotToState()` — converts `RoomSnapshot` → singleplayer `state.ts` getters |
| `src/online/spAdapter.ts` | Binds global action handlers (`selectHandCard`, `handleBoardCellClick`, `endCurrentDay`) to localRoom functions |

## Bot Behavior

- **Draft**: picks the first card in hand with `store` mode
- **Placement**: places chosen cards into available slots (early_morning → night)
- **Confirm**: auto-confirms day when all chosen cards placed
- Timer-based (400ms delay) so moves feel natural

## Backward Compatibility

- Old app.ts game loop preserved (startDailyDraft, selectHandCard, etc.) but unused
- Global handlers overridden by spAdapter on game start
- 35/35 server tests pass