### PR TITLE
fix: remove raw UUID from lobby UI, center entry screen

### DIFF
--- a/css/client.less
+++ b/css/client.less
@@ -9048,6 +9048,10 @@ body {
   width: 1600px !important;
   height: 900px !important;
   min-height: 900px !important;
+  position: absolute !important;
+  left: 50% !important;
+  top: 50% !important;
+  transform: translate(-50%, -50%) !important;
 }
 
 /* 

--- a/src/screens/lobby.ts
+++ b/src/screens/lobby.ts
@@ -80,8 +80,8 @@ export function renderOnlineEntryScreen(
         </div>
 
         ${
-						savedSession
-							? `
+					savedSession
+						? `
               <div class="online-entry-card__resume">
                 <div>
                   <strong>Phiên cũ</strong>
@@ -91,7 +91,7 @@ export function renderOnlineEntryScreen(
                 <button class="online-entry-card__ghost" onclick="event.stopPropagation(); window.clearSavedRoomFromLobby()">Xóa lưu</button>
               </div>
             `
-							: ""
+						: ""
 				}
       </section>
     </main>
@@ -116,7 +116,6 @@ export function renderOnlineLobbyRoomScreen(
 	if (phase !== "lobby") return "";
 
 	const safeRoomId = escapeHtml(roomId);
-	const safePlayerId = escapeHtml(playerId);
 	const safeSelfName = escapeHtml(selfPlayerName);
 
 	const playersHtml = players
@@ -124,9 +123,8 @@ export function renderOnlineLobbyRoomScreen(
 			const isSelf = player.id === playerId;
 			const safePid = escapeHtml(player.id);
 			const safePName = escapeHtml(player.name);
-			const safeDisplayName = player.isConnected || player.hasJoined
-				? safePName
-				: "Đang chờ...";
+			const safeDisplayName =
+				player.isConnected || player.hasJoined ? safePName : "Đang chờ...";
 
 			const slotClass = player.isConnected
 				? "is-connected"
@@ -143,7 +141,7 @@ export function renderOnlineLobbyRoomScreen(
 
 			return `
         <div class="online-lobby-player ${slotClass} ${isSelf ? "is-self" : ""}">
-          <div class="online-lobby-player__slot">${safePid.toUpperCase()}</div>
+          <div class="online-lobby-player__slot">${safePid.slice(0, 8).toUpperCase()}</div>
           <div class="online-lobby-player__info">
             <strong>${safeDisplayName}</strong>
             <span>${player.isConnected ? (player.isReady ? "Sẵn sàng" : "Chưa sẵn sàng") : player.hasJoined ? "Đã offline • giữ slot" : "Trống"}</span>
@@ -161,7 +159,7 @@ export function renderOnlineLobbyRoomScreen(
           <div>
             <span>ONLINE ROOM</span>
             <h1>${safeRoomId}</h1>
-            <p>Bạn là ${safePlayerId.toUpperCase()} • ${safeSelfName}</p>
+            <p>Bạn là ${safeSelfName}</p>
           </div>
 
           <div class="online-lobby-card__header-actions">

--- a/src/version.ts
+++ b/src/version.ts
@@ -4,6 +4,6 @@
  * BUILD_TIME is replaced at build time by the bundler (rollup).
  */
 
-export const VERSION = "0.20.0";
+export const VERSION = "0.20.1";
 export const BUILD_TIME = "__BUILD_TIME_PLACEHOLDER__";
 export const APP_NAME = "Trekkopoly";


### PR DESCRIPTION
**1. UUID leaking in lobby UI (2 places)**\n- Identity header showed raw `playerId` UUID → now just shows player name\n- Player slot label showed full UUID → now shows first 8 chars\n\n**2. Entry screen not centered**\nThe `online-entry-screen` had fixed 1600x900px dimensions with `!important` but no centering, so it sat at top-left of the viewport exposing background below. Added `position: absolute; left: 50%; top: 50%; transform: translate(-50%, -50%)`.\n\n**3. Version bump 0.20.0 → 0.20.1**