### PR TITLE
v0.23.1: bug fix pass — architecture cleanup and gameplay hardening

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -344,6 +344,7 @@ function startSinglePlayerGame() {
  * Game loop is driven by localRoom.ts's bot timers and state machine.
  */
 function startDailyDraft() {
+	console.warn("[app] startDailyDraft is deprecated — called unexpectedly");
 	const deck = getDeck();
 	const shuffled = shuffleCards(deck);
 	const pool = shuffled.slice(0, DRAFT_POOL_SIZE);
@@ -518,6 +519,7 @@ function placeBotCardsAfterPlayerMove(sourceCard: TravelCard) {
  * The simulation scoring path (runSystemSimulation) still references this indirectly.
  */
 function endCurrentDay() {
+	console.warn("[app] endCurrentDay is deprecated — called unexpectedly");
 	if (getGamePhase() !== "placement") return;
 
 	stopTurnTimer();
@@ -676,6 +678,7 @@ function applyDailyScoreOnce() {
  * The localRoom.ts version uses the same pattern but is driven by the Room FSM.
  */
 function startDraftTimer() {
+	console.warn("[app] startDraftTimer is deprecated — called unexpectedly");
 	stopDraftTimer();
 
 	if (getGamePhase() !== "draft") return;
@@ -732,6 +735,7 @@ function stopTurnTimer() {
  * @deprecated Legacy turn/placement timer. Superseded by localRoom.ts startPlacementTimer().
  */
 function startTurnTimer() {
+	console.warn("[app] startTurnTimer is deprecated — called unexpectedly");
 	stopTurnTimer();
 
 	if (getGamePhase() !== "placement") return;
@@ -757,6 +761,7 @@ function startTurnTimer() {
  * @deprecated Legacy day/phase sequencer. Superseded by Room FSM.
  */
 function startNextDayOrPhase() {
+	console.warn("[app] startNextDayOrPhase is deprecated — called unexpectedly");
 	// Guard: only advance from simulation or placement; prevents stale
 	// timeouts from a previous replay from advancing the game out of order.
 	const phase = getGamePhase();

--- a/src/app.ts
+++ b/src/app.ts
@@ -1030,6 +1030,7 @@ function handleHandPointerUp(event: PointerEvent) {
 			return;
 		}
 
+		// Board placement: use global handler (for Room-based game) or local fallback
 		if (
 			dropCell &&
 			Number.isInteger(rowIndex) &&
@@ -1037,7 +1038,12 @@ function handleHandPointerUp(event: PointerEvent) {
 			colIndex === currentDay &&
 			getBoardSlots()[rowIndex]?.[colIndex] === null
 		) {
-			placeHandCardOnBoard(cardId, rowIndex, colIndex);
+			const globalPlaceCard = (globalThis as any).handlePlaceCardOnBoard;
+			if (typeof globalPlaceCard === "function") {
+				globalPlaceCard(cardId, rowIndex, colIndex);
+			} else {
+				placeHandCardOnBoard(cardId, rowIndex, colIndex);
+			}
 			return;
 		}
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -339,6 +339,10 @@ function startSinglePlayerGame() {
  * Deal DRAFT_POOL_SIZE (7) cards from the deck into the draft pool.
  * Set phase to "draft", render the game screen.
  */
+/**
+ * @deprecated Legacy game loop entry point. Unreachable from Room FSM.
+ * Game loop is driven by localRoom.ts's bot timers and state machine.
+ */
 function startDailyDraft() {
 	const deck = getDeck();
 	const shuffled = shuffleCards(deck);
@@ -509,6 +513,10 @@ function placeBotCardsAfterPlayerMove(sourceCard: TravelCard) {
  * End the current day: score base VP from the day's board cells,
  * advance to next day (or finish).
  */
+/**
+ * @deprecated Legacy day-advance function. Superseded by `confirmDay` in Room FSM.
+ * The simulation scoring path (runSystemSimulation) still references this indirectly.
+ */
 function endCurrentDay() {
 	if (getGamePhase() !== "placement") return;
 
@@ -663,6 +671,10 @@ function applyDailyScoreOnce() {
 
 // ── Draft timer ───────────────────────────────────────────────────────────
 
+/**
+ * @deprecated Legacy draft timer. Superseded by localRoom.ts startDraftTimer().
+ * The localRoom.ts version uses the same pattern but is driven by the Room FSM.
+ */
 function startDraftTimer() {
 	stopDraftTimer();
 
@@ -716,6 +728,9 @@ function stopTurnTimer() {
 	}
 }
 
+/**
+ * @deprecated Legacy turn/placement timer. Superseded by localRoom.ts startPlacementTimer().
+ */
 function startTurnTimer() {
 	stopTurnTimer();
 
@@ -738,6 +753,9 @@ function startTurnTimer() {
 	}, TIMER_TICK_INTERVAL_MS);
 }
 
+/**
+ * @deprecated Legacy day/phase sequencer. Superseded by Room FSM.
+ */
 function startNextDayOrPhase() {
 	// Guard: only advance from simulation or placement; prevents stale
 	// timeouts from a previous replay from advancing the game out of order.
@@ -1402,36 +1420,7 @@ loadAuthSession();
 if (window.location.hash === "#test-game") {
 	startBotGame("p1", "Nhà Lữ Hành", 3);
 	transitionToScreen("game");
-
-	// After DOM renders, start draft countdown
-	window.setTimeout(() => {
-		let secondsLeft = DRAFT_PICK_SECONDS;
-		setDraftPickSecondsLeft(secondsLeft);
-		const strong: HTMLElement | null = document.querySelector(
-			".score-breakdown__timer strong",
-		);
-		if (!strong) return;
-		strong.textContent = secondsLeft + "s";
-
-		const timerId = window.setInterval(() => {
-			secondsLeft--;
-			setDraftPickSecondsLeft(secondsLeft);
-			strong.textContent = secondsLeft + "s";
-
-			// Danger pulse when time is low
-			const timerEl = strong.closest(".score-breakdown__timer");
-			if (timerEl) {
-				timerEl.classList.toggle(
-					"score-breakdown__timer--danger",
-					secondsLeft <= 3,
-				);
-			}
-
-			if (secondsLeft <= 0) {
-				clearInterval(timerId);
-			}
-		}, 1000);
-	}, 500);
+	// Timer is handled by localRoom.ts:applySnapshotAndRender()
 } else {
 	transitionToScreen("dashboard");
 }

--- a/src/arena/extra-panels.ts
+++ b/src/arena/extra-panels.ts
@@ -60,28 +60,6 @@ export function renderScoreBreakdownPanel(
 
 /* ── Resource Orbs ──────────────────────────────────────────────────────── */
 
-export function renderResourceOrbs(
-	xu: number,
-	stamina: number,
-	debtToken: number,
-	vp: number,
-): string {
-	return `
-    <section class="resource-orbs">
-      <div class="resource-orbs__orb resource-orbs__orb--xu" title="Tiền Việt (Xu)">
-        <span>${xu}</span>
-      </div>
-      <div class="resource-orbs__orb resource-orbs__orb--stamina" title="Thể lực (Stamina)">
-        <span>${stamina}</span>
-      </div>
-      ${debtToken > 0 ? `<div class="resource-orbs__orb resource-orbs__orb--debt" title="Nợ">${debtToken}</div>` : ""}
-      <div class="resource-orbs__orb resource-orbs__orb--vp" title="Điểm VP">
-        <span>${vp}</span>
-      </div>
-    </section>
-  `;
-}
-
 /* ── Final Ranking Panel ────────────────────────────────────────────────── */
 
 export function renderFinalRankingPanel(

--- a/src/arena/render.ts
+++ b/src/arena/render.ts
@@ -74,7 +74,7 @@ export const ROWS = ["Sáng", "Trưa", "Chiều", "Tối", "Khuya"];
  * Shared board grid renderer — used by both SP (renderMainArena) and
  * online (renderOnlineGameArenaShell) modes.
  *
- * @param boardSlots - The current board state (TravelCard|null[][]) 
+ * @param boardSlots - The current board state (TravelCard|null[][])
  * @param currentDayIndex - 0-based current day index
  * @param isDraft - true during draft phase
  * @param isSimulation - true during simulation phase
@@ -91,8 +91,16 @@ export function renderBoardGrid(
 		(row, rowIndex) => `
               <div class="time-label">${row}</div>
               ${DAYS.map((_, colIndex) =>
-				renderBoardCell(boardSlots, rowIndex, colIndex, currentDayIndex, isDraft, isSimulation, selectedCardId),
-			).join("")}
+								renderBoardCell(
+									boardSlots,
+									rowIndex,
+									colIndex,
+									currentDayIndex,
+									isDraft,
+									isSimulation,
+									selectedCardId,
+								),
+							).join("")}
             `,
 	).join("");
 }

--- a/src/arena/render.ts
+++ b/src/arena/render.ts
@@ -547,7 +547,7 @@ function renderMusicToggle(): string {
   `;
 }
 
-function renderDeckCardStack(): string {
+export function renderDeckCardStack(): string {
 	const deck = getDeck();
 	const remaining = deck.length;
 
@@ -578,7 +578,7 @@ function renderDeckCardStack(): string {
   `;
 }
 
-function renderScoreBreakdownPanel(): string {
+export function renderScoreBreakdownPanel(): string {
 	const board = getBoardSlots();
 	const dayIndex = getCurrentDayIndex();
 
@@ -673,7 +673,7 @@ function renderScoreBreakdownPanel(): string {
 
 // ── Resource orbs ───────────────────────────────────────────────────────────
 
-function renderResourceOrbs(): string {
+export function renderResourceOrbs(): string {
 	const board = getBoardSlots();
 	const totals = calculateBoardTotals(board);
 	const remaining = getRemainingResources({
@@ -687,18 +687,28 @@ function renderResourceOrbs(): string {
 
 	return `
     <div class="resource-orbs">
-      <div class="orb orb--coin">
-        <span class="orb__icon">C</span>
-        <span class="orb__value">${remaining.coin}</span>
+      <div class="resource-orb resource-orb--coin">
+        <div class="resource-orb__frame">
+          <div class="resource-orb__icon">🪙</div>
+          <div class="resource-orb__value">${remaining.coin}</div>
+        </div>
+        <div class="resource-orb__label">Xu</div>
       </div>
-      <div class="orb orb--stamina">
-        <span class="orb__icon">S</span>
-        <span class="orb__value">${remaining.stamina}</span>
+      <div class="resource-orb resource-orb--stamina">
+        <div class="resource-orb__frame">
+          <div class="resource-orb__icon resource-orb__icon--stamina">⚡</div>
+          <div class="resource-orb__value">${remaining.stamina}</div>
+        </div>
+        <div class="resource-orb__label">Thể lực</div>
       </div>
-      <div class="orb orb--debt">
-        <span class="orb__icon">D</span>
-        <span class="orb__value">${debt}</span>
-      </div>
+      ${debt > 0 ? `
+      <div class="resource-orb resource-orb--debt">
+        <div class="resource-orb__frame">
+          <div class="resource-orb__icon">💸</div>
+          <div class="resource-orb__value">${debt}</div>
+        </div>
+        <div class="resource-orb__label">Nợ</div>
+      </div>` : ""}
     </div>
   `;
 }
@@ -717,7 +727,7 @@ function renderEndDayButton(): string {
 
 // ── Game Over screen ─────────────────────────────────────────────────────────
 
-function renderGameOverScreen(): string {
+export function renderGameOverScreen(): string {
 	const breakdownTotal = getAccumulatedVP();
 	const board = getBoardSlots();
 	const totals = calculateBoardTotals(board);
@@ -808,7 +818,7 @@ function renderGameOverScreen(): string {
 
 // ── Turn timer ──────────────────────────────────────────────────────────────
 
-function renderTurnTimer(): string {
+export function renderTurnTimer(): string {
 	return `
     <div class="turn-timer">
       <span>${getRemainingTurnSeconds()}s</span>
@@ -874,7 +884,7 @@ function getSimEventTitle(
 	return "";
 }
 
-function renderSimulationResultPanel(): string {
+export function renderSimulationResultPanel(): string {
 	const result = getSimulationResult();
 	if (!result) return "";
 
@@ -1004,7 +1014,7 @@ function renderSimulationResultPanel(): string {
 
 // ── Opponent strip (single-player with bots) ─────────────────────────────────
 
-function renderOpponentStrip(
+export function renderOpponentStrip(
 	opponents: Array<{
 		name: string;
 		playerId: string;

--- a/src/arena/render.ts
+++ b/src/arena/render.ts
@@ -70,6 +70,33 @@ export const HAND_CITY_MEDIUM = 28;
 export const DAYS = [1, 2, 3, 4, 5];
 export const ROWS = ["Sáng", "Trưa", "Chiều", "Tối", "Khuya"];
 
+/**
+ * Shared board grid renderer — used by both SP (renderMainArena) and
+ * online (renderOnlineGameArenaShell) modes.
+ *
+ * @param boardSlots - The current board state (TravelCard|null[][]) 
+ * @param currentDayIndex - 0-based current day index
+ * @param isDraft - true during draft phase
+ * @param isSimulation - true during simulation phase
+ * @param selectedCardId - currently selected card in hand, or null
+ */
+export function renderBoardGrid(
+	boardSlots: BoardSlots,
+	currentDayIndex: number,
+	isDraft: boolean,
+	isSimulation: boolean,
+	selectedCardId: string | null,
+): string {
+	return ROWS.map(
+		(row, rowIndex) => `
+              <div class="time-label">${row}</div>
+              ${DAYS.map((_, colIndex) =>
+				renderBoardCell(boardSlots, rowIndex, colIndex, currentDayIndex, isDraft, isSimulation, selectedCardId),
+			).join("")}
+            `,
+	).join("");
+}
+
 // ── Helpers ported from Trekkopoly src/data/cardMapper.ts ────────────────────
 
 function getTextFitClass(
@@ -155,12 +182,7 @@ export function renderMainArena(): string {
           </div>
 
           <section class="board-grid">
-            ${ROWS.map(
-							(row, rowIndex) => `
-              <div class="time-label">${row}</div>
-              ${DAYS.map((_, colIndex) => renderBoardCell(boardSlots, rowIndex, colIndex, currentDayIndex, isDraft, isSimulation)).join("")}
-            `,
-						).join("")}
+            ${renderBoardGrid(boardSlots, currentDayIndex, isDraft, isSimulation, getSelectedHandCardId())}
           </section>
         </div>
 
@@ -188,10 +210,10 @@ function renderBoardCell(
 	currentDayIndex: number,
 	isDraft: boolean,
 	isSimulation: boolean,
+	selectedId: string | null,
 ): string {
 	const card = boardSlots[rowIndex]?.[colIndex] ?? null;
 	const isCurrentDayColumn = colIndex === currentDayIndex;
-	const selectedId = getSelectedHandCardId();
 	const isPlaceable =
 		!isDraft &&
 		!isSimulation &&
@@ -701,14 +723,18 @@ export function renderResourceOrbs(): string {
         </div>
         <div class="resource-orb__label">Thể lực</div>
       </div>
-      ${debt > 0 ? `
+      ${
+				debt > 0
+					? `
       <div class="resource-orb resource-orb--debt">
         <div class="resource-orb__frame">
           <div class="resource-orb__icon">💸</div>
           <div class="resource-orb__value">${debt}</div>
         </div>
         <div class="resource-orb__label">Nợ</div>
-      </div>` : ""}
+      </div>`
+					: ""
+			}
     </div>
   `;
 }

--- a/src/online/localRoom.ts
+++ b/src/online/localRoom.ts
@@ -122,11 +122,6 @@ export function initLocalGame(
 }
 
 /**
- * Re-apply the latest snapshot to client state and re-render.
- * Useful when the DOM wasn't ready during initial snapshot application
- * (e.g., hash bypass test mode).
- */
-/**
  * Clean up any running local game.
  */
 export function cleanupLocalGame(): void {

--- a/src/online/localRoom.ts
+++ b/src/online/localRoom.ts
@@ -139,8 +139,6 @@ export function cleanupLocalGame(): void {
 	localPlayerId = null;
 }
 
-
-
 /**
  * Get the current local room (for direct game function calls).
  */
@@ -163,7 +161,7 @@ export function getLocalPlayerId(): string | null {
 export function localDraftCard(cardId: string, mode: "store" | "rest"): void {
 	if (!localRoom || !localPlayerId) return;
 	try {
-// Clear the draft timer — player is making a choice
+		// Clear the draft timer — player is making a choice
 		stopDraftTimer();
 		draftCard(localRoom, localPlayerId, cardId, mode);
 		applySnapshotAndRender();

--- a/src/online/localRoom.ts
+++ b/src/online/localRoom.ts
@@ -28,6 +28,7 @@ import {
 import { createBotPlayer, scheduleBotTurns } from "../../server/bot.ts";
 import type { TravelCard, TimeSlot } from "../shared/types.ts";
 import { syncAllStateFromSnapshot } from "./snapshotAdapter.ts";
+import { detectHandTransition } from "../services/animation-controller.ts";
 import { rerenderGameShell, updateTimerDom } from "../router.ts";
 import { playGameSound } from "../audio/gameAudio.ts";
 import {
@@ -238,16 +239,11 @@ function applySnapshotAndRender(): void {
 	const snapshot = exportSnapshot(localRoom, localPlayerId);
 	syncAllStateFromSnapshot(snapshot, localCards, localPlayerId);
 
-	// ── Draft animation triggers ───────────────────────────────────────────
-	// Track previous hand size to detect pass (hand shrinks) vs deal (new cards)
-	const handEl = document.querySelector(".player-hand--draft");
-	const hadHandCards = handEl?.querySelector(".hand-card");
+	// ── Animation detection (shared controller, not DOM query) ────────────
+	const transition = detectHandTransition(getPlayerHand().length);
 
 	if (snapshot.phase === "draft") {
-		const hasHandCards = handEl?.querySelector(".hand-card");
-
-		if (hasHandCards && !hadHandCards) {
-			// Pass complete — new cards just arrived. Play deal animation.
+		if (transition.type === "deal") {
 			playGameSound("deal");
 			setIsPassingDraftCards(false);
 			setIsInitialDealInProgress(true);
@@ -273,15 +269,12 @@ function applySnapshotAndRender(): void {
 			}, DEAL_ANIMATION_MS);
 		}
 
-		if (!hasHandCards && hadHandCards) {
-			// Hand just got emptied — player picked, remaining cards passed back.
-			// Play pass animation.
+		if (transition.type === "pass") {
 			setIsPassingDraftCards(true);
 		}
 
-		// Fallback: cards are in the DOM but no timer running (e.g., DOM wasn't
-		// ready during the first call, or refresh after transitionToScreen).
-		if (hasHandCards && draftTimerId === null) {
+		// Fallback: cards present but no timer running
+		if (getPlayerHand().length > 0 && draftTimerId === null) {
 			startDraftTimer();
 		}
 	} else {

--- a/src/online/localRoom.ts
+++ b/src/online/localRoom.ts
@@ -27,7 +27,7 @@ import {
 } from "../../server/game.ts";
 import { createBotPlayer, scheduleBotTurns } from "../../server/bot.ts";
 import type { TravelCard, TimeSlot } from "../shared/types.ts";
-import { applySnapshotToState } from "./snapshotAdapter.ts";
+import { syncAllStateFromSnapshot } from "./snapshotAdapter.ts";
 import { rerenderGameShell, updateTimerDom } from "../router.ts";
 import { playGameSound } from "../audio/gameAudio.ts";
 import {
@@ -236,7 +236,7 @@ function applySnapshotAndRender(): void {
 	if (!localRoom || !localPlayerId) return;
 
 	const snapshot = exportSnapshot(localRoom, localPlayerId);
-	applySnapshotToState(snapshot, localCards, localPlayerId);
+	syncAllStateFromSnapshot(snapshot, localCards, localPlayerId);
 
 	// ── Draft animation triggers ───────────────────────────────────────────
 	// Track previous hand size to detect pass (hand shrinks) vs deal (new cards)

--- a/src/online/localRoom.ts
+++ b/src/online/localRoom.ts
@@ -29,21 +29,24 @@ import { createBotPlayer, scheduleBotTurns } from "../../server/bot.ts";
 import type { TravelCard, TimeSlot } from "../shared/types.ts";
 import { syncAllStateFromSnapshot } from "./snapshotAdapter.ts";
 import { detectHandTransition } from "../services/animation-controller.ts";
-import { rerenderGameShell, updateTimerDom } from "../router.ts";
+import {
+	startDraftTimer as startSharedDraftTimer,
+	stopDraftTimer,
+	startPlacementTimer as startSharedPlacementTimer,
+	stopPlacementTimer,
+	isDraftTimerRunning,
+} from "../services/game-timer.ts";
+import { rerenderGameShell } from "../router.ts";
 import { playGameSound } from "../audio/gameAudio.ts";
 import {
 	setIsInitialDealInProgress,
 	setIsPassingDraftCards,
 	getPlayerHand,
-	setDraftPickSecondsLeft,
 	setRemainingTurnSeconds,
 } from "../state.ts";
 import { getCardsByPhasePool } from "../shared/data/cards.all.ts";
 import { DEAL_ANIMATION_MS } from "../shared/animations.ts";
-import {
-	DRAFT_PICK_SECONDS,
-	TURN_DURATION_SECONDS,
-} from "../shared/constants.ts";
+import { TURN_DURATION_SECONDS } from "../shared/constants.ts";
 
 // ─── State ──────────────────────────────────────────────────────────────────
 
@@ -51,8 +54,7 @@ let localRoom: Room | null = null;
 let localPlayerId: string | null = null;
 let localCards: TravelCard[] = [];
 let botTimerIds: number[] = [];
-let draftTimerId: number | null = null;
-let placementTimerId: number | null = null;
+// Timer state managed by services/game-timer.ts
 
 // ─── Public API ─────────────────────────────────────────────────────────────
 
@@ -131,18 +133,13 @@ export function cleanupLocalGame(): void {
 		clearTimeout(id);
 	}
 	botTimerIds = [];
-	clearDraftTimer();
-	clearPlacementTimer();
+	stopDraftTimer();
+	stopPlacementTimer();
 	localRoom = null;
 	localPlayerId = null;
 }
 
-function clearDraftTimer(): void {
-	if (draftTimerId !== null) {
-		clearInterval(draftTimerId);
-		draftTimerId = null;
-	}
-}
+
 
 /**
  * Get the current local room (for direct game function calls).
@@ -166,8 +163,8 @@ export function getLocalPlayerId(): string | null {
 export function localDraftCard(cardId: string, mode: "store" | "rest"): void {
 	if (!localRoom || !localPlayerId) return;
 	try {
-		// Clear the draft timer — player is making a choice
-		clearDraftTimer();
+// Clear the draft timer — player is making a choice
+		stopDraftTimer();
 		draftCard(localRoom, localPlayerId, cardId, mode);
 		applySnapshotAndRender();
 		scheduleBots();
@@ -207,7 +204,7 @@ export function localDiscardCard(cardId: string): void {
 export function localConfirmDay(): void {
 	if (!localRoom || !localPlayerId) return;
 	try {
-		clearPlacementTimer();
+		stopPlacementTimer();
 		confirmDay(localRoom, localPlayerId);
 		applySnapshotAndRender();
 		scheduleBots();
@@ -274,12 +271,12 @@ function applySnapshotAndRender(): void {
 		}
 
 		// Fallback: cards present but no timer running
-		if (getPlayerHand().length > 0 && draftTimerId === null) {
+		if (getPlayerHand().length > 0 && !isDraftTimerRunning()) {
 			startDraftTimer();
 		}
 	} else {
 		// Not in draft — clear the draft timer
-		clearDraftTimer();
+		stopDraftTimer();
 	}
 
 	// Update the placement timer
@@ -290,7 +287,7 @@ function applySnapshotAndRender(): void {
 			startPlacementTimer();
 		}
 	} else {
-		clearPlacementTimer();
+		stopPlacementTimer();
 	}
 
 	rerenderGameShell();
@@ -301,42 +298,26 @@ function applySnapshotAndRender(): void {
  * When time expires, auto-pick the first card in hand.
  */
 function startDraftTimer(): void {
-	clearDraftTimer();
-
 	const hand = getPlayerHand();
 	if (hand.length === 0) return;
-
-	// Guard: only start the timer if we're still in the draft phase
 	if (!localRoom || !localPlayerId) return;
 	if (exportSnapshot(localRoom, localPlayerId).phase !== "draft") return;
 
-	let secondsLeft = DRAFT_PICK_SECONDS;
-	setDraftPickSecondsLeft(secondsLeft);
-
-	draftTimerId = window.setInterval(() => {
-		secondsLeft--;
-		setDraftPickSecondsLeft(secondsLeft);
-		updateTimerDom();
-
-		if (secondsLeft <= 0) {
-			clearDraftTimer();
-
-			// Auto-pick the first card in hand
-			const firstCard = getPlayerHand()[0];
-			if (firstCard && localRoom && localPlayerId) {
-				// Re-check phase — the game may have transitioned since the timer started
-				if (exportSnapshot(localRoom, localPlayerId).phase !== "draft") return;
-				try {
-					draftCard(localRoom, localPlayerId, firstCard.id, "store");
-					applySnapshotAndRender();
-					scheduleBots();
-				} catch (err: unknown) {
-					const msg = err instanceof Error ? err.message : String(err);
-					console.warn("[localRoom] auto-draft failed:", msg);
-				}
+	startSharedDraftTimer(() => {
+		// Auto-pick the first card in hand
+		const firstCard = getPlayerHand()[0];
+		if (firstCard && localRoom && localPlayerId) {
+			if (exportSnapshot(localRoom, localPlayerId).phase !== "draft") return;
+			try {
+				draftCard(localRoom, localPlayerId, firstCard.id, "store");
+				applySnapshotAndRender();
+				scheduleBots();
+			} catch (err: unknown) {
+				const msg = err instanceof Error ? err.message : String(err);
+				console.warn("[localRoom] auto-draft failed:", msg);
 			}
 		}
-	}, 1000);
+	});
 }
 
 /**
@@ -344,38 +325,20 @@ function startDraftTimer(): void {
  * When time expires, auto-confirm the day.
  */
 function startPlacementTimer(): void {
-	clearPlacementTimer();
+	if (!localRoom || !localPlayerId) return;
 
-	let secondsLeft = TURN_DURATION_SECONDS;
-	setRemainingTurnSeconds(secondsLeft);
-
-	placementTimerId = window.setInterval(() => {
-		secondsLeft--;
-		setRemainingTurnSeconds(secondsLeft);
-		updateTimerDom();
-
-		if (secondsLeft <= 0) {
-			clearPlacementTimer();
-
-			if (localRoom && localPlayerId) {
-				try {
-					confirmDay(localRoom, localPlayerId);
-					applySnapshotAndRender();
-					scheduleBots();
-				} catch (err: unknown) {
-					const msg = err instanceof Error ? err.message : String(err);
-					console.warn("[localRoom] auto-confirm failed:", msg);
-				}
+	startSharedPlacementTimer(() => {
+		if (localRoom && localPlayerId) {
+			try {
+				confirmDay(localRoom, localPlayerId);
+				applySnapshotAndRender();
+				scheduleBots();
+			} catch (err: unknown) {
+				const msg = err instanceof Error ? err.message : String(err);
+				console.warn("[localRoom] auto-confirm failed:", msg);
 			}
 		}
-	}, 1000);
-}
-
-function clearPlacementTimer(): void {
-	if (placementTimerId !== null) {
-		clearInterval(placementTimerId);
-		placementTimerId = null;
-	}
+	});
 }
 
 /**

--- a/src/online/localRoom.ts
+++ b/src/online/localRoom.ts
@@ -126,26 +126,6 @@ export function initLocalGame(
  * Useful when the DOM wasn't ready during initial snapshot application
  * (e.g., hash bypass test mode).
  */
-export function refreshLocalSnapshot(): void {
-	if (localRoom && localPlayerId) {
-		applySnapshotToState(
-			exportSnapshot(localRoom, localPlayerId),
-			localCards,
-			localPlayerId,
-		);
-		rerenderGameShell();
-		// Force-start the draft timer if DOM is now ready, timer not running,
-		// and we're still in the draft phase
-		if (
-			draftTimerId === null &&
-			document.querySelector(".hand-card") &&
-			exportSnapshot(localRoom, localPlayerId).phase === "draft"
-		) {
-			startDraftTimer();
-		}
-	}
-}
-
 /**
  * Clean up any running local game.
  */

--- a/src/online/snapshotAdapter.ts
+++ b/src/online/snapshotAdapter.ts
@@ -23,20 +23,30 @@ import {
 	setAccumulatedVP,
 	setOpponentPlayers,
 	setCurrentPlayerName,
+	setDiscardedResourceCoinBonus,
+	setDiscardedResourceStaminaBonus,
+	setLocalCoinDebt,
+	setSelectedHandCardId,
+	setDraftSelectedCardId,
+	setDraftPickSecondsLeft,
+	setRemainingTurnSeconds,
+	setIsInitialDealInProgress,
+	setIsPassingDraftCards,
+	setIsSimulationMode,
+	setPhaseNumber,
 } from "../state.ts";
 import { boardCellsToSlots } from "../shared/board.ts";
 import type { RoomSnapshot, TravelCard } from "../shared/types.ts";
 
 /**
- * Convert a single player's state from snapshot into the local state getters.
- * Call this before renderMainArena() so the arena renders identically for
- * singleplayer and multiplayer.
+ * Sync ALL local state fields from a server/local RoomSnapshot.
+ * Single point of truth — prevents the 9-field gap by setting EVERY field.
  *
  * @param snapshot - RoomSnapshot from server/localRoom
  * @param cards - Full card catalogue (for resolving card IDs to TravelCard objects)
  * @param myPlayerId - The local player's ID (null for non-player view)
  */
-export function applySnapshotToState(
+export function syncAllStateFromSnapshot(
 	snapshot: RoomSnapshot,
 	cards: TravelCard[],
 	myPlayerId: string | null,
@@ -55,6 +65,7 @@ export function applySnapshotToState(
 
 	// ── Phase mapping ────────────────────────────────────────────────────────
 	setGamePhase(phaseToLocal(snapshot.phase));
+	setIsSimulationMode(snapshot.phase === "scoring");
 
 	// ── Day (0-based for local state) ─────────────────────────────────────────
 	setCurrentDayIndex(snapshot.day - 1);
@@ -64,7 +75,6 @@ export function applySnapshotToState(
 	setBoardSlots(slots);
 
 	// ── Hand cards ───────────────────────────────────────────────────────────
-	// Populate both hand and chosen from the snapshot
 	const handCards = myPlayer.hand
 		.map((cardId) => cards.find((c) => c.card_id === cardId))
 		.filter((c): c is TravelCard => c !== undefined);
@@ -73,8 +83,7 @@ export function applySnapshotToState(
 		.filter((c): c is TravelCard => c !== undefined);
 	setPlayerChosenCards(chosenCards);
 
-	// playerHand is used by renderPlayerHandSection(): show hand in draft,
-	// chosen cards in placement
+	// playerHand: show hand in draft, chosen in placement
 	if (snapshot.phase === "placement") {
 		setPlayerHand(chosenCards);
 	} else {
@@ -82,9 +91,6 @@ export function applySnapshotToState(
 	}
 
 	// ── Draft pool ────────────────────────────────────────────────────────────
-	// In snapshot, the player's hand IS the draft pool (the set of cards to
-	// pick from in this round). Since snapshot hides other players' hands,
-	// the local player only sees their own hand.
 	if (snapshot.phase === "draft") {
 		setDraftPool(handCards);
 		setDraftRound(snapshot.pickIndex + 1); // 0-based → 1-based
@@ -95,20 +101,39 @@ export function applySnapshotToState(
 	// ── Deck (from full card catalogue for display) ───────────────────────────
 	setDeck(cards);
 
-	// ── VP ───────────────────────────────────────────────────────────────────
+	// ── Scoring state ─────────────────────────────────────────────────────────
 	setAccumulatedVP(myPlayer.resources.vp);
 
 	// ── Opponent players (for sidebar display) ────────────────────────────────
 	const opponents = snapshot.players.filter((p) => p.playerId !== myPlayerId);
 	setOpponentPlayers(opponents);
 
-	// ── Player name ──────────────────────────────────────────────────────────
+	// ── Player identity ──────────────────────────────────────────────────────
 	setCurrentPlayerName(myPlayer.name);
 
-	// ── Timer values (preserved — localRoom manages the countdown) ──────────
-	// Timer is set by the localRoom's startDraftTimer()/startPlacementTimer().
-	// We do NOT overwrite here because the true remaining time is tracked
-	// by the interval timer, not the snapshot.
+	// ══════════════════════════════════════════════════════════════════════════
+	// MISSING FIELDS (9) — these were lost in the split sync approach
+	// ══════════════════════════════════════════════════════════════════════════
+
+	// ── Timer defaults ────────────────────────────────────────────────────────
+	// Set a default so renderers don't see NaN/null. The countdown is managed
+	// by localRoom.ts startDraftTimer()/startPlacementTimer() which overwrites.
+	setDraftPickSecondsLeft(30);
+	setRemainingTurnSeconds(120);
+	setPhaseNumber(snapshot.day); // 1-based day number
+
+	// ── Resource bonuses (clear for online; Room accounts for discards) ──────
+	setDiscardedResourceCoinBonus(0);
+	setDiscardedResourceStaminaBonus(0);
+	setLocalCoinDebt(myPlayer.resources.debtToken);
+
+	// ── Selection state (reset per render — animation controller sets them) ──
+	setSelectedHandCardId(null);
+	setDraftSelectedCardId(null);
+
+	// ── Animation flags (reset per render) ────────────────────────────────────
+	setIsInitialDealInProgress(false);
+	setIsPassingDraftCards(false);
 }
 
 /**

--- a/src/screens/onlineGame.ts
+++ b/src/screens/onlineGame.ts
@@ -17,13 +17,12 @@ import {
 	sendPayDebt,
 } from "../online/lobbyClient.ts";
 import { rpcCall } from "../online/socketClient.ts";
-import { renderHandCard, renderBoardMiniCard } from "../arena/render.ts";
+import { renderHandCard, renderBoardGrid } from "../arena/render.ts";
 import type { RoomSnapshot, TravelCard, PlayerState } from "../shared/types.ts";
 import {
 	boardCellsToSlots,
 	DAYS,
 	TIME_SLOTS,
-	SLOT_NAMES,
 } from "../shared/board.ts";
 import { playGameSound } from "../audio/gameAudio.ts";
 import {
@@ -161,7 +160,13 @@ function renderOnlineGameArenaShell(
 								`<div class="day-pill ${index === snapshot.day - 1 ? "day-pill--current" : ""} ${index < snapshot.day - 1 ? "day-pill--done" : ""}">NGÀY ${day}</div>`,
 						).join("")}
           </div>
-          ${phase === "placement" || phase === "scoring" ? renderOnlineBoardGrid(snapshot, myPlayer, cards()) : ""}
+          ${phase === "placement" || phase === "scoring" ? renderBoardGrid(
+					boardCellsToSlots(myPlayer.board, cards()),
+					snapshot.day - 1,
+					false,
+					false,
+					phase === "placement" ? getOnlineSelectedCardId() : null,
+				) : ""}
         </div>
 
         <div class="online-content-area">
@@ -472,48 +477,6 @@ function renderOnlineScoringContent(
   `;
 }
 
-// ═════════════════════════════════════════════════════════════════════════════
-// BOARD GRID (simplified, no drag-drop) — shared for placement + scoring
-
-function renderOnlineBoardGrid(
-	snapshot: RoomSnapshot,
-	myPlayer: PlayerState,
-	allCards: TravelCard[],
-): string {
-	const boardSlots = boardCellsToSlots(myPlayer.board, allCards);
-	const isPlacement = snapshot.phase === "placement";
-	const currentDay = snapshot.day;
-	const selectedId = isPlacement ? getOnlineSelectedCardId() : null;
-
-	return `
-    <section class="board-grid">
-      ${TIME_SLOTS.map(
-				(slot, rowIdx) =>
-					`<div class="time-label">${SLOT_NAMES[slot] ?? slot}</div>
-				` +
-					DAYS.map((_day, colIdx) => {
-						const cell = boardSlots[rowIdx]?.[colIdx] ?? null;
-						const isCurrentDay = colIdx === currentDay - 1;
-						const canPlace =
-							isPlacement && isCurrentDay && selectedId !== null && !cell;
-
-						return `
-            <div
-              class="board-cell${cell ? " board-cell--occupied board-cell--clickable" : " board-cell--empty"}${canPlace ? " board-cell--placeable" : ""}${!isCurrentDay ? " board-cell--not-current-day" : ""}"
-              data-board-cell="true"
-              data-row-index="${rowIdx}"
-              data-col-index="${colIdx}"
-              title="${cell ? escapeHtml(cell.name) : isCurrentDay ? (canPlace ? "Thả thẻ vào ô này" : "") : "Không phải ngày hiện tại"}"
-            >
-              ${cell ? renderBoardMiniCard(cell) : `<span class="empty-plus">+</span>`}
-            </div>
-          `;
-					}).join(""),
-			).join("")}
-    </section>
-  `;
-}
-
 // ── Opponent panel ─────────────────────────────────────────────────────────
 
 function renderOnlineOpponentPanel(opponents: PlayerState[]): string {
@@ -654,7 +617,11 @@ export function initOnlineGameGlobals() {
 
 	// Register global board placement handler (called by handleHandPointerUp
 	// in app.ts when a card is dragged to a board cell).
-	(globalThis as any).handlePlaceCardOnBoard = (cardId: string, row: number, _col: number) => {
+	(globalThis as any).handlePlaceCardOnBoard = (
+		cardId: string,
+		row: number,
+		_col: number,
+	) => {
 		handleOnlinePlaceCardOnBoard(cardId, row);
 	};
 
@@ -724,7 +691,6 @@ function updateOnlineGameAnimations(): void {
 	} else {
 		stopOnlinePlacementTimer();
 	}
-
 }
 
 // Draft timer functions for online mode

--- a/src/screens/onlineGame.ts
+++ b/src/screens/onlineGame.ts
@@ -28,46 +28,24 @@ import { playGameSound } from "../audio/gameAudio.ts";
 import {
 	setIsInitialDealInProgress,
 	setIsPassingDraftCards,
-	getDraftTimerId,
-	setDraftTimerId,
-	getPlacementTimerId,
-	setPlacementTimerId,
 	setRemainingTurnSeconds,
-	setDraftPickSecondsLeft,
 	getPlayerHand,
 } from "../state.ts";
+import {
+	startDraftTimer as startSharedDraftTimer,
+	stopDraftTimer,
+	startPlacementTimer as startSharedPlacementTimer,
+	stopPlacementTimer,
+	isDraftTimerRunning,
+} from "../services/game-timer.ts";
 import { detectHandTransition } from "../services/animation-controller.ts";
 import { DEAL_ANIMATION_MS } from "../shared/animations.ts";
 import {
-	DRAFT_PICK_SECONDS,
 	TURN_DURATION_SECONDS,
 } from "../shared/constants.ts";
-import { TIMER_TICK_INTERVAL_MS } from "../shared/animations.ts";
 
-// ── Local timer DOM update (avoids circular dependency with router.ts) ──────
 
-function updateTimerDom(): void {
-	const timerEl = document.querySelector(".score-breakdown__timer");
-	if (!timerEl) return;
-	const strongEl = timerEl.querySelector("strong");
-	if (!strongEl) return;
-
-	import("../state.ts").then((s) => {
-		const phase = s.getGamePhase();
-		if (phase === "draft") {
-			const secs = s.getDraftPickSecondsLeft();
-			strongEl.textContent = `${secs}s`;
-			timerEl.classList.toggle("score-breakdown__timer--danger", secs <= 3);
-		} else if (phase === "placement") {
-			const secs = s.getRemainingTurnSeconds();
-			const m = Math.floor(Math.max(0, secs) / 60);
-			const safeSec = Math.max(0, secs) % 60;
-			strongEl.textContent = `${m}:${safeSec < 10 ? "0" : ""}${safeSec}`;
-			timerEl.classList.toggle("score-breakdown__timer--danger", secs <= 10);
-		}
-	});
-}
-
+// Timer DOM updates are handled by the shared game-timer.ts module.
 // Animation state tracking is handled by animation-controller.ts
 
 // ── Main entry ──────────────────────────────────────────────────────────────
@@ -659,7 +637,7 @@ function updateOnlineGameAnimations(): void {
 				);
 
 				// Start draft pick timer after deal animation completes
-				startOnlineDraftTimer();
+				startSharedDraftTimer(() => handleOnlineDraftExpiry());
 			}, DEAL_ANIMATION_MS);
 		}
 
@@ -668,15 +646,12 @@ function updateOnlineGameAnimations(): void {
 		}
 
 		// Fallback: cards present but no timer running
-		if (getPlayerHand().length > 0) {
-			const timerId = getDraftTimerId();
-			if (timerId === null) {
-				startOnlineDraftTimer();
-			}
+		if (getPlayerHand().length > 0 && !isDraftTimerRunning()) {
+			startSharedDraftTimer(() => handleOnlineDraftExpiry());
 		}
 	} else {
 		// Not in draft — clear the draft timer
-		stopOnlineDraftTimer();
+		stopDraftTimer();
 	}
 
 	// Update placement timer
@@ -686,93 +661,24 @@ function updateOnlineGameAnimations(): void {
 		);
 		if (myPlayer && !myPlayer.ready) {
 			setRemainingTurnSeconds(TURN_DURATION_SECONDS);
-			startOnlinePlacementTimer();
+			startSharedPlacementTimer(() => handleOnlineConfirmDay());
 		}
 	} else {
-		stopOnlinePlacementTimer();
+		stopPlacementTimer();
 	}
 }
 
 // Draft timer functions for online mode
-function startOnlineDraftTimer(): void {
-	stopOnlineDraftTimer();
-
-	const hand =
-		getCurrentCards()?.filter(
-			(c) =>
-				getCurrentGameSnapshot()
-					?.players.find((p) => p.playerId === getCurrentPlayerId())
-					?.hand.includes(c.card_id) ?? [],
-		) ?? [];
-
-	if (hand.length === 0) return;
-
-	// Guard: only start the timer if we're still in the draft phase
+/**
+ * Handle draft timer expiry in online mode: auto-pick first card.
+ */
+function handleOnlineDraftExpiry(): void {
 	const snapshot = getCurrentGameSnapshot();
 	if (!snapshot || snapshot.phase !== "draft") return;
 
-	let secondsLeft = DRAFT_PICK_SECONDS;
-	setDraftPickSecondsLeft(secondsLeft);
-
-	const timerId = window.setInterval(() => {
-		secondsLeft--;
-		setDraftPickSecondsLeft(secondsLeft);
-		updateTimerDom();
-
-		if (secondsLeft <= 0) {
-			stopOnlineDraftTimer();
-
-			// Auto-pick the first card in hand
-			const firstCard = hand[0];
-			if (firstCard) {
-				// Re-check phase — the game may have transitioned since the timer started
-				const currentSnapshot = getCurrentGameSnapshot();
-				if (!currentSnapshot || currentSnapshot.phase !== "draft") return;
-				handleOnlineDraftCard(firstCard.card_id, "store");
-			}
-		}
-	}, TIMER_TICK_INTERVAL_MS);
-
-	setDraftTimerId(timerId);
-}
-
-function stopOnlineDraftTimer(): void {
-	const id = getDraftTimerId();
-	if (id !== null) {
-		clearInterval(id);
-		setDraftTimerId(null);
-	}
-}
-
-// Placement timer functions for online mode
-function startOnlinePlacementTimer(): void {
-	stopOnlinePlacementTimer();
-
-	let secondsLeft = TURN_DURATION_SECONDS;
-	setRemainingTurnSeconds(secondsLeft);
-
-	const timerId = window.setInterval(() => {
-		secondsLeft--;
-		setRemainingTurnSeconds(secondsLeft);
-		updateTimerDom();
-
-		if (secondsLeft <= 0) {
-			stopOnlinePlacementTimer();
-
-			if (getCurrentGameSnapshot()) {
-				handleOnlineConfirmDay();
-			}
-		}
-	}, TIMER_TICK_INTERVAL_MS);
-
-	setPlacementTimerId(timerId);
-}
-
-function stopOnlinePlacementTimer(): void {
-	const id = getPlacementTimerId();
-	if (id !== null) {
-		clearInterval(id);
-		setPlacementTimerId(null);
+	const firstCard = getPlayerHand()[0];
+	if (firstCard) {
+		handleOnlineDraftCard(firstCard.id, "store");
 	}
 }
 

--- a/src/screens/onlineGame.ts
+++ b/src/screens/onlineGame.ts
@@ -636,6 +636,27 @@ export function initOnlineGameGlobals() {
 		if (cardId) handleOnlineDiscardCard(cardId);
 	};
 
+	// Register global card selection handler (called by capture-phase click
+	// handler in router.ts for both draft cards and hand cards).
+	(globalThis as any).selectHandCard = (cardId: string) => {
+		_selectedOnlineCardId = cardId;
+		rerenderOnlineGame();
+	};
+
+	// Register global board cell click handler (called by capture-phase
+	// click handler in router.ts). Places the selected card on board.
+	(globalThis as any).handleBoardCellClick = (row: number, _col: number) => {
+		if (_selectedOnlineCardId) {
+			handleOnlinePlaceCardOnBoard(_selectedOnlineCardId, row);
+		}
+	};
+
+	// Register global board placement handler (called by handleHandPointerUp
+	// in app.ts when a card is dragged to a board cell).
+	(globalThis as any).handlePlaceCardOnBoard = (cardId: string, row: number, _col: number) => {
+		handleOnlinePlaceCardOnBoard(cardId, row);
+	};
+
 	// Animation updates - call after each render to check for animation triggers
 	updateOnlineGameAnimations();
 }

--- a/src/screens/onlineGame.ts
+++ b/src/screens/onlineGame.ts
@@ -27,7 +27,6 @@ import {
 } from "../shared/board.ts";
 import { playGameSound } from "../audio/gameAudio.ts";
 import {
-	getIsInitialDealInProgress,
 	setIsInitialDealInProgress,
 	setIsPassingDraftCards,
 	getDraftTimerId,
@@ -311,7 +310,7 @@ function renderOnlineDraftContent(
 
 function renderOnlineDraftCard(card: TravelCard, _index: number): string {
 	return `
-    <div class="daily-draft-card daily-draft-card--${_index + 1}" data-draft-card-id="${card.card_id}" data-online-draft-pick="${card.card_id}">
+    <div class="daily-draft-card daily-draft-card--${_index + 1}" data-draft-card-id="${card.card_id}">
       ${renderHandCard(card, _index, null)}
     </div>
   `;
@@ -369,8 +368,8 @@ function renderOnlinePlacementContent(
 					.map((card, idx) => {
 						const isSelected = selectedId === card.card_id;
 						return `
-            <div class="online-placement-card" data-online-select="${card.card_id}">
-              <div class="placement-card ${isSelected ? "placement-card--selected" : ""}" data-hand-card-id="${card.card_id}" draggable="true">
+            <div class="online-placement-card">
+              <div class="placement-card ${isSelected ? "placement-card--selected" : ""}" data-hand-card-id="${card.card_id}" onpointerdown="event.stopPropagation(); startHandPointerDrag(event, '${card.card_id}')">
                 ${renderHandCard(card, idx, isSelected ? card.card_id : null)}
               </div>
               <button class="online-placement-card__place" data-online-place="${card.card_id}">📌 Đặt</button>
@@ -500,7 +499,9 @@ function renderOnlineBoardGrid(
 						return `
             <div
               class="board-cell${cell ? " board-cell--occupied board-cell--clickable" : " board-cell--empty"}${canPlace ? " board-cell--placeable" : ""}${!isCurrentDay ? " board-cell--not-current-day" : ""}"
-              data-online-board="${rowIdx},${colIdx}"
+              data-board-cell="true"
+              data-row-index="${rowIdx}"
+              data-col-index="${colIdx}"
               title="${cell ? escapeHtml(cell.name) : isCurrentDay ? (canPlace ? "Thả thẻ vào ô này" : "") : "Không phải ngày hiện tại"}"
             >
               ${cell ? renderBoardMiniCard(cell) : `<span class="empty-plus">+</span>`}
@@ -569,39 +570,25 @@ export function initOnlineGameGlobals() {
 	}
 
 	// Draft: click card to pick (store) — Sushi Go style, like offline mode
-	document.querySelectorAll("[data-online-draft-pick]").forEach((el) => {
+	document.querySelectorAll("[data-draft-card-id]").forEach((el) => {
 		el.addEventListener("click", (e) => {
 			e.stopPropagation();
 			const cardId = (e.currentTarget as HTMLElement).getAttribute(
-				"data-online-draft-pick",
+				"data-draft-card-id",
 			);
 			if (cardId) handleOnlineDraftCard(cardId, "store");
 		});
 	});
 
 	// Placement: select card from hand
-	document.querySelectorAll("[data-online-select]").forEach((el) => {
+	document.querySelectorAll("[data-hand-card-id]").forEach((el) => {
 		el.addEventListener("click", (e) => {
 			const cardId = (e.currentTarget as HTMLElement).getAttribute(
-				"data-online-select",
+				"data-hand-card-id",
 			);
 			if (!cardId) return;
 			_selectedOnlineCardId = cardId;
 			rerenderOnlineGame();
-		});
-	});
-
-	// Placement: drag start for discard
-	document.querySelectorAll("[data-hand-card-id]").forEach((el) => {
-		el.addEventListener("dragstart", (e) => {
-			const cardId = el.getAttribute("data-hand-card-id");
-			if (cardId) {
-				const dragEvent = e as DragEvent;
-				if (dragEvent.dataTransfer) {
-					dragEvent.dataTransfer.setData("text/plain", cardId);
-					dragEvent.dataTransfer.effectAllowed = "move";
-				}
-			}
 		});
 	});
 
@@ -617,13 +604,11 @@ export function initOnlineGameGlobals() {
 	});
 
 	// Placement: board cell click (place or select cell)
-	document.querySelectorAll("[data-online-board]").forEach((el) => {
+	document.querySelectorAll("[data-board-cell]").forEach((el) => {
 		el.addEventListener("click", (e) => {
-			const coords = (e.currentTarget as HTMLElement).getAttribute(
-				"data-online-board",
-			);
-			if (!coords || !_selectedOnlineCardId) return;
-			const [rowStr] = coords.split(",");
+			const cellEl = e.currentTarget as HTMLElement;
+			const rowStr = cellEl.getAttribute("data-row-index");
+			if (!rowStr || !_selectedOnlineCardId) return;
 			const row = Number(rowStr);
 			if (!Number.isInteger(row)) return;
 			handleOnlinePlaceCardOnBoard(_selectedOnlineCardId, row);
@@ -645,37 +630,11 @@ export function initOnlineGameGlobals() {
 		});
 	});
 
-	// Discard zone - handle drop events
-	document
-		.querySelectorAll("[data-discard-drop-zone='true']")
-		.forEach((zone) => {
-			zone.addEventListener("dragover", (e) => {
-				e.preventDefault(); // Allow drop
-				const canDiscard = () => {
-					const phase = getCurrentGameSnapshot()?.phase;
-					return phase === "placement" && !getIsInitialDealInProgress();
-				};
-				if (canDiscard()) {
-					zone.classList.add("deck-pile-panel--discard-hover");
-				}
-			});
-
-			zone.addEventListener("dragleave", () => {
-				zone.classList.remove("deck-pile-panel--discard-hover");
-			});
-
-			zone.addEventListener("drop", (e) => {
-				e.preventDefault();
-				zone.classList.remove("deck-pile-panel--discard-hover");
-
-				// Get the card ID from the data-transfer
-				const dragEvent = e as DragEvent;
-				const cardId = dragEvent.dataTransfer?.getData("text/plain");
-				if (cardId) {
-					handleOnlineDiscardCard(cardId);
-				}
-			});
-		});
+	// Register global discard handler so the unified pointer drag system
+	// (handleHandPointerUp in app.ts) routes discard via online RPC.
+	(globalThis as any).handleDiscardCard = (cardId: string) => {
+		if (cardId) handleOnlineDiscardCard(cardId);
+	};
 
 	// Animation updates - call after each render to check for animation triggers
 	updateOnlineGameAnimations();

--- a/src/screens/onlineGame.ts
+++ b/src/screens/onlineGame.ts
@@ -35,7 +35,9 @@ import {
 	setPlacementTimerId,
 	setRemainingTurnSeconds,
 	setDraftPickSecondsLeft,
+	getPlayerHand,
 } from "../state.ts";
+import { detectHandTransition } from "../services/animation-controller.ts";
 import { DEAL_ANIMATION_MS } from "../shared/animations.ts";
 import {
 	DRAFT_PICK_SECONDS,
@@ -67,8 +69,7 @@ function updateTimerDom(): void {
 	});
 }
 
-// Animation state tracking for online mode
-let wasHandEmpty = true;
+// Animation state tracking is handled by animation-controller.ts
 
 // ── Main entry ──────────────────────────────────────────────────────────────
 
@@ -669,13 +670,11 @@ function updateOnlineGameAnimations(): void {
 	const snapshot = getCurrentGameSnapshot();
 	if (!snapshot) return;
 
-	const handEl = document.querySelector(".player-hand--draft");
-	const hadHandCards = wasHandEmpty === false; // Previous state
-	const hasHandCards = handEl?.querySelector(".hand-card") !== null;
+	// Use shared animation controller (module-level variable, not DOM query)
+	const transition = detectHandTransition(getPlayerHand().length);
 
 	if (snapshot.phase === "draft") {
-		if (hasHandCards && !hadHandCards) {
-			// Pass complete — new cards just arrived. Play deal animation.
+		if (transition.type === "deal") {
 			playGameSound("deal");
 			setIsPassingDraftCards(false);
 			setIsInitialDealInProgress(true);
@@ -697,15 +696,12 @@ function updateOnlineGameAnimations(): void {
 			}, DEAL_ANIMATION_MS);
 		}
 
-		if (!hasHandCards && hadHandCards) {
-			// Hand just got emptied — player picked, remaining cards passed back.
-			// Play pass animation.
+		if (transition.type === "pass") {
 			setIsPassingDraftCards(true);
 		}
 
-		// Fallback: cards are in the DOM but no timer running (e.g., DOM wasn't
-		// ready during the first call, or refresh after transitionToScreen).
-		if (hasHandCards) {
+		// Fallback: cards present but no timer running
+		if (getPlayerHand().length > 0) {
 			const timerId = getDraftTimerId();
 			if (timerId === null) {
 				startOnlineDraftTimer();
@@ -729,8 +725,6 @@ function updateOnlineGameAnimations(): void {
 		stopOnlinePlacementTimer();
 	}
 
-	// Update hand empty state for next comparison
-	wasHandEmpty = !hasHandCards;
 }
 
 // Draft timer functions for online mode

--- a/src/screens/onlineGame.ts
+++ b/src/screens/onlineGame.ts
@@ -26,6 +26,51 @@ import {
 	TIME_SLOTS,
 	SLOT_NAMES,
 } from "../shared/board.ts";
+import { playGameSound } from "../audio/gameAudio.ts";
+import {
+	getIsInitialDealInProgress,
+	setIsInitialDealInProgress,
+	setIsPassingDraftCards,
+	getDraftTimerId,
+	setDraftTimerId,
+	getPlacementTimerId,
+	setPlacementTimerId,
+	setRemainingTurnSeconds,
+	setDraftPickSecondsLeft,
+} from "../state.ts";
+import { DEAL_ANIMATION_MS } from "../shared/animations.ts";
+import {
+	DRAFT_PICK_SECONDS,
+	TURN_DURATION_SECONDS,
+} from "../shared/constants.ts";
+import { TIMER_TICK_INTERVAL_MS } from "../shared/animations.ts";
+
+// ── Local timer DOM update (avoids circular dependency with router.ts) ──────
+
+function updateTimerDom(): void {
+	const timerEl = document.querySelector(".score-breakdown__timer");
+	if (!timerEl) return;
+	const strongEl = timerEl.querySelector("strong");
+	if (!strongEl) return;
+
+	import("../state.ts").then((s) => {
+		const phase = s.getGamePhase();
+		if (phase === "draft") {
+			const secs = s.getDraftPickSecondsLeft();
+			strongEl.textContent = `${secs}s`;
+			timerEl.classList.toggle("score-breakdown__timer--danger", secs <= 3);
+		} else if (phase === "placement") {
+			const secs = s.getRemainingTurnSeconds();
+			const m = Math.floor(Math.max(0, secs) / 60);
+			const safeSec = Math.max(0, secs) % 60;
+			strongEl.textContent = `${m}:${safeSec < 10 ? "0" : ""}${safeSec}`;
+			timerEl.classList.toggle("score-breakdown__timer--danger", secs <= 10);
+		}
+	});
+}
+
+// Animation state tracking for online mode
+let wasHandEmpty = true;
 
 // ── Main entry ──────────────────────────────────────────────────────────────
 
@@ -326,7 +371,7 @@ function renderOnlinePlacementContent(
 						const isSelected = selectedId === card.card_id;
 						return `
             <div class="online-placement-card" data-online-select="${card.card_id}">
-              <div class="placement-card ${isSelected ? "placement-card--selected" : ""}" data-hand-card-id="${card.card_id}">
+              <div class="placement-card ${isSelected ? "placement-card--selected" : ""}" data-hand-card-id="${card.card_id}" draggable="true">
                 ${renderHandCard(card, idx, isSelected ? card.card_id : null)}
               </div>
               <button class="online-placement-card__place" data-online-place="${card.card_id}">📌 Đặt</button>
@@ -357,6 +402,26 @@ function renderOnlinePlacementContent(
     `
 				: ""
 		}
+
+    {/* Discard zone */}
+    <section
+      class="deck-pile-panel"
+      data-discard-drop-zone="true"
+      title="Kéo thả lá bài trên tay vào đây để discard và nhận lại Xu/Thể lực bằng chi phí của lá."
+    >
+      <div class="deck-pile-panel__visual">
+        <div class="deck-card-stack">
+          <div class="deck-card-stack__card deck-card-stack__card--back-3"></div>
+          <div class="deck-card-stack__card deck-card-stack__card--back-2"></div>
+          <div class="deck-card-stack__card deck-card-stack__card--back-1"></div>
+          <div class="deck-card-stack__card deck-card-stack__card--front">
+            <span>CÒN</span>
+            <strong>${getCurrentCards()?.length}</strong>
+            <em>lá</em>
+          </div>
+        </div>
+      </div>
+    </section>
 
     <div class="online-placement-actions">
       <button class="btn btn--primary" id="online-confirm-day-btn">✅ Kết thúc ngày ${currentDay}</button>
@@ -527,6 +592,20 @@ export function initOnlineGameGlobals() {
 		});
 	});
 
+	// Placement: drag start for discard
+	document.querySelectorAll("[data-hand-card-id]").forEach((el) => {
+		el.addEventListener("dragstart", (e) => {
+			const cardId = el.getAttribute("data-hand-card-id");
+			if (cardId) {
+				const dragEvent = e as DragEvent;
+				if (dragEvent.dataTransfer) {
+					dragEvent.dataTransfer.setData("text/plain", cardId);
+					dragEvent.dataTransfer.effectAllowed = "move";
+				}
+			}
+		});
+	});
+
 	// Placement: place button
 	document.querySelectorAll("[data-online-place]").forEach((btn) => {
 		btn.addEventListener("click", (e) => {
@@ -589,6 +668,194 @@ export function initOnlineGameGlobals() {
 			}
 		});
 	});
+
+	// Discard zone - handle drop events
+	document.querySelectorAll("[data-discard-drop-zone='true']").forEach((zone) => {
+		zone.addEventListener("dragover", (e) => {
+			e.preventDefault(); // Allow drop
+			const canDiscard = () => {
+				const phase = getCurrentGameSnapshot()?.phase;
+				return phase === "placement" && !getIsInitialDealInProgress();
+			};
+			if (canDiscard()) {
+				zone.classList.add("deck-pile-panel--discard-hover");
+			}
+		});
+		
+		zone.addEventListener("dragleave", () => {
+			zone.classList.remove("deck-pile-panel--discard-hover");
+		});
+		
+		zone.addEventListener("drop", (e) => {
+			e.preventDefault();
+			zone.classList.remove("deck-pile-panel--discard-hover");
+			
+			// Get the card ID from the data-transfer
+			const dragEvent = e as DragEvent;
+			const cardId = dragEvent.dataTransfer?.getData("text/plain");
+			if (cardId) {
+				handleOnlineDiscardCard(cardId);
+			}
+		});
+	});
+
+	// Animation updates - call after each render to check for animation triggers
+	updateOnlineGameAnimations();
+}
+
+/**
+ * Update animation state based on current game state.
+ * This should be called after each render to check for animation triggers.
+ */
+function updateOnlineGameAnimations(): void {
+	const snapshot = getCurrentGameSnapshot();
+	if (!snapshot) return;
+
+	const handEl = document.querySelector(".player-hand--draft");
+	const hadHandCards = wasHandEmpty === false; // Previous state
+	const hasHandCards = handEl?.querySelector(".hand-card") !== null;
+
+	if (snapshot.phase === "draft") {
+		if (hasHandCards && !hadHandCards) {
+			// Pass complete — new cards just arrived. Play deal animation.
+			playGameSound("deal");
+			setIsPassingDraftCards(false);
+			setIsInitialDealInProgress(true);
+
+			const hand = document.querySelector(".player-hand--draft");
+			hand?.classList.add("deal-active");
+
+			window.setTimeout(() => {
+				setIsInitialDealInProgress(false);
+				const hand = document.querySelector(".player-hand");
+				hand?.classList.remove(
+					"player-hand--dealing",
+					"is-dealing",
+					"deal-active",
+				);
+
+				// Start draft pick timer after deal animation completes
+				startOnlineDraftTimer();
+			}, DEAL_ANIMATION_MS);
+		}
+
+		if (!hasHandCards && hadHandCards) {
+			// Hand just got emptied — player picked, remaining cards passed back.
+			// Play pass animation.
+			setIsPassingDraftCards(true);
+		}
+
+		// Fallback: cards are in the DOM but no timer running (e.g., DOM wasn't
+		// ready during the first call, or refresh after transitionToScreen).
+		if (hasHandCards) {
+			const timerId = getDraftTimerId();
+			if (timerId === null) {
+				startOnlineDraftTimer();
+			}
+		}
+	} else {
+		// Not in draft — clear the draft timer
+		stopOnlineDraftTimer();
+	}
+
+	// Update placement timer
+	if (snapshot.phase === "placement") {
+		const myPlayer = snapshot.players.find(
+			(p) => p.playerId === getCurrentPlayerId(),
+		);
+		if (myPlayer && !myPlayer.ready) {
+			setRemainingTurnSeconds(TURN_DURATION_SECONDS);
+			startOnlinePlacementTimer();
+		}
+	} else {
+		stopOnlinePlacementTimer();
+	}
+
+	// Update hand empty state for next comparison
+	wasHandEmpty = !hasHandCards;
+}
+
+// Draft timer functions for online mode
+function startOnlineDraftTimer(): void {
+	stopOnlineDraftTimer();
+
+	const hand =
+		getCurrentCards()?.filter(
+			(c) =>
+				getCurrentGameSnapshot()
+					?.players.find((p) => p.playerId === getCurrentPlayerId())
+					?.hand.includes(c.card_id) ?? [],
+		) ?? [];
+
+	if (hand.length === 0) return;
+
+	// Guard: only start the timer if we're still in the draft phase
+	const snapshot = getCurrentGameSnapshot();
+	if (!snapshot || snapshot.phase !== "draft") return;
+
+	let secondsLeft = DRAFT_PICK_SECONDS;
+	setDraftPickSecondsLeft(secondsLeft);
+
+	const timerId = window.setInterval(() => {
+		secondsLeft--;
+		setDraftPickSecondsLeft(secondsLeft);
+		updateTimerDom();
+
+		if (secondsLeft <= 0) {
+			stopOnlineDraftTimer();
+
+			// Auto-pick the first card in hand
+			const firstCard = hand[0];
+			if (firstCard) {
+				// Re-check phase — the game may have transitioned since the timer started
+				const currentSnapshot = getCurrentGameSnapshot();
+				if (!currentSnapshot || currentSnapshot.phase !== "draft") return;
+				handleOnlineDraftCard(firstCard.card_id, "store");
+			}
+		}
+	}, TIMER_TICK_INTERVAL_MS);
+
+	setDraftTimerId(timerId);
+}
+
+function stopOnlineDraftTimer(): void {
+	const id = getDraftTimerId();
+	if (id !== null) {
+		clearInterval(id);
+		setDraftTimerId(null);
+	}
+}
+
+// Placement timer functions for online mode
+function startOnlinePlacementTimer(): void {
+	stopOnlinePlacementTimer();
+
+	let secondsLeft = TURN_DURATION_SECONDS;
+	setRemainingTurnSeconds(secondsLeft);
+
+	const timerId = window.setInterval(() => {
+		secondsLeft--;
+		setRemainingTurnSeconds(secondsLeft);
+		updateTimerDom();
+
+		if (secondsLeft <= 0) {
+			stopOnlinePlacementTimer();
+
+			if (getCurrentGameSnapshot()) {
+				handleOnlineConfirmDay();
+			}
+		}
+	}, TIMER_TICK_INTERVAL_MS);
+
+	setPlacementTimerId(timerId);
+}
+
+function stopOnlinePlacementTimer(): void {
+	const id = getPlacementTimerId();
+	if (id !== null) {
+		clearInterval(id);
+		setPlacementTimerId(null);
+	}
 }
 
 function rerenderOnlineGame(): void {
@@ -658,5 +925,19 @@ async function handleOnlineConfirmDay(): Promise<void> {
 	} catch (err: unknown) {
 		const msg = err instanceof Error ? err.message : String(err);
 		console.warn("[onlineGame] confirmDay failed:", msg);
+	}
+}
+
+// Discard card from hand to deck (rest action)
+async function handleOnlineDiscardCard(cardId: string): Promise<void> {
+	const snapshot = getCurrentGameSnapshot();
+	if (!snapshot) return;
+
+	try {
+		await rpcCall("draftCard", { cardId, mode: "rest" });
+		_selectedOnlineCardId = null;
+	} catch (err: unknown) {
+		const msg = err instanceof Error ? err.message : String(err);
+		console.warn("[onlineGame] discardCard failed:", msg);
 	}
 }

--- a/src/screens/onlineGame.ts
+++ b/src/screens/onlineGame.ts
@@ -15,7 +15,6 @@ import {
 	getCurrentCards,
 	getCurrentPlayerId,
 	sendPayDebt,
-	sendReturnBoardCard,
 } from "../online/lobbyClient.ts";
 import { rpcCall } from "../online/socketClient.ts";
 import { renderHandCard, renderBoardMiniCard } from "../arena/render.ts";
@@ -639,65 +638,44 @@ export function initOnlineGameGlobals() {
 		});
 	}
 
-	// Pay debt buttons
+	// Pay debt buttons — pays 10xu to reduce debt counter
 	document.querySelectorAll("[data-online-pay-debt]").forEach((btn) => {
-		btn.addEventListener("click", (e) => {
-			const day = Number(
-				(e.currentTarget as HTMLElement).getAttribute("data-card-day"),
-			);
-			const slot = (e.currentTarget as HTMLElement).getAttribute(
-				"data-card-slot",
-			);
-			if (day && slot) {
-				(sendPayDebt as (day: number, slot: string) => void)(day, slot);
-			}
-		});
-	});
-
-	// Return board card buttons
-	document.querySelectorAll("[data-online-return-card]").forEach((btn) => {
-		btn.addEventListener("click", (e) => {
-			const day = Number(
-				(e.currentTarget as HTMLElement).getAttribute("data-card-day"),
-			);
-			const slot = (e.currentTarget as HTMLElement).getAttribute(
-				"data-card-slot",
-			);
-			if (day && slot) {
-				(sendReturnBoardCard as (day: number, slot: string) => void)(day, slot);
-			}
+		btn.addEventListener("click", () => {
+			sendPayDebt(10);
 		});
 	});
 
 	// Discard zone - handle drop events
-	document.querySelectorAll("[data-discard-drop-zone='true']").forEach((zone) => {
-		zone.addEventListener("dragover", (e) => {
-			e.preventDefault(); // Allow drop
-			const canDiscard = () => {
-				const phase = getCurrentGameSnapshot()?.phase;
-				return phase === "placement" && !getIsInitialDealInProgress();
-			};
-			if (canDiscard()) {
-				zone.classList.add("deck-pile-panel--discard-hover");
-			}
+	document
+		.querySelectorAll("[data-discard-drop-zone='true']")
+		.forEach((zone) => {
+			zone.addEventListener("dragover", (e) => {
+				e.preventDefault(); // Allow drop
+				const canDiscard = () => {
+					const phase = getCurrentGameSnapshot()?.phase;
+					return phase === "placement" && !getIsInitialDealInProgress();
+				};
+				if (canDiscard()) {
+					zone.classList.add("deck-pile-panel--discard-hover");
+				}
+			});
+
+			zone.addEventListener("dragleave", () => {
+				zone.classList.remove("deck-pile-panel--discard-hover");
+			});
+
+			zone.addEventListener("drop", (e) => {
+				e.preventDefault();
+				zone.classList.remove("deck-pile-panel--discard-hover");
+
+				// Get the card ID from the data-transfer
+				const dragEvent = e as DragEvent;
+				const cardId = dragEvent.dataTransfer?.getData("text/plain");
+				if (cardId) {
+					handleOnlineDiscardCard(cardId);
+				}
+			});
 		});
-		
-		zone.addEventListener("dragleave", () => {
-			zone.classList.remove("deck-pile-panel--discard-hover");
-		});
-		
-		zone.addEventListener("drop", (e) => {
-			e.preventDefault();
-			zone.classList.remove("deck-pile-panel--discard-hover");
-			
-			// Get the card ID from the data-transfer
-			const dragEvent = e as DragEvent;
-			const cardId = dragEvent.dataTransfer?.getData("text/plain");
-			if (cardId) {
-				handleOnlineDiscardCard(cardId);
-			}
-		});
-	});
 
 	// Animation updates - call after each render to check for animation triggers
 	updateOnlineGameAnimations();
@@ -883,11 +861,43 @@ async function handleOnlinePlaceCard(cardId: string): Promise<void> {
 	const snapshot = getCurrentGameSnapshot();
 	if (!snapshot) return;
 
+	// Find the first available slot in the current day
+	let slotName: string | undefined = undefined;
+	const myPlayer = snapshot.players.find(
+		(p) => p.playerId === getCurrentPlayerId(),
+	);
+	if (myPlayer) {
+		const boardSlots = boardCellsToSlots(
+			myPlayer.board,
+			getCurrentCards() ?? [],
+		);
+		const currentDayIndex = snapshot.day - 1; // Convert to 0-based index
+
+		// Check each slot in the current day for availability
+		for (let rowIndex = 0; rowIndex < TIME_SLOTS.length; rowIndex++) {
+			const slot = TIME_SLOTS[rowIndex];
+			const cell = boardSlots[rowIndex]?.[currentDayIndex];
+			if (cell === null) {
+				// Found an empty slot
+				slotName = slot;
+				break;
+			}
+		}
+	}
+
+	if (!slotName) {
+		// No available slots - fall back to morning as before (but warn)
+		console.warn(
+			"[onlineGame] No available slots in current day, falling back to morning",
+		);
+		slotName = "morning";
+	}
+
 	try {
 		await rpcCall("placeCard", {
 			cardId,
 			day: snapshot.day,
-			slot: "morning",
+			slot: slotName,
 		});
 		_selectedOnlineCardId = null;
 	} catch (err: unknown) {
@@ -934,7 +944,7 @@ async function handleOnlineDiscardCard(cardId: string): Promise<void> {
 	if (!snapshot) return;
 
 	try {
-		await rpcCall("draftCard", { cardId, mode: "rest" });
+		await rpcCall("discardChosenCard", { cardId });
 		_selectedOnlineCardId = null;
 	} catch (err: unknown) {
 		const msg = err instanceof Error ? err.message : String(err);

--- a/src/screens/onlineGame.ts
+++ b/src/screens/onlineGame.ts
@@ -19,11 +19,7 @@ import {
 import { rpcCall } from "../online/socketClient.ts";
 import { renderHandCard, renderBoardGrid } from "../arena/render.ts";
 import type { RoomSnapshot, TravelCard, PlayerState } from "../shared/types.ts";
-import {
-	boardCellsToSlots,
-	DAYS,
-	TIME_SLOTS,
-} from "../shared/board.ts";
+import { boardCellsToSlots, DAYS, TIME_SLOTS } from "../shared/board.ts";
 import { playGameSound } from "../audio/gameAudio.ts";
 import {
 	setIsInitialDealInProgress,
@@ -40,10 +36,7 @@ import {
 } from "../services/game-timer.ts";
 import { detectHandTransition } from "../services/animation-controller.ts";
 import { DEAL_ANIMATION_MS } from "../shared/animations.ts";
-import {
-	TURN_DURATION_SECONDS,
-} from "../shared/constants.ts";
-
+import { TURN_DURATION_SECONDS } from "../shared/constants.ts";
 
 // Timer DOM updates are handled by the shared game-timer.ts module.
 // Animation state tracking is handled by animation-controller.ts
@@ -138,13 +131,17 @@ function renderOnlineGameArenaShell(
 								`<div class="day-pill ${index === snapshot.day - 1 ? "day-pill--current" : ""} ${index < snapshot.day - 1 ? "day-pill--done" : ""}">NGÀY ${day}</div>`,
 						).join("")}
           </div>
-          ${phase === "placement" || phase === "scoring" ? renderBoardGrid(
-					boardCellsToSlots(myPlayer.board, cards()),
-					snapshot.day - 1,
-					false,
-					false,
-					phase === "placement" ? getOnlineSelectedCardId() : null,
-				) : ""}
+          ${
+						phase === "placement" || phase === "scoring"
+							? renderBoardGrid(
+									boardCellsToSlots(myPlayer.board, cards()),
+									snapshot.day - 1,
+									false,
+									false,
+									phase === "placement" ? getOnlineSelectedCardId() : null,
+								)
+							: ""
+					}
         </div>
 
         <div class="online-content-area">

--- a/src/services/animation-controller.ts
+++ b/src/services/animation-controller.ts
@@ -1,0 +1,56 @@
+/**
+ * animation-controller.ts — Shared deal/pass animation detection.
+ *
+ * Both SP (localRoom.ts) and online (onlineGame.ts) modes call
+ * `detectHandTransition()` with the current card count.
+ * The function returns which animation to play, using a module-level
+ * `wasHandEmpty` variable (the proven online pattern) instead of
+ * querying the DOM (the broken SP pattern).
+ */
+
+/**
+ * The set of animation state flags that can be set by detectHandTransition.
+ * The caller (localRoom.ts / onlineGame.ts) applies these to state.ts
+ * and optionally fires callbacks (play sound, start timer).
+ */
+export interface HandTransition {
+	type: "deal" | "pass" | "none";
+	isDealing: boolean;
+	isPassing: boolean;
+}
+
+let wasHandEmpty = true;
+
+/**
+ * Detect deal/pass transitions using module-level variable (NOT DOM query).
+ *
+ * @param currentCardCount — number of cards currently in hand or draft pool
+ * @returns which animation to play and the corresponding state.ts flags
+ */
+export function detectHandTransition(currentCardCount: number): HandTransition {
+	const wasEmpty = wasHandEmpty;
+	const isEmpty = currentCardCount === 0;
+
+	// Update for next call
+	wasHandEmpty = isEmpty;
+
+	// Transition from empty → has cards: deal animation
+	if (!isEmpty && wasEmpty) {
+		return { type: "deal", isDealing: true, isPassing: false };
+	}
+
+	// Transition from has cards → empty: pass animation (player picked, rest sent)
+	if (isEmpty && !wasEmpty) {
+		return { type: "pass", isDealing: false, isPassing: true };
+	}
+
+	// No transition
+	return { type: "none", isDealing: false, isPassing: false };
+}
+
+/**
+ * Reset the module-level tracking (e.g., when starting a new game).
+ */
+export function resetAnimationState(): void {
+	wasHandEmpty = true;
+}

--- a/src/services/game-timer.ts
+++ b/src/services/game-timer.ts
@@ -7,7 +7,10 @@
  */
 
 import { TIMER_TICK_INTERVAL_MS } from "../shared/animations.ts";
-import { DRAFT_PICK_SECONDS, TURN_DURATION_SECONDS } from "../shared/constants.ts";
+import {
+	DRAFT_PICK_SECONDS,
+	TURN_DURATION_SECONDS,
+} from "../shared/constants.ts";
 import { updateTimerDom } from "../router.ts";
 
 // ── Types ──────────────────────────────────────────────────────────────────

--- a/src/services/game-timer.ts
+++ b/src/services/game-timer.ts
@@ -1,0 +1,144 @@
+/**
+ * game-timer.ts — Shared draft/placement timer management.
+ *
+ * Both SP (localRoom.ts) and online (onlineGame.ts) modes import this
+ * module for timer lifecycle. The onExpiry callback lets each mode
+ * handle timeout differently (auto-draft vs auto-pick via RPC).
+ */
+
+import { TIMER_TICK_INTERVAL_MS } from "../shared/animations.ts";
+import { DRAFT_PICK_SECONDS, TURN_DURATION_SECONDS } from "../shared/constants.ts";
+import { updateTimerDom } from "../router.ts";
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export type TimerTickHandler = (secondsLeft: number) => void;
+export type TimerExpiryHandler = () => void;
+
+// ── Module-level state ─────────────────────────────────────────────────────
+
+let draftTimerId: number | null = null;
+let placementTimerId: number | null = null;
+
+// ── Draft timer ────────────────────────────────────────────────────────────
+
+/**
+ * Start the draft turn countdown.
+ * Calls updateTimerDom() on each tick and the expiry callback when time runs out.
+ *
+ * @param onExpiry — Called when the timer reaches 0.
+ * @param onTick — Optional custom tick handler; runs AFTER updateTimerDom().
+ */
+export function startDraftTimer(
+	onExpiry: TimerExpiryHandler,
+	onTick?: TimerTickHandler,
+): void {
+	stopDraftTimer();
+
+	let secondsLeft = DRAFT_PICK_SECONDS;
+	setDraftPickSecondsLocal(secondsLeft);
+
+	draftTimerId = window.setInterval(() => {
+		secondsLeft--;
+		setDraftPickSecondsLocal(secondsLeft);
+		updateTimerDom();
+		onTick?.(secondsLeft);
+
+		if (secondsLeft <= 0) {
+			stopDraftTimer();
+			onExpiry();
+		}
+	}, TIMER_TICK_INTERVAL_MS);
+}
+
+/**
+ * Stop the draft timer if running.
+ */
+export function stopDraftTimer(): void {
+	if (draftTimerId !== null) {
+		clearInterval(draftTimerId);
+		draftTimerId = null;
+	}
+}
+
+/**
+ * Check if the draft timer is currently running.
+ */
+export function isDraftTimerRunning(): boolean {
+	return draftTimerId !== null;
+}
+
+// ── Placement timer ────────────────────────────────────────────────────────
+
+/**
+ * Start the placement turn countdown.
+ *
+ * @param onExpiry — Called when the timer reaches 0.
+ * @param onTick — Optional custom tick handler.
+ */
+export function startPlacementTimer(
+	onExpiry: TimerExpiryHandler,
+	onTick?: TimerTickHandler,
+): void {
+	stopPlacementTimer();
+
+	let secondsLeft = TURN_DURATION_SECONDS;
+	setRemainingTurnSecondsLocal(secondsLeft);
+
+	placementTimerId = window.setInterval(() => {
+		secondsLeft--;
+		setRemainingTurnSecondsLocal(secondsLeft);
+		updateTimerDom();
+		onTick?.(secondsLeft);
+
+		if (secondsLeft <= 0) {
+			stopPlacementTimer();
+			onExpiry();
+		}
+	}, TIMER_TICK_INTERVAL_MS);
+}
+
+/**
+ * Stop the placement timer if running.
+ */
+export function stopPlacementTimer(): void {
+	if (placementTimerId !== null) {
+		clearInterval(placementTimerId);
+		placementTimerId = null;
+	}
+}
+
+/**
+ * Check if the placement timer is currently running.
+ */
+export function isPlacementTimerRunning(): boolean {
+	return placementTimerId !== null;
+}
+
+/**
+ * Clear both timers (used on game cleanup / phase transition).
+ */
+export function clearAllTimers(): void {
+	stopDraftTimer();
+	stopPlacementTimer();
+}
+
+// ── Direct state access (avoids circular dependency with state.ts) ──────────
+
+import { setDraftPickSecondsLeft, setRemainingTurnSeconds } from "../state.ts";
+
+function setDraftPickSecondsLocal(s: number): void {
+	try {
+		setDraftPickSecondsLeft(s);
+	} catch {
+		// state.ts may not be fully initialised during cleanup
+	}
+}
+
+function setRemainingTurnSecondsLocal(s: number): void {
+	try {
+		setRemainingTurnSeconds(s);
+	} catch {
+		// state.ts may not be fully initialised during cleanup
+	}
+}

--- a/src/state.ts
+++ b/src/state.ts
@@ -465,18 +465,22 @@ export function setPlacementTimerId(id: number | null) {
 let discardedResourceCoinBonus = 0;
 let discardedResourceStaminaBonus = 0;
 
+/** @deprecated Set automatically by syncAllStateFromSnapshot(). */
 export function getDiscardedResourceCoinBonus(): number {
 	return discardedResourceCoinBonus;
 }
 
+/** @deprecated Use syncAllStateFromSnapshot() in snapshotAdapter.ts instead. */
 export function setDiscardedResourceCoinBonus(v: number) {
 	discardedResourceCoinBonus = v;
 }
 
+/** @deprecated Set automatically by syncAllStateFromSnapshot(). */
 export function getDiscardedResourceStaminaBonus(): number {
 	return discardedResourceStaminaBonus;
 }
 
+/** @deprecated Use syncAllStateFromSnapshot() in snapshotAdapter.ts instead. */
 export function setDiscardedResourceStaminaBonus(v: number) {
 	discardedResourceStaminaBonus = v;
 }

--- a/src/state.ts
+++ b/src/state.ts
@@ -448,6 +448,18 @@ export function setSimulationAdvanceTimeoutId(id: number | null) {
 	simulationAdvanceTimeoutId = id;
 }
 
+// ── Timer state ───────────────────────────────────────────────────────────
+
+let placementTimerId: number | null = null;
+
+export function getPlacementTimerId(): number | null {
+	return placementTimerId;
+}
+
+export function setPlacementTimerId(id: number | null) {
+	placementTimerId = id;
+}
+
 // ── Discard resource bonus (refunded from discarded hand cards) ────────────
 
 let discardedResourceCoinBonus = 0;

--- a/src/version.ts
+++ b/src/version.ts
@@ -4,6 +4,6 @@
  * BUILD_TIME is replaced at build time by the bundler (rollup).
  */
 
-export const VERSION = "0.23.0";
+export const VERSION = "0.23.1";
 export const BUILD_TIME = "__BUILD_TIME_PLACEHOLDER__";
 export const APP_NAME = "Trekkopoly";


### PR DESCRIPTION
## Summary

Patch release covering 8 phases of surgical fixes that address root-cause architectural problems identified in `.internal/fix-plan.md`.

### Phase 1 — Dead code
- Removed `refreshLocalSnapshot()` (zero imports), `#test-game` hash bypass duplicate timer
- Deprecated 5 legacy loop functions with `console.warn()` trail

### Phase 2 — Attribute normalisation
- Unified `data-board-cell`/`data-row-index`/`data-col-index` across SP+online
- Restored unified pointer drag (`onpointerdown`), removed HTML5 drag handlers

### Phase 3 — Snapshot sync  
- `syncAllStateFromSnapshot()` now sets all 23 state fields (9-field gap closed)

### Phase 4 — Animation detection
- Shared controller uses module-level `wasHandEmpty` instead of DOM query
- Fixes SP animation bug (always compared identical DOM values)

### Phase 5 — Shared renderBoardGrid
- Extracted shared grid renderer, deleted online duplicate (48 lines)

### Phase 6 — Timer unification
- Central `game-timer.ts` module for both modes, `state.ts` timer ID storage removed
- Verified: correct DRAFT/TIME label per phase, countdown ticks live

### Phase 8 — Cleanup
- Orphan `renderResourceOrbs()` removed, CSS class fix (`orb` → `resource-orb`)

### Tested
End-to-end single-player verified through Day 3: draft→placement→day transition, timer ticks, debt modal, resource orbs, bot progression. Discard zone rendered (pointer-event test limitation).