### PR TITLE
fix: lobby host name, slot spacing, and ID label

### DIFF
--- a/css/client.less
+++ b/css/client.less
@@ -6812,7 +6812,7 @@ body {
 
 .online-lobby-player {
   display: grid;
-  grid-template-columns: 62px 1fr 82px;
+  grid-template-columns: 76px 1fr 82px;
   align-items: center;
   gap: 12px;
   border: 1px solid rgba(15, 23, 42, 0.1);
@@ -6848,6 +6848,22 @@ body {
   font-size: 20px;
   font-weight: 1000;
   text-shadow: 0 1px 2px rgba(255, 255, 255, 0.8);
+  line-height: 1.1;
+  letter-spacing: 0.08em;
+}
+
+.online-lobby-player__slot-label {
+  display: block;
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.15em;
+  color: rgba(30, 64, 175, 0.55);
+  text-shadow: none;
+  margin-top: 2px;
+}
+
+.online-lobby-player__info {
+  padding-left: 8px;
 }
 
 .online-lobby-player__info strong {

--- a/src/screens/lobby.ts
+++ b/src/screens/lobby.ts
@@ -117,6 +117,9 @@ export function renderOnlineLobbyRoomScreen(
 
 	const safeRoomId = escapeHtml(roomId);
 	const safeSelfName = escapeHtml(selfPlayerName);
+	// First connected/joined player is the host
+	const host = players.find(p => p.isConnected || p.hasJoined);
+	const hostName = host ? escapeHtml(host.name) : "P1";
 
 	const playersHtml = players
 		.map((player) => {
@@ -141,7 +144,7 @@ export function renderOnlineLobbyRoomScreen(
 
 			return `
         <div class="online-lobby-player ${slotClass} ${isSelf ? "is-self" : ""}">
-          <div class="online-lobby-player__slot">${safePid.slice(0, 8).toUpperCase()}</div>
+          <div class="online-lobby-player__slot">${safePid.slice(0, 8).toUpperCase()}<span class="online-lobby-player__slot-label">ID</span></div>
           <div class="online-lobby-player__info">
             <strong>${safeDisplayName}</strong>
             <span>${player.isConnected ? (player.isReady ? "Sẵn sàng" : "Chưa sẵn sàng") : player.hasJoined ? "Đã offline • giữ slot" : "Trống"}</span>
@@ -191,7 +194,7 @@ export function renderOnlineLobbyRoomScreen(
         </div>
 
         <div class="online-lobby-card__hint">
-          Host là P1. Tất cả người chơi đang trong phòng cần bấm Sẵn sàng trước khi bắt đầu.
+          Host là ${hostName}. Tất cả người chơi đang trong phòng cần bấm Sẵn sàng trước khi bắt đầu.
         </div>
       </section>
     </main>


### PR DESCRIPTION
1. Host hint now dynamic - bottom text shows the actual host's display name instead of hardcoded 'P1'\n2. Slot spacing - grid column widened 62px→76px, added 8px left padding to player info\n3. ID label - added 'ID' subtext below the slot code to explain what it is