### PR TITLE
fix: remove raw playerId UUID from saved session display

### DIFF
--- a/src/screens/lobby.ts
+++ b/src/screens/lobby.ts
@@ -85,7 +85,7 @@ export function renderOnlineEntryScreen(
               <div class="online-entry-card__resume">
                 <div>
                   <strong>Phiên cũ</strong>
-                  <span>Room ${escapeHtml(savedSession.roomId)} • ${escapeHtml(savedSession.playerId)} • ${escapeHtml(savedSession.playerName)}</span>
+                  <span>Room ${escapeHtml(savedSession.roomId)} • ${escapeHtml(savedSession.playerName)}</span>
                 </div>
                 <button onclick="event.stopPropagation(); window.reconnectSavedRoomFromLobby()">Reconnect</button>
                 <button class="online-entry-card__ghost" onclick="event.stopPropagation(); window.clearSavedRoomFromLobby()">Xóa lưu</button>


### PR DESCRIPTION
The saved session section in the lobby was rendering the full internal `playerId` UUID (e.g. `7AC45F6F-F82A-42C3-BAAA-53DC382C90C5`) alongside the human-readable `playerName`. Users shouldn't see internal identifiers.

**Before:** `Room E5CD6D67 • 7AC45F6F-F82A-42C3-BAAA-53DC382C90C5 • Nhà Lữ Hành`
**After:** `Room E5CD6D67 • Nhà Lữ Hành`