### PR TITLE
TREKPOLOGY: planning confirm, draft UX, starting stats

### DIFF
--- a/TREKPOLOGY/assets/backgrounds/lobby-background.jpg
+++ b/TREKPOLOGY/assets/backgrounds/lobby-background.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44ab17595eeec3b52034ca866d1ec81ae4e0a3dd07daec2dbead37cf2a8508b0
+size 1238901

--- a/TREKPOLOGY/assets/backgrounds/saigon-collage-hover/backgroundboard.jpg
+++ b/TREKPOLOGY/assets/backgrounds/saigon-collage-hover/backgroundboard.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0466218511275e0c73a830046f7130790ef356740e013852bfdae3f5b91cbac0
+size 1350331

--- a/TREKPOLOGY/index.html
+++ b/TREKPOLOGY/index.html
@@ -3,23 +3,30 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
-  <title>Trekkopoly - Lữ Khách Bàn Cờ</title>
-  
+  <title>TREKPOLOGY - Lữ Khách Bàn Cờ</title>
   <link rel="icon" href="data:,">
-  
   <meta name="theme-color" content="#4e3325">
-  <link rel="manifest" href="./manifest.json">
-
   <link rel="stylesheet" href="./build/client.css">
 </head>
 <body>
-  <div id="app"></div>
-  
-  <video id="cinematic-transition-video" src="/assets/videos/chuyencanh2.mp4" playsinline preload="auto" style="display: none;"></video>
+  <div id="lobby-bg" style="
+    display: none;
+    position: fixed;
+    inset: 0;
+    width: 100vw;
+    height: 100vh;
+    z-index: 0;
+    background-image: url('./assets/backgrounds/lobby-background.jpg');
+    background-size: cover;
+    background-position: center center;
+    background-repeat: no-repeat;
+    image-rendering: -webkit-optimize-contrast;
+    image-rendering: crisp-edges;
+  "></div>
+  <div id="app" style="position: relative; z-index: 1;"></div>
+  <video id="cinematic-transition-video" src="./assets/chuyencanh2.mp4" playsinline preload="auto" style="display: none;"></video>
   <div id="white-flash-overlay" style="display: none;"></div>
-  
   <script src="https://cdn.socket.io/4.8.1/socket.io.min.js"></script>
-  
   <script type="module" src="./build/app.js"></script>
 </body>
 </html>

--- a/TREKPOLOGY/server/draftEngine.ts
+++ b/TREKPOLOGY/server/draftEngine.ts
@@ -3,6 +3,27 @@ import { PLAYER_IDS, shuffleCards } from "./gameEngine.js";
 
 const DRAFT_STARTING_POOL_SIZE = 7;
 const DRAFT_PICK_TARGET = 5;
+const DRAFT_PICK_SECONDS = 90;
+const DRAFT_CENTER_DEAL_CARD_MS = 900;
+const DRAFT_CENTER_DEAL_GAP_MS = 150;
+const DRAFT_CENTER_DEAL_STEP_MS = DRAFT_CENTER_DEAL_CARD_MS + DRAFT_CENTER_DEAL_GAP_MS;
+const DRAFT_PASS_ANIMATION_MS = 1500;
+
+function getDraftCenterDealDurationMs(cardCount: number): number {
+  const n = Math.max(1, Math.min(DRAFT_STARTING_POOL_SIZE, cardCount));
+  return DRAFT_CENTER_DEAL_STEP_MS * (n - 1) + DRAFT_CENTER_DEAL_CARD_MS + 250;
+}
+
+function getDraftDealHoldSeconds(cardCount: number, includePass = false): number {
+  const dealMs = getDraftCenterDealDurationMs(cardCount);
+  const extraMs = includePass ? DRAFT_PASS_ANIMATION_MS + 300 : 300;
+  return Math.max(1, Math.ceil((dealMs + extraMs) / 1000));
+}
+
+function maxDraftPoolSize(state: RoomState, playerIds: PlayerId[]): number {
+  if (playerIds.length === 0) return DRAFT_STARTING_POOL_SIZE;
+  return Math.max(...playerIds.map((id) => state.players[id].draftPool.length), 1);
+}
 
 function getActiveDraftPlayerIds(state: RoomState): PlayerId[] {
   const connectedPlayerIds = PLAYER_IDS.filter((playerId) => {
@@ -30,7 +51,8 @@ function returnCardsToDeck(state: RoomState, cards: ServerTravelCardData[]) {
 export function startDraftForCurrentDay(state: RoomState) {
   state.phase = "draft";
   state.draftRound = 1;
-  state.timer = 10;
+  state.timer = DRAFT_PICK_SECONDS;
+  state.draftTimerHold = getDraftDealHoldSeconds(DRAFT_STARTING_POOL_SIZE);
 
   const activePlayerIds = getActiveDraftPlayerIds(state);
 
@@ -41,6 +63,7 @@ export function startDraftForCurrentDay(state: RoomState) {
     player.pickedDraftCards = [];
     player.hand = [];
     player.selectedDraftCardId = null;
+    player.draftPickConfirmed = false;
   });
 
   /*
@@ -84,6 +107,42 @@ export function selectDraftCard(
   return null;
 }
 
+export function confirmDraftPick(
+  state: RoomState,
+  payload: {
+    playerId: PlayerId;
+  }
+): string | null {
+  if (state.phase !== "draft") {
+    return "Chưa tới phase chia bài.";
+  }
+
+  const player = state.players[payload.playerId];
+
+  if (!player) return "Không tìm thấy người chơi.";
+  if (!player.isConnected) return "Người chơi chưa kết nối.";
+  if (player.selectedDraftCardId === null) {
+    return "Bạn chưa chọn lá bài.";
+  }
+
+  player.draftPickConfirmed = true;
+
+  const activePlayerIds = getActiveDraftPlayerIds(state);
+  const allConfirmed = activePlayerIds.every((playerId) => {
+    const activePlayer = state.players[playerId];
+
+    if (activePlayer.draftPool.length === 0) return true;
+
+    return activePlayer.draftPickConfirmed;
+  });
+
+  if (allConfirmed) {
+    finishDraftRound(state);
+  }
+
+  return null;
+}
+
 export function finishDraftRound(state: RoomState) {
   if (state.phase !== "draft") return;
 
@@ -101,6 +160,7 @@ export function finishDraftRound(state: RoomState) {
     player.pickedDraftCards.push(selectedCard);
     player.draftPool = player.draftPool.filter((card) => card.id !== selectedCard.id);
     player.selectedDraftCardId = null;
+    player.draftPickConfirmed = false;
   }
 
   const everyonePickedEnough = activePlayerIds.every((playerId) => {
@@ -112,27 +172,48 @@ export function finishDraftRound(state: RoomState) {
     return;
   }
 
-  if (activePlayerIds.length === 1) {
-    resetSinglePlayerDraftPool(state, activePlayerIds[0]);
-  } else {
+  if (activePlayerIds.length > 1) {
     rotateDraftPoolsClockwise(state, activePlayerIds);
+  } else {
+    /*
+      Online 1 người: không giữ pool cũ.
+      Trả bài dư về deck rồi random lại pool mới với số lá giảm dần:
+      7 -> pick -> 6 -> pick -> 5 -> pick -> 4 -> pick -> 3.
+    */
+    const onlyPlayerId = activePlayerIds[0];
+    const onlyPlayer = state.players[onlyPlayerId];
+    returnCardsToDeck(state, onlyPlayer.draftPool);
+
+    const nextPoolSize = Math.max(
+      DRAFT_STARTING_POOL_SIZE - onlyPlayer.pickedDraftCards.length,
+      DRAFT_STARTING_POOL_SIZE - DRAFT_PICK_TARGET + 1
+    );
+
+    onlyPlayer.draftPool = drawRandomCardsFromDeck(state, nextPoolSize);
+    onlyPlayer.selectedDraftCardId = null;
+    onlyPlayer.draftPickConfirmed = false;
   }
 
   state.draftRound += 1;
-  state.timer = 10;
+  state.timer = DRAFT_PICK_SECONDS;
+  state.draftTimerHold = getDraftDealHoldSeconds(
+    maxDraftPoolSize(state, activePlayerIds),
+    activePlayerIds.length > 1,
+  );
   logDraftDebug(state, "finishDraftRound");
 }
 
 function resetSinglePlayerDraftPool(state: RoomState, playerId: PlayerId) {
   const player = state.players[playerId];
 
-  /*
-    Chơi 1 người: chọn 1 lá xong thì 6 lá còn lại quay về deck,
-    deck được shuffle lại, rồi roll pool 7 lá mới.
-    Như vậy mỗi lần chọn đều có ý nghĩa, không phải chọn tiếp từ pool cũ.
-  */
   returnCardsToDeck(state, player.draftPool);
-  player.draftPool = drawRandomCardsFromDeck(state, DRAFT_STARTING_POOL_SIZE);
+
+  const nextPoolSize = Math.max(
+    DRAFT_STARTING_POOL_SIZE - player.pickedDraftCards.length,
+    DRAFT_STARTING_POOL_SIZE - DRAFT_PICK_TARGET + 1
+  );
+
+  player.draftPool = drawRandomCardsFromDeck(state, nextPoolSize);
   player.selectedDraftCardId = null;
 }
 
@@ -152,6 +233,7 @@ function rotateDraftPoolsClockwise(state: RoomState, activePlayerIds: PlayerId[]
 function finishDraftAndStartPlanning(state: RoomState) {
   state.phase = "planning";
   state.timer = 60;
+  state.draftTimerHold = 0;
 
   const leftoverDraftCards: ServerTravelCardData[] = [];
 
@@ -164,6 +246,7 @@ function finishDraftAndStartPlanning(state: RoomState) {
     player.pickedDraftCards = player.hand.slice();
     player.draftPool = [];
     player.selectedDraftCardId = null;
+    player.planningConfirmed = false;
   }
 
   returnCardsToDeck(state, leftoverDraftCards);

--- a/TREKPOLOGY/server/gameEngine.ts
+++ b/TREKPOLOGY/server/gameEngine.ts
@@ -2766,6 +2766,9 @@ export function createServerDeck(): ServerCardWithEffect[] {
 }
 
 
+const STARTING_COIN = 30;
+const STARTING_STAMINA = 15;
+
 export function createEmptyPlayer(
   id: PlayerId,
   name: string,
@@ -2776,8 +2779,8 @@ export function createEmptyPlayer(
     name,
     hasJoined: isConnected,
     score: 0,
-    coin: 3,
-    stamina: 2,
+    coin: STARTING_COIN,
+    stamina: STARTING_STAMINA,
     usedSlots: 0,
     coinDebt: 0,
     isConnected,
@@ -2787,6 +2790,7 @@ export function createEmptyPlayer(
     pickedDraftCards: [],
     hand: [],
     selectedDraftCardId: null,
+    planningConfirmed: false,
   };
 }
 
@@ -2811,6 +2815,7 @@ function stripPrivatePlayerState(player: RoomState["players"][PlayerId]) {
     isConnected: player.isConnected,
     isReady: player.isReady,
     hasJoined: player.hasJoined,
+    planningConfirmed: player.planningConfirmed === true,
     board: player.board,
   };
 }

--- a/TREKPOLOGY/server/index.ts
+++ b/TREKPOLOGY/server/index.ts
@@ -6,9 +6,10 @@ import type {
   RoomState,
   ServerToClientEvents,
 } from "./types.js";
-import { finishDraftRound, selectDraftCard } from "./draftEngine.js";
+import { confirmDraftPick, selectDraftCard } from "./draftEngine.js";
 import { getPlayerViewState } from "./gameEngine.js";
 import {
+  confirmPlanning,
   createRoom,
   discardCardFromPlayerHand,
   joinRoom,
@@ -33,6 +34,26 @@ const io = new Server<ClientToServerEvents, ServerToClientEvents>(httpServer, {
 const rooms = new Map<string, RoomState>();
 const socketPlayerIds = new Map<string, PlayerId>();
 const socketRoomIds = new Map<string, string>();
+
+function bindSocketPlayer(
+  socket: { id: string; join: (room: string) => void },
+  payload: { roomId: string; playerId: PlayerId },
+  state: RoomState
+): PlayerId | null {
+  const mappedPlayerId = socketPlayerIds.get(socket.id);
+  const playerId = mappedPlayerId ?? payload.playerId;
+  const player = state.players[playerId];
+
+  if (!player?.isConnected) {
+    return null;
+  }
+
+  socketPlayerIds.set(socket.id, playerId);
+  socketRoomIds.set(socket.id, payload.roomId);
+  socket.join(payload.roomId);
+
+  return playerId;
+}
 
 function emitRoomState(roomId: string) {
   const state = rooms.get(roomId);
@@ -207,12 +228,22 @@ io.on("connection", (socket) => {
       return;
     }
 
-    const everyoneSelected = Object.values(state.players).every((player) => {
-      return player.draftPool.length === 0 || player.selectedDraftCardId !== null;
-    });
+    emitRoomState(payload.roomId);
+  });
 
-    if (everyoneSelected) {
-      finishDraftRound(state);
+  socket.on("draft:confirmPick", (payload) => {
+    const state = rooms.get(payload.roomId);
+
+    if (!state) {
+      socket.emit("game:error", { message: "Không tìm thấy phòng." });
+      return;
+    }
+
+    const error = confirmDraftPick(state, payload);
+
+    if (error) {
+      socket.emit("game:error", { message: error });
+      return;
     }
 
     emitRoomState(payload.roomId);
@@ -290,6 +321,31 @@ io.on("connection", (socket) => {
     emitRoomState(payload.roomId);
   });
 
+  socket.on("planning:confirm", (payload) => {
+    const state = rooms.get(payload.roomId);
+
+    if (!state) {
+      socket.emit("game:error", { message: "Không tìm thấy phòng." });
+      return;
+    }
+
+    const playerId = bindSocketPlayer(socket, payload, state);
+
+    if (!playerId) {
+      socket.emit("game:error", { message: "Người chơi chưa kết nối hoặc không hợp lệ." });
+      return;
+    }
+
+    const error = confirmPlanning(state, { playerId });
+
+    if (error) {
+      socket.emit("game:error", { message: error });
+      return;
+    }
+
+    emitRoomState(payload.roomId);
+  });
+
   socket.on("disconnect", () => {
     const playerId = socketPlayerIds.get(socket.id);
     const roomId = socketRoomIds.get(socket.id);
@@ -298,6 +354,7 @@ io.on("connection", (socket) => {
     if (playerId && state) {
       state.players[playerId].isConnected = false;
       state.players[playerId].isReady = false;
+      state.players[playerId].planningConfirmed = false;
       emitRoomState(roomId!);
     }
 

--- a/TREKPOLOGY/server/package.json
+++ b/TREKPOLOGY/server/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx index.ts"
+    "dev": "tsx index.ts",
+    "start": "tsx index.ts"
   },
   "dependencies": {
     "socket.io": "^4.8.1",

--- a/TREKPOLOGY/server/rooms.ts
+++ b/TREKPOLOGY/server/rooms.ts
@@ -6,8 +6,23 @@ import {
   shuffleCards,
 } from "./gameEngine.js";
 import { startDraftForCurrentDay } from "./draftEngine.js";
+import { advancePlanningToSimulation } from "./timerEngine.js";
 
 const PLAYER_IDS: PlayerId[] = ["p1", "p2", "p3", "p4"];
+
+function getActiveConnectedPlayerIds(state: RoomState): PlayerId[] {
+  const connectedPlayerIds = PLAYER_IDS.filter((playerId) => {
+    const player = state.players[playerId];
+
+    return player.isConnected && player.hasJoined;
+  });
+
+  return connectedPlayerIds.length > 0 ? connectedPlayerIds : ["p1"];
+}
+
+function clearPlayerPlanningConfirmed(player: RoomState["players"][PlayerId]) {
+  player.planningConfirmed = false;
+}
 
 
 type ServerCardEffect = {
@@ -184,6 +199,7 @@ export function createRoom(firstPlayerName: string): {
     dayIndex: 0,
     draftRound: 0,
     timer: 0,
+    draftTimerHold: 0,
     deck: shuffleCards(createServerDeck()),
     players: {
       p1: createEmptyPlayer("p1", firstPlayerName || "An", true),
@@ -354,6 +370,8 @@ export function placeCardOnPlayerBoard(
   if (state.phase !== "planning") return "Chưa tới phase xếp bài.";
   if (payload.colIndex !== state.dayIndex) return "Chỉ được xếp bài vào ngày hiện tại.";
 
+  clearPlayerPlanningConfirmed(player);
+
   const cell = player.board[payload.rowIndex]?.[payload.colIndex];
 
   if (cell === undefined) return "Ô không hợp lệ.";
@@ -442,6 +460,8 @@ export function discardCardFromPlayerHand(
   if (!player) return "Không tìm thấy người chơi.";
   if (state.phase !== "planning") return "Chỉ được discard trong phase xếp bài.";
 
+  clearPlayerPlanningConfirmed(player);
+
   const handIndex = player.hand.findIndex((card) => card.id === payload.cardId);
   const card = handIndex >= 0 ? player.hand[handIndex] : null;
 
@@ -476,6 +496,8 @@ export function payDebtTokenOnBoard(
   if (!player) return "Không tìm thấy người chơi.";
   if (state.phase !== "planning") return "Chỉ được trả nợ trong phase xếp bài.";
 
+  clearPlayerPlanningConfirmed(player);
+
   const debtAmount = player.coinDebt ?? 0;
 
   if (debtAmount <= 0) {
@@ -508,6 +530,8 @@ export function returnBoardCardToPlayerHand(
   if (!player) return "Không tìm thấy người chơi.";
   if (state.phase !== "planning") return "Chỉ được rút bài trong phase xếp bài.";
   if (payload.colIndex !== state.dayIndex) return "Chỉ được rút bài của ngày hiện tại.";
+
+  clearPlayerPlanningConfirmed(player);
 
   const cell = player.board[payload.rowIndex]?.[payload.colIndex];
 
@@ -558,6 +582,35 @@ export function returnBoardCardToPlayerHand(
   player.coin += cell.coin ?? 0;
   player.stamina += cell.stamina ?? 0;
   player.usedSlots = Math.max(0, player.usedSlots - 1);
+
+  return null;
+}
+
+export function confirmPlanning(
+  state: RoomState,
+  payload: {
+    playerId: PlayerId;
+  }
+): string | null {
+  if (state.phase !== "planning") {
+    return "Chưa tới phase xếp bài.";
+  }
+
+  const player = state.players[payload.playerId];
+
+  if (!player) return "Không tìm thấy người chơi.";
+  if (!player.isConnected) return "Người chơi chưa kết nối.";
+
+  player.planningConfirmed = true;
+
+  const activePlayerIds = getActiveConnectedPlayerIds(state);
+  const allConfirmed = activePlayerIds.every((playerId) => {
+    return state.players[playerId].planningConfirmed === true;
+  });
+
+  if (allConfirmed) {
+    advancePlanningToSimulation(state);
+  }
 
   return null;
 }

--- a/TREKPOLOGY/server/timerEngine.ts
+++ b/TREKPOLOGY/server/timerEngine.ts
@@ -2,7 +2,7 @@ import type { PlayerId, RoomState } from "./types.js";
 import { finishDraftRound, startDraftForCurrentDay } from "./draftEngine.js";
 import { PLAYER_IDS, createEmptyBoard, createServerDeck } from "./gameEngine.js";
 
-const SIMULATION_SECONDS = 6;
+export const SIMULATION_SECONDS = 6;
 const RESULT_SECONDS = 3;
 const GAMEOVER_SECONDS = 10;
 const MAX_DAY_INDEX = 4;
@@ -231,6 +231,17 @@ function startNextDayOrFinish(state: RoomState) {
   startDraftForCurrentDay(state);
 }
 
+export function advancePlanningToSimulation(state: RoomState) {
+  if (state.phase !== "planning") return;
+
+  state.phase = "simulation";
+  state.timer = SIMULATION_SECONDS;
+
+  for (const playerId of PLAYER_IDS) {
+    state.players[playerId].planningConfirmed = false;
+  }
+}
+
 export function tickRoom(state: RoomState) {
   if (
     state.phase !== "draft" &&
@@ -240,6 +251,11 @@ export function tickRoom(state: RoomState) {
     state.phase !== "gameover" &&
     state.phase !== "cinematic"
   ) {
+    return;
+  }
+
+  if (state.phase === "draft" && (state.draftTimerHold ?? 0) > 0) {
+    state.draftTimerHold -= 1;
     return;
   }
 
@@ -262,8 +278,7 @@ export function tickRoom(state: RoomState) {
   }
 
   if (state.phase === "planning") {
-    state.phase = "simulation";
-    state.timer = SIMULATION_SECONDS;
+    advancePlanningToSimulation(state);
     return;
   }
 

--- a/TREKPOLOGY/server/types.ts
+++ b/TREKPOLOGY/server/types.ts
@@ -48,6 +48,7 @@ export type PlayerPublicState = {
   isConnected: boolean;
   isReady: boolean;
   hasJoined: boolean;
+  planningConfirmed?: boolean;
   board: PublicBoardCell[][];
 };
 
@@ -56,6 +57,8 @@ export type PlayerPrivateState = PlayerPublicState & {
   pickedDraftCards: ServerTravelCardData[];
   hand: ServerTravelCardData[];
   selectedDraftCardId: string | null;
+  draftPickConfirmed?: boolean;
+  planningConfirmed?: boolean;
 };
 
 export type RoomState = {
@@ -65,6 +68,7 @@ export type RoomState = {
   dayIndex: number;
   draftRound: number;
   timer: number;
+  draftTimerHold: number;
   deck: ServerTravelCardData[];
   players: Record<PlayerId, PlayerPrivateState>;
 };
@@ -112,6 +116,11 @@ export type ClientToServerEvents = {
     cardId: string;
   }) => void;
 
+  "draft:confirmPick": (payload: {
+    roomId: string;
+    playerId: PlayerId;
+  }) => void;
+
   "planning:placeCard": (payload: {
     roomId: string;
     playerId: PlayerId;
@@ -149,6 +158,11 @@ export type ClientToServerEvents = {
     playerId: PlayerId;
     rowIndex: number;
     colIndex: number;
+  }) => void;
+
+  "planning:confirm": (payload: {
+    roomId: string;
+    playerId: PlayerId;
   }) => void;
 };
 

--- a/TREKPOLOGY/src/app.ts
+++ b/TREKPOLOGY/src/app.ts
@@ -1,5 +1,5 @@
 import { renderMapSelectionScreen } from "./ui/mapSelection.js";
-import { initDashboardHub, renderDashboard } from "./ui/dashboard.js";
+import { cleanupDashboardHub, initDashboardHub, renderDashboard } from "./ui/dashboard.js";
 import {
   authClientState,
   createOnlineRoom,
@@ -14,6 +14,8 @@ import {
   reconnectOnlineRoom,
   registerAccount,
   selectOnlineDraftCard,
+  confirmOnlineDraftPick,
+  confirmOnlinePlanning,
   sendDiscardCard,
   sendPayDebt,
   sendPlaceCard,
@@ -26,6 +28,9 @@ import { phase1Cards } from "./data/cards.phase1.js";
 import { mapGameCardToTravelCard } from "./data/cardMapper.js";
 import {
   DRAFT_PICK_SECONDS,
+  DRAFT_CENTER_DEAL_STEP_MS,
+  DRAFT_PASS_ANIMATION_MS,
+  getDraftCenterDealDurationMs,
   HAND_SIZE,
   PHASE_DAYS,
   PLAYER_COUNT,
@@ -88,7 +93,7 @@ const DRAFT_PICK_TARGET = HAND_SIZE;
 
 
 import {
-  type GameSoundName,
+  GameSoundName,
   playGameSound,
   setupGameAudioDelegation,
   playCardThump,
@@ -375,7 +380,42 @@ function getOnlineSelfDraftPool(): TravelCardData[] | null {
 function getOnlineDraftDisplayPool(): TravelCardData[] | null {
   if (!isOnlineRoomActive()) return null;
 
-  return onlineDraftDisplayPool ?? getOnlineSelfDraftPool();
+  const serverPool = getOnlineSelfDraftPool();
+
+  /*
+    Fix online draft bị mất bài ở tab khác:
+    server vẫn có state.self.draftPool nhưng client đôi khi đang giữ
+    onlineDraftDisplayPool rỗng/null do animation/pass state. Khi đó UI không render bài,
+    dù hết giờ server vẫn auto-pick được. Luôn fallback về serverPool nếu có bài.
+  */
+  if (isPassingDraftCards && !isOnlineFinalDraftReturnAnimating) {
+    const passPool = onlineDraftPassSnapshotPool ?? onlineDraftDisplayPool;
+
+    if (passPool && passPool.length > 0) {
+      return passPool;
+    }
+
+    return passPool ?? serverPool;
+  }
+
+  if (
+    (isInitialDealInProgress || isDraftCenterDealing) &&
+    onlineDraftDisplayPool &&
+    onlineDraftDisplayPool.length > 0
+  ) {
+    return onlineDraftDisplayPool;
+  }
+
+  if (onlineDraftDisplayPool && onlineDraftDisplayPool.length > 0) {
+    return onlineDraftDisplayPool;
+  }
+
+  if (serverPool && serverPool.length > 0) {
+    onlineDraftDisplayPool = [...serverPool];
+    return onlineDraftDisplayPool;
+  }
+
+  return onlineDraftDisplayPool ?? serverPool;
 }
 
 function getDraftPoolSignature(cards: TravelCardData[] | null | undefined) {
@@ -389,6 +429,176 @@ function setOnlineDraftDisplayPoolFromServer() {
   onlineDraftPendingPool = null;
 }
 
+function recoverOnlineDraftDisplayAfterTabVisible(reason = "visible-sync") {
+  if (!isOnlineRoomActive()) return false;
+
+  const state = onlineClientState.roomState;
+  if (!state || state.phase !== "draft") return false;
+
+  const serverPool = getOnlineSelfDraftPool();
+  if (!serverPool || serverPool.length === 0) return false;
+
+  const visiblePool =
+    onlineDraftDisplayPool ??
+    onlineDraftPassSnapshotPool ??
+    onlineDraftPendingPool;
+
+  const hasVisibleCards = !!visiblePool && visiblePool.length > 0;
+  const animationExpired = draftDealVisualEndsAt > 0 && Date.now() > draftDealVisualEndsAt + 180;
+  const visualDealStillRunning =
+    isInitialDealInProgress ||
+    isDraftCenterDealing ||
+    isPassingDraftCards ||
+    Date.now() < draftDealVisualEndsAt;
+  const staleAnimation = animationExpired && visualDealStillRunning;
+
+  /*
+    Khi tab bị background, browser pause timer/animation.
+    Nếu focus lại mà server đang có pool thật, ưu tiên hiện bài ngay,
+    không chạy animation chia bài muộn ở tab đó nữa.
+  */
+  if (hasVisibleCards && !staleAnimation && !visualDealStillRunning) return false;
+
+  clearOnlineDraftAnimationTimer();
+  clearDraftCenterDealAnimation();
+
+  onlineDraftDisplayPool = [...serverPool];
+  onlineDraftPassSnapshotPool = null;
+  onlineDraftPendingPool = null;
+  draftHandPendingCardId = null;
+  draftPoolFlyReturnCardId = null;
+
+  isPassingDraftCards = false;
+  isInitialDealInProgress = false;
+  shouldActivateOnlineDealAnimation = false;
+  shouldActivateOnlinePassAnimation = false;
+  draftDealVisualEndsAt = 0;
+
+  draftSelectedCardId = state.self.selectedDraftCardId ?? null;
+  lastOnlineRenderSignature = "";
+
+  console.debug(`[DRAFT SYNC] recovered draft pool after tab visible: ${reason}`, {
+    poolSize: serverPool.length,
+    timer: state.timer,
+    round: state.draftRound,
+  });
+
+  return true;
+}
+
+function syncOnlineDraftDisplayAfterTabVisible() {
+  if (document.visibilityState !== "visible") return;
+
+  if (recoverOnlineDraftDisplayAfterTabVisible("visibility/focus")) {
+    rerenderGameShell();
+  }
+}
+
+function isOnlineInterRoundPoolPassActive(): boolean {
+  return isPassingDraftCards && !isOnlineFinalDraftReturnAnimating;
+}
+
+function getDraftCenterDealCardCount(): number {
+  if (isOnlineRoomActive()) {
+    const pool =
+      onlineDraftDisplayPool ??
+      onlineDraftPendingPool ??
+      getOnlineSelfDraftPool() ??
+      [];
+    return Math.max(1, pool.length);
+  }
+
+  const renderPool = getDraftCenterRenderPool();
+  if (renderPool.length > 0) return renderPool.length;
+
+  const localPool = getCurrentDraftPlayer()?.pool ?? [];
+  return Math.max(1, localPool.length);
+}
+
+function getDraftCenterDealDurationForCurrentPool(): number {
+  return getDraftCenterDealDurationMs(getDraftCenterDealCardCount());
+}
+
+function completeOnlineDraftPoolPassAndDeal() {
+  onlineDraftAnimationTimerId = null;
+
+  if (!onlineDraftPendingPool?.length) {
+    if (onlinePassCompleteRetryCount < 40) {
+      onlinePassCompleteRetryCount += 1;
+      onlineDraftAnimationTimerId = window.setTimeout(
+        completeOnlineDraftPoolPassAndDeal,
+        100,
+      );
+      return;
+    }
+    setOnlineDraftDisplayPoolFromServer();
+  } else {
+    onlinePassCompleteRetryCount = 0;
+    onlineDraftDisplayPool = [...onlineDraftPendingPool];
+    onlineDraftPendingPool = null;
+  }
+
+  onlineDraftPassSnapshotPool = null;
+  draftHandPendingCardId = null;
+  draftPoolFlyReturnCardId = null;
+  isPassingDraftCards = false;
+  resetDraftPoolCollapseState();
+  isInitialDealInProgress = true;
+
+  const roomState = onlineClientState.roomState;
+  draftSelectedCardId = roomState?.self.selectedDraftCardId ?? null;
+
+  const dealMs = getDraftCenterDealDurationMs(
+    Math.max(1, onlineDraftDisplayPool?.length ?? 0),
+  );
+  isDraftCenterDealing = true;
+  draftDealVisualEndsAt = Date.now() + dealMs;
+
+  lastOnlineRenderSignature = "";
+  rerenderGameShell();
+  startDraftCenterDealAnimation(dealMs);
+
+  onlineDraftAnimationTimerId = window.setTimeout(() => {
+    finishOnlineDraftDealVisualOnly();
+  }, dealMs);
+}
+
+function beginOnlineDraftPoolPass(
+  snapshotPool: TravelCardData[],
+  nextServerPool: TravelCardData[] | null
+) {
+  if (isOnlineFinalDraftReturnAnimating || !isDraftPhase) return;
+  if (snapshotPool.length === 0) return;
+
+  if (isPassingDraftCards) {
+    if (nextServerPool?.length) {
+      onlineDraftPendingPool = [...nextServerPool];
+    }
+    return;
+  }
+
+  clearOnlineDraftAnimationTimer();
+
+  onlinePassCompleteRetryCount = 0;
+  onlineDraftPassSnapshotPool = [...snapshotPool];
+  if (nextServerPool?.length) {
+    onlineDraftPendingPool = [...nextServerPool];
+  }
+
+  draftSelectedCardId = null;
+  draftPoolFlyReturnCardId = null;
+  resetDraftPoolCollapseState();
+
+  shouldActivateOnlineDealAnimation = false;
+  shouldActivateOnlinePassAnimation = true;
+  isInitialDealInProgress = false;
+  isPassingDraftCards = true;
+
+  onlineDraftAnimationTimerId = window.setTimeout(() => {
+    completeOnlineDraftPoolPassAndDeal();
+  }, DRAFT_PASS_ANIMATION_MS);
+}
+
 
 function getOnlineSelfHand(): TravelCardData[] | null {
   return (getOnlineSelfState()?.hand as TravelCardData[] | undefined) ?? null;
@@ -400,6 +610,24 @@ function getOnlineSelectedDraftCardId() {
 
 function getDraftVisualSelectedCardId() {
   return getOnlineSelectedDraftCardId() ?? draftSelectedCardId;
+}
+
+function getDraftPoolHighlightedCardId(): string | null {
+  // Pool không hiển thị trạng thái "đã chọn" — lá pending nằm trên tay, slot pool bị ẩn.
+  return null;
+}
+
+function shouldShowDraftWaitBanner(): boolean {
+  if (!isDraftPhase || isDraftDealVisualActive() || isPassingDraftCards) return false;
+  if (!draftHandPendingCardId) return false;
+
+  if (!isOnlineRoomActive()) return false;
+
+  const connectedCount = playerIds.filter((playerId) => {
+    return onlineClientState.roomState?.players[playerId]?.isConnected;
+  }).length;
+
+  return connectedCount > 1;
 }
 
 function getOnlinePlayer(playerId?: PlayerId) {
@@ -790,6 +1018,8 @@ function applyOnlineRoomStateToLocal() {
 
   if (!state) return;
 
+  syncSelfPlanningConfirmLockFromServer();
+
   phaseNumber = state.phaseNumber ?? phaseNumber;
   currentDayIndex = Math.max(0, Math.min(PHASE_DAYS - 1, state.dayIndex));
 
@@ -817,15 +1047,13 @@ function applyOnlineRoomStateToLocal() {
 
   const serverDraftPool = (state.self.draftPool as TravelCardData[] | undefined) ?? [];
   const onlinePoolSignature = getDraftPoolSignature(serverDraftPool);
-  const displayPoolSignature = getDraftPoolSignature(onlineDraftDisplayPool);
-  const hasDisplayPool = onlineDraftDisplayPool !== null;
+  const hasDisplayPool = onlineDraftDisplayPool !== null && onlineDraftDisplayPool.length > 0;
 
   if (isOnlineRoomActive()) {
     const enteredDraft = state.phase === "draft" && lastOnlineAnimationPhase !== "draft";
-    const serverPoolChanged =
-      state.phase === "draft" &&
-      lastOnlineAnimationPhase === "draft" &&
-      onlinePoolSignature !== lastOnlineAnimationPoolSignature;
+    const pickedDraftCount = state.self.pickedDraftCards?.length ?? 0;
+    const pickedIncreased = pickedDraftCount > lastOnlinePickedDraftCount;
+    const draftRoundAdvanced = state.draftRound > lastOnlineAnimationDraftRound;
 
     /*
       Online draft tách 3 việc:
@@ -837,53 +1065,72 @@ function applyOnlineRoomStateToLocal() {
     */
     if (enteredDraft) {
       clearOnlineDraftAnimationTimer();
+      resetDraftPoolCollapseState();
+      draftHandPendingCardId = null;
+      draftPoolFlyReturnCardId = null;
+      onlineDraftPassSnapshotPool = null;
 
       setOnlineDraftDisplayPoolFromServer();
 
-      shouldActivateOnlineDealAnimation = true;
+      /*
+        Nếu tab đang ở background hoặc mình quay lại khi lượt draft đã chạy vài giây,
+        KHÔNG chạy lại animation chia bài từ đầu. Nếu chạy lại, tab đó sẽ kẹt
+        "Đang chia bài..." và không render pool chọn bài, dù server vẫn có bài.
+      */
+      const shouldSkipOnlineDealAnimation =
+        document.visibilityState !== "visible" ||
+        state.timer < DRAFT_PICK_SECONDS - 1;
+
+      shouldActivateOnlineDealAnimation = !shouldSkipOnlineDealAnimation;
       shouldActivateOnlinePassAnimation = false;
-      isInitialDealInProgress = true;
+      isInitialDealInProgress = !shouldSkipOnlineDealAnimation;
       isPassingDraftCards = false;
       hasPlayedOnlinePlanningDealAfterDraft = false;
 
-      playGameSound("deal");
-
-      onlineDraftAnimationTimerId = window.setTimeout(() => {
-        finishOnlineDraftDealVisualOnly();
-      }, 1320);
-    } else if (serverPoolChanged && hasDisplayPool && displayPoolSignature !== onlinePoolSignature) {
-      clearOnlineDraftAnimationTimer();
-
-      onlineDraftPendingPool = [...serverDraftPool];
-
-      shouldActivateOnlineDealAnimation = false;
-      shouldActivateOnlinePassAnimation = true;
-      isInitialDealInProgress = false;
-      isPassingDraftCards = true;
-
-      onlineDraftAnimationTimerId = window.setTimeout(() => {
-        if (onlineDraftPendingPool) {
-          onlineDraftDisplayPool = [...onlineDraftPendingPool];
-          onlineDraftPendingPool = null;
-        }
-
-        /*
-          Sau khi trả/chuyền bài vào deck xong, render pool mới dưới dạng dealing
-          để các lượt 2/3/4/5 cũng có animation chia bài giống lượt 1.
-        */
-        isPassingDraftCards = false;
-        isInitialDealInProgress = true;
-        shouldActivateOnlineDealAnimation = true;
+      if (shouldSkipOnlineDealAnimation) {
+        isDraftCenterDealing = false;
+        draftDealVisualEndsAt = 0;
         onlineDraftAnimationTimerId = null;
-        draftSelectedCardId = state.self.selectedDraftCardId;
-
-        rerenderGameShell();
-        activateDraftDealAnimation();
-
+      } else {
+        const dealMs = getDraftCenterDealDurationMs(
+          Math.max(1, serverDraftPool.length),
+        );
         onlineDraftAnimationTimerId = window.setTimeout(() => {
           finishOnlineDraftDealVisualOnly();
-        }, 1320);
-      }, 1500);
+        }, dealMs);
+      }
+    } else if (
+      state.phase === "draft" &&
+      lastOnlineAnimationPhase === "draft" &&
+      (pickedIncreased || draftRoundAdvanced)
+    ) {
+      if (isPassingDraftCards && !isOnlineFinalDraftReturnAnimating) {
+        if (serverDraftPool.length > 0) {
+          onlineDraftPendingPool = [...serverDraftPool];
+        }
+
+        if (pickedIncreased && !isDraftPickFlying) {
+          draftHandPendingCardId = null;
+          draftPoolFlyReturnCardId = null;
+        }
+      } else if (!isOnlineFinalDraftReturnAnimating) {
+        const snapshot =
+          onlineDraftDisplayPool ??
+          onlineDraftPassSnapshotPool ??
+          (serverDraftPool.length > 0 ? [...serverDraftPool] : null);
+
+        if (snapshot?.length) {
+          beginOnlineDraftPoolPass(snapshot, serverDraftPool);
+        } else if (!hasDisplayPool) {
+          setOnlineDraftDisplayPoolFromServer();
+        }
+      }
+    } else if (
+      state.phase === "draft" &&
+      serverDraftPool.length > 0 &&
+      (!onlineDraftDisplayPool || onlineDraftDisplayPool.length === 0)
+    ) {
+      setOnlineDraftDisplayPoolFromServer();
     } else if (state.phase === "draft" && !hasDisplayPool) {
       setOnlineDraftDisplayPoolFromServer();
     }
@@ -932,6 +1179,7 @@ function applyOnlineRoomStateToLocal() {
       clearOnlineDraftAnimationTimer();
 
       onlineDraftDisplayPool = null;
+      onlineDraftPassSnapshotPool = null;
       onlineDraftPendingPool = null;
       shouldActivateOnlineDealAnimation = false;
       shouldActivateOnlinePassAnimation = false;
@@ -939,6 +1187,12 @@ function applyOnlineRoomStateToLocal() {
       isPassingDraftCards = false;
     }
 
+    if (pickedDraftCount > lastOnlinePickedDraftCount && !isDraftPickFlying && !isPassingDraftCards) {
+      draftHandPendingCardId = null;
+      draftPoolFlyReturnCardId = null;
+    }
+
+    lastOnlinePickedDraftCount = pickedDraftCount;
     lastOnlineAnimationPhase = state.phase;
     lastOnlineAnimationDraftRound = state.draftRound;
     lastOnlineAnimationPoolSignature = onlinePoolSignature;
@@ -962,12 +1216,30 @@ function applyOnlineRoomStateToLocal() {
     if (onlineHand) {
       playerHand = [...onlineHand];
     }
+
+    updatePlanningConfirmButtonVisualOnly();
   }
 
   if (state.phase === "draft") {
     playerHand = [];
-    draftSelectedCardId = state.self.selectedDraftCardId;
-    updateDraftSelectedVisualOnly();
+
+    if (!isDraftPickFlying) {
+      draftSelectedCardId = state.self.selectedDraftCardId;
+
+      if (
+        state.self.selectedDraftCardId &&
+        !draftHandPendingCardId &&
+        !isDraftDealVisualActive()
+      ) {
+        draftHandPendingCardId = state.self.selectedDraftCardId;
+      }
+    }
+
+    if (!isDraftDealVisualActive() && !isDraftPickFlying) {
+      updateDraftHandVisualOnly();
+      updateDraftPoolFlownVisualOnly();
+      updateDraftSelectedVisualOnly();
+    }
   }
 
   if (state.phase === "simulation" || state.phase === "result") {
@@ -1057,6 +1329,11 @@ let draftSelectedCardId: string | null = null;
 let draftPickSecondsLeft = DRAFT_PICK_SECONDS;
 let draftTimerId: number | null = null;
 let isPassingDraftCards = false;
+let isDraftPoolCollapsed = false;
+let isDraftPoolCollapseAnimating = false;
+let draftPoolCollapseAnimMode: "collapse" | "expand" | null = null;
+let draftPoolCollapseTimerId: number | null = null;
+let draftPassDisplayPool: TravelCardData[] | null = null;
 let draftRound = 1;
 let lastDraftPickResults: DraftPickResult[] = [];
 let playerBoards: Record<PlayerId, BoardSlots> = createEmptyPlayerBoards();
@@ -1072,6 +1349,14 @@ let selectedHandCardId: string | null = null;
 let draggedHandCardId: string | null = null;
 let handPointerDragState: HandPointerDragState | null = null;
 let lastPlacedBoardPosition: BoardPosition | null = null;
+let lastUtilityEffectFlash: {
+  rowIndex: number;
+  colIndex: number;
+  type: "coin" | "stamina" | "vp";
+  value: number;
+  id: number;
+} | null = null;
+let resourceOrbFlashType: "coin" | "stamina" | "vp" | null = null;
 let focusedHandCardId: string | null = null;
 let focusedBoardCard: TravelCardData | null = null;
 let focusedBoardPosition: BoardPosition | null = null;
@@ -1085,7 +1370,7 @@ let simulationReplayIndex = 0;
 let simulationReplayTimerId: number | null = null;
 let isReplayComplete = false;
 let isMidGameRankingOpen = false;
-const hasPlayedDealAnimation = true;
+let hasPlayedDealAnimation = true;
 let didMoveHandPointerDrag = false;
 let lastPointerDownCardId: string | null = null;
 
@@ -1795,6 +2080,203 @@ function getCardBonusBadge(card: TravelCardData) {
   return "";
 }
 
+
+function stripCardText(value: string) {
+  return value
+    .replace(/<[^>]*>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function getUtilityPlacementEffect(card: TravelCardData) {
+  const effect = card.onPlayEffect;
+  const tags = getCardTagKeys(card);
+  const isUtilityCard =
+    tags.includes("UTILITY") ||
+    String(card.tag || "").toLowerCase() === "utility" ||
+    stripCardText(card.tagLabel || "").toLowerCase().includes("tiện ích");
+
+  const fullText = stripCardText(
+    [
+      card.name,
+      card.shortName || "",
+      card.description || "",
+      card.bonusText || "",
+      card.tagLabel || "",
+    ].join(" ")
+  ).toLowerCase();
+
+  const explicitValue = Number(effect?.effect_value ?? 0);
+  const numberMatch = fullText.match(/(?:\+|nhận|hoi|hồi|cộng|thêm)\s*(\d+)/i);
+  const inferredValue = numberMatch ? Number(numberMatch[1]) : 1;
+  const value = explicitValue > 0 ? explicitValue : inferredValue;
+
+  if (effect?.has_effect) {
+    if (effect.effect_type === "RECOVER_XU") {
+      return {
+        type: "coin" as const,
+        value,
+        label: `+${value} Xu`,
+        icon: "🪙",
+      };
+    }
+
+    if (effect.effect_type === "RECOVER_LA") {
+      return {
+        type: "stamina" as const,
+        value,
+        label: `+${value} Thể lực`,
+        icon: "⚡",
+      };
+    }
+
+    if (effect.effect_type === "GAIN_VP") {
+      return {
+        type: "vp" as const,
+        value,
+        label: `+${value} VP`,
+        icon: "★",
+      };
+    }
+  }
+
+  /*
+    Fallback cho data utility nếu mapper/server chưa truyền onPlayEffect.
+    Đọc mô tả/bonus để vẫn hiện đúng hiệu ứng.
+  */
+  if (!isUtilityCard) return null;
+
+  if (
+    fullText.includes("xu") ||
+    fullText.includes("tiền") ||
+    fullText.includes("coin") ||
+    fullText.includes("gold")
+  ) {
+    return {
+      type: "coin" as const,
+      value,
+      label: `+${value} Xu`,
+      icon: "🪙",
+    };
+  }
+
+  if (
+    fullText.includes("thể lực") ||
+    fullText.includes("the luc") ||
+    fullText.includes("năng lượng") ||
+    fullText.includes("nang luong") ||
+    fullText.includes("stamina") ||
+    fullText.includes("nl")
+  ) {
+    return {
+      type: "stamina" as const,
+      value,
+      label: `+${value} Thể lực`,
+      icon: "⚡",
+    };
+  }
+
+  if (fullText.includes("vp") || fullText.includes("điểm") || fullText.includes("diem")) {
+    return {
+      type: "vp" as const,
+      value,
+      label: `+${value} VP`,
+      icon: "★",
+    };
+  }
+
+  return {
+    type: "vp" as const,
+    value,
+    label: `+${value} VP`,
+    icon: "★",
+  };
+}
+
+function triggerUtilityEffectFlash(params: {
+  rowIndex: number;
+  colIndex: number;
+  type: "coin" | "stamina" | "vp";
+  value: number;
+}) {
+  const flashId = Date.now();
+
+  lastUtilityEffectFlash = {
+    ...params,
+    id: flashId,
+  };
+  resourceOrbFlashType = params.type;
+
+  window.setTimeout(() => {
+    if (lastUtilityEffectFlash?.id === flashId) {
+      lastUtilityEffectFlash = null;
+    }
+
+    if (resourceOrbFlashType === params.type) {
+      resourceOrbFlashType = null;
+    }
+
+    rerenderArena();
+  }, 1050);
+}
+
+function applyUtilityPlacementEffect(card: TravelCardData, rowIndex: number, colIndex: number) {
+  const effect = getUtilityPlacementEffect(card);
+
+  if (!effect) return false;
+
+  if (effect.type === "coin") {
+    eventResourceModifier = {
+      ...eventResourceModifier,
+      coin: eventResourceModifier.coin + effect.value,
+    };
+    playGameSound("eventPromo");
+  } else if (effect.type === "stamina") {
+    eventResourceModifier = {
+      ...eventResourceModifier,
+      stamina: eventResourceModifier.stamina + effect.value,
+    };
+    playGameSound("eventPromo");
+  } else if (effect.type === "vp") {
+    accumulatedVP += effect.value;
+    playGameSound("eventPromo");
+  }
+
+  triggerUtilityEffectFlash({
+    rowIndex,
+    colIndex,
+    type: effect.type,
+    value: effect.value,
+  });
+
+  return true;
+}
+
+function renderUtilityEffectFlash(rowIndex: number, colIndex: number) {
+  if (
+    !lastUtilityEffectFlash ||
+    lastUtilityEffectFlash.rowIndex !== rowIndex ||
+    lastUtilityEffectFlash.colIndex !== colIndex
+  ) {
+    return "";
+  }
+
+  const { type, value } = lastUtilityEffectFlash;
+  const icon = type === "coin" ? "🪙" : type === "stamina" ? "⚡" : "★";
+  const label = type === "coin" ? `+${value} Xu` : type === "stamina" ? `+${value} Thể lực` : `+${value} VP`;
+
+  return `
+    <div class="utility-effect-pop utility-effect-pop--${type}" aria-hidden="true">
+      <div class="utility-effect-pop__burst"></div>
+      <div class="utility-effect-pop__icon">${icon}</div>
+      <div class="utility-effect-pop__label">${label}</div>
+      <div class="utility-effect-pop__spark utility-effect-pop__spark--1"></div>
+      <div class="utility-effect-pop__spark utility-effect-pop__spark--2"></div>
+      <div class="utility-effect-pop__spark utility-effect-pop__spark--3"></div>
+    </div>
+  `;
+}
+
 function renderBoardMiniCard(card: TravelCardData, replayStep?: SimulationReplayStep | null) {
   const displayName = getBoardDisplayName(card);
   const displayCity = getBoardDisplayCity(card);
@@ -1887,8 +2369,11 @@ function renderBoardMiniCard(card: TravelCardData, replayStep?: SimulationReplay
   `;
 }
 
-function renderHandCard(card: TravelCardData, index: number) {
-  const isDraftSelected = isDraftPhase && card.id === getDraftVisualSelectedCardId();
+function renderHandCard(card: TravelCardData, index: number, disableFan: boolean = false) {
+  const isDraftSelected =
+    isDraftPhase &&
+    !disableFan &&
+    card.id === draftHandPendingCardId;
   const isPlanningSelected = !isDraftPhase && card.id === selectedHandCardId;
   const isSelected = isDraftSelected || isPlanningSelected;
   const affordability = getCardAffordability(card);
@@ -1899,7 +2384,7 @@ function renderHandCard(card: TravelCardData, index: number) {
 
   return `
     <article
-      class="hand-card hand-card--${card.rarity} hand-card--fan-${index + 1} ${isPlanningSelected ? "hand-card--selected" : ""} ${isDraftSelected ? "hand-card--draft-selected" : ""} ${unaffordableClass}"
+      class="hand-card hand-card--${card.rarity} ${disableFan ? "" : `hand-card--fan-${index + 1}`} ${isPlanningSelected ? "hand-card--selected" : ""} ${isDraftSelected ? "hand-card--draft-selected" : ""} ${unaffordableClass}"
       data-hand-card-id="${card.id}"
       style="${isSelected ? "box-shadow: 0 0 0 4px rgba(255,255,255,.95), 0 0 0 8px rgba(139,92,246,.82), 0 18px 34px rgba(75,47,25,.28);" : ""}"
       title="${affordabilityMessage}"
@@ -2069,18 +2554,708 @@ function renderDraftHandTopMeta() {
   `;
 }
 
-function renderDraftHandCards() {
-  const onlinePool = isOnlineRoomActive() ? getOnlineDraftDisplayPool() : null;
-  const activePlayer = getCurrentDraftPlayer();
-  const activePool = onlinePool ?? activePlayer?.pool ?? [];
+function getPickedDraftCount(): number {
+  if (isOnlineRoomActive()) {
+    return (getOnlineSelfState()?.pickedDraftCards?.length ?? 0);
+  }
+  return getCurrentDraftPlayer()?.picked?.length ?? 0;
+}
 
-  if (activePool.length === 0) {
-    return `<div class="draft-hand-empty">Đang chuẩn bị bài...</div>`;
+function getConfirmedPickedDraftCards(): TravelCardData[] {
+  if (isOnlineRoomActive()) {
+    return (getOnlineSelfState()?.pickedDraftCards as TravelCardData[] | undefined) ?? [];
+  }
+  return getCurrentDraftPlayer()?.picked ?? [];
+}
+
+function findCardInDraftPool(cardId: string): TravelCardData | null {
+  const pool = isOnlineRoomActive()
+    ? (getOnlineDraftDisplayPool() ?? [])
+    : (getCurrentDraftPlayer()?.pool ?? []);
+  return pool.find((card) => card.id === cardId) ?? null;
+}
+
+function getDraftHandDisplayCards(): TravelCardData[] {
+  const confirmed = getConfirmedPickedDraftCards();
+  const pendingId = draftHandPendingCardId;
+
+  if (!pendingId || confirmed.some((card) => card.id === pendingId)) {
+    return confirmed;
   }
 
-  return activePool
-    .map((card, index) => renderDailyDraftCard(card, index))
+  const pendingCard = findCardInDraftPool(pendingId);
+  return pendingCard ? [...confirmed, pendingCard] : confirmed;
+}
+
+function getDraftHandDisplayCount(): number {
+  return getDraftHandDisplayCards().length;
+}
+
+const DRAFT_PICKED_FAN_LAYOUT: Record<number, Array<{ rotate: number; ty: number }>> = {
+  1: [{ rotate: 0, ty: -6 }],
+  2: [
+    { rotate: -16, ty: -4 },
+    { rotate: 16, ty: -4 },
+  ],
+  3: [
+    { rotate: -18, ty: -5 },
+    { rotate: 0, ty: -10 },
+    { rotate: 18, ty: -5 },
+  ],
+  4: [
+    { rotate: -20, ty: -3 },
+    { rotate: -8, ty: -8 },
+    { rotate: 8, ty: -8 },
+    { rotate: 20, ty: -3 },
+  ],
+  5: [
+    { rotate: -18, ty: -2 },
+    { rotate: -9, ty: -7 },
+    { rotate: 0, ty: -11 },
+    { rotate: 9, ty: -7 },
+    { rotate: 18, ty: -2 },
+  ],
+};
+
+function readDraftHandCardMetrics() {
+  const root = document.documentElement;
+  const handCardW = parseFloat(getComputedStyle(root).getPropertyValue("--hand-card-w")) || 158;
+  const handCardH = parseFloat(getComputedStyle(root).getPropertyValue("--hand-card-h")) || 218;
+  const cardW = handCardW * 0.84;
+  const cardH = handCardH * 0.84;
+  const stepX = handCardW * 0.46;
+
+  return { handCardW, handCardH, cardW, cardH, stepX };
+}
+
+function getDraftFanSlotLayout(count: number, slotIndex: number) {
+  return DRAFT_PICKED_FAN_LAYOUT[count]?.[slotIndex - 1] ?? { rotate: 0, ty: 0 };
+}
+
+function computeDraftHandSlotRect(count: number, slotIndex: number): DOMRect | null {
+  const cardsEl = document.querySelector(".player-hand__cards--draft") as HTMLElement | null;
+  if (!cardsEl || count < 1 || slotIndex < 1 || slotIndex > count) return null;
+
+  const layout = getDraftFanSlotLayout(count, slotIndex);
+  const { cardW, cardH, stepX } = readDraftHandCardMetrics();
+  const containerRect = cardsEl.getBoundingClientRect();
+  const totalWidth = cardW + (count - 1) * stepX;
+  const firstLeft = containerRect.left + (containerRect.width - totalWidth) / 2;
+  const slotLeft = firstLeft + (slotIndex - 1) * stepX;
+  const slotTop = containerRect.bottom - cardH - 4 + layout.ty;
+
+  return new DOMRect(slotLeft, slotTop, cardW, cardH);
+}
+
+function parseDraftHandSlotMeta(cardEl: HTMLElement): { count: number; slotIndex: number } | null {
+  const slotMatch = cardEl.className.match(/hand-card--picked-slot-(\d)/);
+  const parent = cardEl.closest("[class*='picked-count-']") as HTMLElement | null;
+  const countMatch = parent?.className.match(/picked-count-(\d)/);
+
+  if (!slotMatch || !countMatch) return null;
+
+  return {
+    count: parseInt(countMatch[1], 10),
+    slotIndex: parseInt(slotMatch[1], 10),
+  };
+}
+
+function getDraftHandFlyTargetForPending(): { rect: DOMRect; rotate: number } | null {
+  const count = getDraftHandDisplayCount();
+  const slotIndex = count;
+  const rect = computeDraftHandSlotRect(count, slotIndex);
+
+  if (!rect) return null;
+
+  return {
+    rect,
+    rotate: getDraftFanSlotLayout(count, slotIndex).rotate,
+  };
+}
+
+function getDraftHandFlySourceFromElement(cardEl: HTMLElement): { rect: DOMRect; rotate: number } | null {
+  const meta = parseDraftHandSlotMeta(cardEl);
+  if (!meta) return null;
+
+  const rect = computeDraftHandSlotRect(meta.count, meta.slotIndex);
+  if (!rect) return null;
+
+  return {
+    rect,
+    rotate: getDraftFanSlotLayout(meta.count, meta.slotIndex).rotate,
+  };
+}
+
+function getDraftCenterCardWrapper(cardId: string): HTMLElement | null {
+  const card = document.querySelector(
+    `.draft-center-card[data-draft-card-id="${cardId}"]`
+  );
+  return (card?.closest(".draft-center-card-wrapper") as HTMLElement | null) ?? null;
+}
+
+function getDraftPendingHandSlotRect(): DOMRect | null {
+  const slot =
+    document.querySelector(
+      ".hand-card--picked-pending:not(.hand-card--picked-pending-hidden)"
+    ) ??
+    document.querySelector(".hand-card--picked-pending-hidden") ??
+    document.querySelector(".hand-card--picked-pending");
+  const rect = slot?.getBoundingClientRect() ?? null;
+
+  if (!rect || rect.width <= 0 || rect.height <= 0) {
+    return null;
+  }
+
+  return rect;
+}
+
+function getDraftHandFallbackSlotRect(): DOMRect | null {
+  const cardsEl = document.querySelector(".player-hand__cards--draft") as HTMLElement | null;
+  if (!cardsEl) return null;
+
+  const handRect = cardsEl.getBoundingClientRect();
+  const cardWidth = cardsEl.clientWidth > 0 ? cardsEl.clientWidth * 0.12 : 132;
+  const cardHeight = cardWidth * 1.38;
+
+  return new DOMRect(
+    handRect.left + handRect.width / 2 - cardWidth / 2,
+    handRect.bottom - cardHeight - 8,
+    cardWidth,
+    cardHeight
+  );
+}
+
+async function measureDraftPendingHandSlotRect(): Promise<DOMRect | null> {
+  for (let attempt = 0; attempt < 4; attempt++) {
+    if (attempt > 0) {
+      await new Promise<void>((resolve) => {
+        window.requestAnimationFrame(() => window.requestAnimationFrame(() => resolve()));
+      });
+    }
+
+    updateDraftHandVisualOnly({ hiddenPendingMeasure: true });
+
+    const cardsEl = document.querySelector(".player-hand__cards--draft") as HTMLElement | null;
+    if (cardsEl) {
+      void cardsEl.offsetHeight;
+    }
+
+    const target = getDraftHandFlyTargetForPending();
+    if (target) return target.rect;
+
+    const rect = getDraftPendingHandSlotRect();
+    if (rect) return rect;
+  }
+
+  return getDraftHandFallbackSlotRect();
+}
+
+function revertDraftPickFlyToHand(cardId: string) {
+  draftHandPendingCardId = null;
+
+  if (draftSelectedCardId === cardId) {
+    draftSelectedCardId = null;
+  }
+
+  getDraftCenterCardWrapper(cardId)?.classList.remove("draft-center-card-wrapper--flown-to-hand");
+  updateDraftPoolFlownVisualOnly();
+  updateDraftHandVisualOnly();
+  updateDraftConfirmButtonVisualOnly();
+}
+
+function renderPickedDraftCard(
+  card: TravelCardData,
+  index: number,
+  options?: { isPending?: boolean; hiddenForMeasure?: boolean }
+) {
+  const pendingClass = options?.isPending ? " hand-card--picked-pending" : "";
+  const hiddenClass = options?.hiddenForMeasure ? " hand-card--picked-pending-hidden" : "";
+
+  return `
+    <article
+      class="hand-card hand-card--${card.rarity} hand-card--picked-draft hand-card--picked-slot-${index + 1}${pendingClass}${hiddenClass}"
+      data-draft-hand-card-id="${card.id}"
+    >
+      <div class="hand-card__header">
+        <div class="hand-card__title-block">
+          <h3 class="${getHandTitleClass(card.name)}">${card.name}</h3>
+          <div class="${getHandCityClass(card.city)}">📍 ${card.city}</div>
+        </div>
+
+        <div class="hand-card__vp">${card.vp}</div>
+      </div>
+
+      <div class="hand-card__image" style="background-image: url('${card.image}'), url('${images.food}')">
+        <div class="hand-card__icons">
+          <span>${card.icon}</span>
+          <span>★</span>
+        </div>
+      </div>
+
+      <div class="hand-card__content">
+        <div class="hand-card__meta-row">
+          <span class="hand-card__rarity">${card.rarityLabel}</span>
+          <span class="hand-card__tag">${card.tagLabel}</span>
+        </div>
+
+        <p>${card.description}</p>
+
+        <div class="hand-card__bonus">
+          ${card.bonusText}
+        </div>
+      </div>
+
+      <div class="hand-card__footer">
+        <div>
+          <span>GOLD</span>
+          <strong>${card.coin}</strong>
+        </div>
+
+        <div>
+          <span>STAMINA</span>
+          <strong>${card.stamina}</strong>
+        </div>
+      </div>
+    </article>
+  `;
+}
+
+function renderPickedDraftCards(options?: { hiddenPendingMeasure?: boolean }) {
+  const confirmedIds = new Set(getConfirmedPickedDraftCards().map((card) => card.id));
+
+  return getDraftHandDisplayCards()
+    .map((card, index) =>
+      renderPickedDraftCard(card, index, {
+        isPending: card.id === draftHandPendingCardId && !confirmedIds.has(card.id),
+        hiddenForMeasure: options?.hiddenPendingMeasure && card.id === draftHandPendingCardId,
+      })
+    )
     .join("");
+}
+
+function shouldShowDraftPickPool(): boolean {
+  if (!isDraftPhase) return false;
+  if (isOnlineFinalDraftReturnAnimating) return false;
+  if (isOnlineInterRoundPoolPassActive()) {
+    const passPool = onlineDraftPassSnapshotPool ?? onlineDraftDisplayPool;
+    if (passPool?.length) return true;
+  }
+  if (isPassingDraftCards && draftPassDisplayPool?.length) return true;
+  if (getPickedDraftCount() >= DRAFT_PICK_TARGET) return false;
+  return true;
+}
+
+function getDraftCenterRenderPool(): TravelCardData[] {
+  if (isOnlineRoomActive()) {
+    if (isOnlineInterRoundPoolPassActive()) {
+      return onlineDraftPassSnapshotPool ?? onlineDraftDisplayPool ?? [];
+    }
+    return getOnlineDraftDisplayPool() ?? [];
+  }
+
+  if (isPassingDraftCards && draftPassDisplayPool) {
+    return draftPassDisplayPool;
+  }
+
+  return getCurrentDraftPlayer()?.pool ?? [];
+}
+
+function updateDraftConfirmButtonVisualOnly() {
+  if (!isDraftPhase) return;
+
+  const button = document.querySelector(
+    ".deck-pile-panel__draft-confirm"
+  ) as HTMLButtonElement | null;
+  if (!button) return;
+
+  const canConfirm =
+    !!(draftHandPendingCardId || draftSelectedCardId) &&
+    !isDraftPickFlying &&
+    !isPassingDraftCards &&
+    !isDraftDealVisualActive() &&
+    !isDraftPoolCollapseAnimating;
+
+  button.disabled = !canConfirm;
+}
+
+function updatePlanningConfirmButtonVisualOnly() {
+  if (!isOnlinePlanningPhase()) return;
+
+  const button = document.querySelector(
+    ".deck-pile-panel__planning-confirm"
+  ) as HTMLButtonElement | null;
+  if (!button) return;
+
+  const confirmed = isSelfPlanningConfirmed();
+  button.disabled = confirmed;
+  button.textContent = confirmed ? "Đã xác nhận" : "Xác nhận";
+
+  const statusElement = document.querySelector(
+    ".deck-pile-panel__planning-status"
+  ) as HTMLElement | null;
+
+  if (statusElement) {
+    statusElement.textContent = getPlanningConfirmStatusLabel();
+  }
+}
+
+function resetDraftPoolCollapseState() {
+  if (draftPoolCollapseTimerId !== null) {
+    window.clearTimeout(draftPoolCollapseTimerId);
+    draftPoolCollapseTimerId = null;
+  }
+
+  isDraftPoolCollapsed = false;
+  isDraftPoolCollapseAnimating = false;
+  draftPoolCollapseAnimMode = null;
+}
+
+function isDraftPoolToggleBlocked(): boolean {
+  return (
+    isDraftPoolCollapseAnimating ||
+    isDraftPickFlying ||
+    isPassingDraftCards ||
+    isOnlineFinalDraftReturnAnimating
+  );
+}
+
+function renderDraftPoolCollapseButton(): string {
+  if (!isDraftPhase || !shouldShowDraftPickPool()) return "";
+  if (isPassingDraftCards || isOnlineFinalDraftReturnAnimating) return "";
+
+  const label = isDraftPoolCollapsed ? "Mở pool" : "Thu gọn";
+  const disabled = isDraftPoolToggleBlocked();
+
+  return `
+    <button
+      type="button"
+      class="deck-pile-panel__pool-toggle"
+      onclick="event.stopPropagation(); toggleDraftPoolCollapse()"
+      ${disabled ? "disabled" : ""}
+      title="${isDraftPoolCollapsed ? "Hiện lại pool chọn bài" : "Thu gọn pool để xem bàn cờ"}"
+    >
+      ${label}
+    </button>
+  `;
+}
+
+function updateDraftPoolToggleVisualOnly() {
+  const button = document.querySelector(
+    ".deck-pile-panel__pool-toggle"
+  ) as HTMLButtonElement | null;
+  if (!button) return;
+
+  button.textContent = isDraftPoolCollapsed ? "Mở pool" : "Thu gọn";
+  button.disabled = isDraftPoolToggleBlocked();
+  button.title = isDraftPoolCollapsed
+    ? "Hiện lại pool chọn bài"
+    : "Thu gọn pool để xem bàn cờ";
+}
+
+function getDraftCenterPickOverlayElement(): HTMLElement | null {
+  return document.querySelector(
+    ".draft-center-overlay:not(.draft-center-overlay--returning)"
+  ) as HTMLElement | null;
+}
+
+function activateDraftCenterPoolDeckFlyAnimation(
+  mode: "collapse" | "expand"
+): boolean {
+  const overlayElement = getDraftCenterPickOverlayElement();
+  const deckStackElement = document.querySelector(".deck-card-stack") as HTMLElement | null;
+
+  if (!overlayElement || !deckStackElement) return false;
+
+  const poolCards = Array.from(
+    overlayElement.querySelectorAll(
+      ".draft-center-card-wrapper:not(.draft-center-card-wrapper--flown-to-hand)"
+    )
+  ) as HTMLElement[];
+
+  if (poolCards.length === 0) return false;
+
+  overlayElement.classList.remove(
+    "draft-center-overlay--collapsed",
+    "draft-center-overlay--collapsing",
+    "draft-center-overlay--expanding",
+    "pass-active"
+  );
+
+  const overlayRect = overlayElement.getBoundingClientRect();
+  const deckRect = deckStackElement.getBoundingClientRect();
+
+  const gatherCenterX = overlayRect.left + overlayRect.width * 0.5;
+  const gatherCenterY = overlayRect.top + overlayRect.height * 0.38;
+  const deckInsertX = deckRect.left + deckRect.width * 0.34;
+  const deckInsertY = deckRect.top + deckRect.height * 0.54;
+
+  applyDraftReturnGatherVars(
+    poolCards,
+    gatherCenterX,
+    gatherCenterY,
+    deckInsertX,
+    deckInsertY
+  );
+
+  deckStackElement.closest(".deck-pile-panel")?.classList.add("deck-receiving");
+  overlayElement.classList.add(
+    mode === "collapse"
+      ? "draft-center-overlay--collapsing"
+      : "draft-center-overlay--expanding",
+    "pass-active"
+  );
+
+  return true;
+}
+
+function finishDraftPoolCollapseAnimation() {
+  draftPoolCollapseTimerId = null;
+  isDraftPoolCollapseAnimating = false;
+  draftPoolCollapseAnimMode = null;
+  isDraftPoolCollapsed = true;
+
+  const overlayElement = getDraftCenterPickOverlayElement();
+  overlayElement?.classList.remove(
+    "draft-center-overlay--collapsing",
+    "pass-active"
+  );
+  overlayElement?.classList.add("draft-center-overlay--collapsed");
+
+  document.querySelector(".deck-pile-panel")?.classList.remove("deck-receiving");
+  updateDraftPoolToggleVisualOnly();
+  updateDraftConfirmButtonVisualOnly();
+}
+
+function finishDraftPoolExpandAnimation() {
+  draftPoolCollapseTimerId = null;
+  isDraftPoolCollapseAnimating = false;
+  draftPoolCollapseAnimMode = null;
+  isDraftPoolCollapsed = false;
+
+  const overlayElement = getDraftCenterPickOverlayElement();
+  overlayElement?.classList.remove(
+    "draft-center-overlay--expanding",
+    "draft-center-overlay--collapsed",
+    "pass-active"
+  );
+
+  document.querySelector(".deck-pile-panel")?.classList.remove("deck-receiving");
+  updateDraftPoolToggleVisualOnly();
+  updateDraftConfirmButtonVisualOnly();
+}
+
+function collapseDraftPoolVisual() {
+  if (isDraftPoolToggleBlocked() || isDraftPoolCollapsed) return;
+
+  isDraftPoolCollapseAnimating = true;
+  draftPoolCollapseAnimMode = "collapse";
+  updateDraftPoolToggleVisualOnly();
+  updateDraftConfirmButtonVisualOnly();
+  playGameSound("returnDeck");
+
+  window.requestAnimationFrame(() => {
+    window.requestAnimationFrame(() => {
+      if (!activateDraftCenterPoolDeckFlyAnimation("collapse")) {
+        finishDraftPoolCollapseAnimation();
+      }
+    });
+  });
+
+  draftPoolCollapseTimerId = window.setTimeout(() => {
+    finishDraftPoolCollapseAnimation();
+  }, DRAFT_POOL_COLLAPSE_MS);
+}
+
+function expandDraftPoolVisual() {
+  if (isDraftPoolToggleBlocked() || !isDraftPoolCollapsed) return;
+
+  isDraftPoolCollapsed = false;
+  isDraftPoolCollapseAnimating = true;
+  draftPoolCollapseAnimMode = "expand";
+
+  const overlayElement = getDraftCenterPickOverlayElement();
+  overlayElement?.classList.remove("draft-center-overlay--collapsed");
+
+  updateDraftPoolToggleVisualOnly();
+  updateDraftConfirmButtonVisualOnly();
+  playGameSound("cardSelect");
+
+  window.requestAnimationFrame(() => {
+    window.requestAnimationFrame(() => {
+      if (!activateDraftCenterPoolDeckFlyAnimation("expand")) {
+        finishDraftPoolExpandAnimation();
+      }
+    });
+  });
+
+  draftPoolCollapseTimerId = window.setTimeout(() => {
+    finishDraftPoolExpandAnimation();
+  }, DRAFT_POOL_COLLAPSE_MS);
+}
+
+function toggleDraftPoolCollapse() {
+  if (!isDraftPhase || !shouldShowDraftPickPool() || isDraftPoolToggleBlocked()) {
+    return;
+  }
+
+  if (isDraftPoolCollapsed) {
+    expandDraftPoolVisual();
+  } else {
+    collapseDraftPoolVisual();
+  }
+}
+
+function shouldShowDraftLeftoverReturn(): boolean {
+  return isOnlineFinalDraftReturnAnimating && isPassingDraftCards;
+}
+
+function getDraftLeftoverReturnCards(): TravelCardData[] {
+  const pool = getOnlineDraftDisplayPool() ?? [];
+  const pickedIds = new Set(
+    (getOnlineSelfState()?.pickedDraftCards ?? []).map((card) => card.id)
+  );
+  return pool.filter((card) => !pickedIds.has(card.id));
+}
+
+function isDraftPickTimerFrozen(): boolean {
+  const hold = onlineClientState.roomState?.draftTimerHold ?? 0;
+
+  if (isOnlineRoomActive()) {
+    const serverPool = getOnlineSelfDraftPool();
+    const animationExpired = draftDealVisualEndsAt > 0 && Date.now() > draftDealVisualEndsAt + 180;
+
+    if (serverPool?.length && animationExpired) {
+      return hold > 0;
+    }
+  }
+
+  return (
+    isDraftCenterDealing ||
+    isInitialDealInProgress ||
+    isPassingDraftCards ||
+    hold > 0 ||
+    Date.now() < draftDealVisualEndsAt
+  );
+}
+
+function getDraftTimerDisplayLabel(): string {
+  if (isDraftPickTimerFrozen()) return "Chia bài";
+  return `${draftPickSecondsLeft}s`;
+}
+
+function updateDraftTimerDisplayVisualOnly() {
+  const meta = document.querySelector(".player-hand__meta");
+  if (!meta || !isDraftPhase) return;
+
+  meta.textContent = isDraftPickTimerFrozen()
+    ? "Đang chia bài..."
+    : `Còn ${getDraftTimerDisplayLabel()} • ${
+        isPassingDraftCards ? "Đang chuyền bài..." : "bấm 1 lá để chọn"
+      }`;
+  meta.classList.toggle("player-hand__meta--danger", isDraftTimerDanger());
+}
+
+function isDraftTimerDanger(): boolean {
+  return !isDraftPickTimerFrozen() && draftPickSecondsLeft <= 3;
+}
+
+function renderDraftCenterOverlay() {
+  if (!isDraftPhase) return "";
+  if (!shouldShowDraftPickPool()) return "";
+
+  const activePool = getDraftCenterRenderPool();
+
+  if (activePool.length === 0) {
+    return `
+      <div class="draft-center-overlay">
+        <p style="color:#fff5d1; font-size:1.2rem;">Đang chuẩn bị bài...</p>
+      </div>
+    `;
+  }
+
+  const topRow = activePool.slice(0, 4);
+  const bottomRow = activePool.slice(4);
+
+  const renderRow = (cards: TravelCardData[], startIndex: number) => {
+    return cards.map((card, idx) => {
+      const index = startIndex + idx;
+      const globalSlot = startIndex + idx + 1;
+      const isFlownToHand = shouldHideDraftPoolSlot(card.id);
+      const poolPickDisabled =
+        isPassingDraftCards ||
+        isDraftPoolCollapsed ||
+        isDraftPoolCollapseAnimating;
+      const pickButton = poolPickDisabled
+        ? ""
+        : `
+          <button class="draft-center-btn" data-draft-card-id="${card.id}">
+            CHỌN
+          </button>
+        `;
+
+      return `
+        <div class="draft-center-card-wrapper draft-center-card-wrapper--slot-${globalSlot} ${isFlownToHand ? "draft-center-card-wrapper--flown-to-hand" : ""}" style="--draft-deal-delay: ${(globalSlot - 1) * DRAFT_CENTER_DEAL_STEP_MS}ms">
+          <div class="draft-center-card" data-draft-card-id="${card.id}">
+            ${renderHandCard(card, index, true)}
+          </div>
+          ${pickButton}
+        </div>
+      `;
+    }).join("");
+  };
+
+  const overlayModifierClass = [
+    isPassingDraftCards && !isOnlineFinalDraftReturnAnimating
+      ? "draft-center-overlay--passing"
+      : "",
+    isDraftCenterDealing || isInitialDealInProgress
+      ? "draft-center-overlay--dealing"
+      : "",
+    isDraftPoolCollapsed && !isDraftPoolCollapseAnimating
+      ? "draft-center-overlay--collapsed"
+      : "",
+    draftPoolCollapseAnimMode === "collapse" ? "draft-center-overlay--collapsing" : "",
+    draftPoolCollapseAnimMode === "expand" ? "draft-center-overlay--expanding" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return `
+    <div class="draft-center-overlay ${overlayModifierClass}">
+      <div class="draft-center-container">
+        <div class="draft-center-row" style="display: flex; flex-direction: row; gap: 12px; justify-content: center;">${renderRow(topRow, 0)}</div>
+        <div class="draft-center-row" style="display: flex; flex-direction: row; gap: 12px; justify-content: center;">${renderRow(bottomRow, 4)}</div>
+      </div>
+      ${shouldShowDraftWaitBanner() ? '<div class="draft-center-wait-banner">Đang chờ đối thủ...</div>' : ''}
+    </div>
+  `;
+}
+
+function renderDraftLeftoverReturnOverlay(): string {
+  if (!shouldShowDraftLeftoverReturn()) return "";
+
+  const cards = getDraftLeftoverReturnCards();
+
+  const cardHtml = cards
+    .map((card, index) => {
+      const slot = index + 1;
+      return `
+        <div class="draft-center-card-wrapper draft-center-card-wrapper--return draft-center-card-wrapper--return-${slot}">
+          <div class="draft-center-card">
+            ${renderHandCard(card, index, true)}
+          </div>
+        </div>
+      `;
+    })
+    .join("");
+
+  return `
+    <div class="draft-center-overlay draft-center-overlay--returning">
+      <div class="draft-center-container draft-center-container--return">
+        ${cardHtml}
+      </div>
+    </div>
+  `;
 }
 
 function getDraftPreviewIconsForPlayer(playerId: PlayerId): string[] {
@@ -2424,14 +3599,24 @@ function resetSinglePlayerDraftPool() {
   if (!currentPlayer) return;
 
   /*
-    Chơi 1 người: sau khi chọn 1 lá, 6 lá còn lại quay về deck rồi roll pool mới.
-    Như vậy mỗi lượt pick thật sự là một lượt random mới, không phải chuyền bài ảo với bot.
+    Chơi 1 người đúng yêu cầu:
+    - Lượt 1: random 7 lá.
+    - Pick xong 1 lá: trả 6 lá còn lại về deck.
+    - Lượt 2: random lại 6 lá mới.
+    - Lượt 3: random lại 5 lá mới.
+    - Lượt 4: random lại 4 lá mới.
+    - Lượt 5: random lại 3 lá mới.
+    => Không giữ pool cũ, nhưng số lá giảm dần theo số lá đã pick.
   */
   if (currentPlayer.pool.length > 0) {
     deck = shuffleCards([...deck, ...currentPlayer.pool]);
   }
 
-  const nextPool = drawRandomCardsFromDeck(DRAFT_STARTING_POOL_SIZE);
+  const nextPoolSize = Math.max(
+    DRAFT_STARTING_POOL_SIZE - currentPlayer.picked.length,
+    DRAFT_STARTING_POOL_SIZE - DRAFT_PICK_TARGET + 1
+  );
+  const nextPool = drawRandomCardsFromDeck(nextPoolSize);
 
   draftPlayers = draftPlayers.map((player, index) => {
     if (index !== activeIndex) return player;
@@ -2483,6 +3668,11 @@ function startDraftTimer() {
       return;
     }
 
+    if (isDraftPoolCollapseAnimating) {
+      updateDraftTimerDisplayVisualOnly();
+      return;
+    }
+
       rerenderArena();
   }, 1000);
 }
@@ -2498,8 +3688,13 @@ function initializeDailyDraftPhase() {
   draftPlayers = createDailyDraftPlayers();
   preloadDraftImages();
   draftSelectedCardId = null;
+  draftHandPendingCardId = null;
+  draftPoolFlyReturnCardId = null;
+  lastOnlinePickedDraftCount = 0;
   draftPickSecondsLeft = DRAFT_PICK_SECONDS;
   isPassingDraftCards = false;
+  resetDraftPoolCollapseState();
+  draftPassDisplayPool = null;
   draftRound = 1;
   lastDraftPickResults = [];
 
@@ -2604,6 +3799,8 @@ function finishDraftPick(cardId: string | null) {
       pickedCard: chosenCard,
     });
 
+    draftPassDisplayPool = [...currentPlayer.pool];
+
     draftPlayers = draftPlayers.map((player, playerIndex) => {
       if (playerIndex !== activeIndex) return player;
 
@@ -2616,20 +3813,28 @@ function finishDraftPick(cardId: string | null) {
 
     lastDraftPickResults = pickResults;
     draftSelectedCardId = null;
+    draftHandPendingCardId = null;
+    draftPoolFlyReturnCardId = null;
     isPassingDraftCards = true;
 
     stopDraftTimer();
     rerenderArena();
-    activateDraftPassAnimation();
+    activateDraftCenterPoolPassAnimation();
 
     window.setTimeout(() => {
+      draftPassDisplayPool = null;
       const nextCurrentPlayer = getCurrentDraftPlayer();
 
       if (!nextCurrentPlayer || nextCurrentPlayer.picked.length >= DRAFT_PICK_TARGET) {
+        isPassingDraftCards = false;
         completeDailyDraftPhase();
         return;
       }
 
+      /*
+        Chơi 1 người: mỗi lượt random lại pool mới, nhưng size giảm dần.
+        7 lá -> pick -> random 6 lá -> pick -> random 5 lá -> ... -> đủ 5 lá.
+      */
       resetSinglePlayerDraftPool();
       preloadDraftImages();
 
@@ -2639,10 +3844,13 @@ function finishDraftPick(cardId: string | null) {
       lastDraftPickResults = [];
 
       playDraftDealAnimationAndStartTimer();
-    }, 940);
+    }, DRAFT_PASS_ANIMATION_MS);
 
     return;
   }
+
+  const currentPlayerBeforePass = getCurrentDraftPlayer();
+  draftPassDisplayPool = currentPlayerBeforePass ? [...currentPlayerBeforePass.pool] : null;
 
   draftPlayers = draftPlayers.map((player, playerIndex) => {
     if (player.pool.length === 0) return player;
@@ -2668,13 +3876,16 @@ function finishDraftPick(cardId: string | null) {
 
   lastDraftPickResults = pickResults;
   draftSelectedCardId = null;
+  draftHandPendingCardId = null;
+  draftPoolFlyReturnCardId = null;
   isPassingDraftCards = true;
 
   stopDraftTimer();
   rerenderArena();
-  activateDraftPassAnimation();
+  activateDraftCenterPoolPassAnimation();
 
   window.setTimeout(() => {
+    draftPassDisplayPool = null;
     const currentPlayer = getCurrentDraftPlayer();
 
     /*
@@ -2682,6 +3893,7 @@ function finishDraftPick(cardId: string | null) {
       Khi đã đủ 5 lá thì trả 2 lá dư còn lại về deck, không cần draft tới khi pool rỗng.
     */
     if (!currentPlayer || currentPlayer.picked.length >= DRAFT_PICK_TARGET) {
+      isPassingDraftCards = false;
       completeDailyDraftPhase();
       return;
     }
@@ -2695,7 +3907,7 @@ function finishDraftPick(cardId: string | null) {
     lastDraftPickResults = [];
 
     playDraftDealAnimationAndStartTimer();
-  }, 940);
+  }, DRAFT_PASS_ANIMATION_MS);
 }
 
 function autoPickDraftCard() {
@@ -2736,40 +3948,7 @@ function renderDailyDraftCard(card: TravelCardData, index: number) {
 }
 
 function updateDraftSelectedVisualOnly() {
-  const selectedId = getDraftVisualSelectedCardId();
-  const draftCards = Array.from(
-    document.querySelectorAll("[data-draft-card-id]")
-  ) as HTMLElement[];
-
-  draftCards.forEach((element) => {
-    const isSelected = element.dataset.draftCardId === selectedId;
-    const innerCard = element.querySelector(".hand-card") as HTMLElement | null;
-
-    element.classList.toggle("daily-draft-card--selected", isSelected);
-    innerCard?.classList.toggle("hand-card--draft-selected", isSelected);
-
-    /*
-      Chỉ set layer trực tiếp. Không set inline transform nữa để không đè animation deal/pass.
-      CSS sẽ lo hiệu ứng nổi/glow khi selected.
-    */
-    if (isSelected) {
-      element.style.setProperty("z-index", "99999", "important");
-      element.style.setProperty("isolation", "isolate", "important");
-    } else {
-      element.style.removeProperty("z-index");
-      element.style.removeProperty("isolation");
-    }
-
-    if (innerCard) {
-      if (isSelected) {
-        innerCard.style.setProperty("z-index", "99999", "important");
-        innerCard.style.setProperty("position", "relative", "important");
-      } else {
-        innerCard.style.removeProperty("z-index");
-        innerCard.style.removeProperty("position");
-      }
-    }
-  });
+  updateDraftPoolFlownVisualOnly();
 
   const selectedCard = getDraftSelectedCard();
   const titleElement = document.querySelector(".draft-hand-meta__info strong");
@@ -2787,20 +3966,397 @@ function updateDraftSelectedVisualOnly() {
       ? "Đã chọn. Bấm lại lá đó để hủy chọn."
       : "Bấm để chọn, giữ 0.5s để xem lớn.";
   }
+
+  const waitBanner = document.querySelector(".draft-center-wait-banner") as HTMLElement | null;
+  if (waitBanner) {
+    waitBanner.style.display = shouldShowDraftWaitBanner() ? "" : "none";
+  }
+
+  updateDraftConfirmButtonVisualOnly();
+}
+
+function removeDraftPickFlyLayer() {
+  document.querySelectorAll(".draft-pick-fly-layer").forEach((element) => element.remove());
+}
+
+function ensureDraftPickFlyLayer(): HTMLElement {
+  let layer = document.querySelector(".draft-pick-fly-layer") as HTMLElement | null;
+
+  if (!layer) {
+    layer = document.createElement("div");
+    layer.className = "draft-pick-fly-layer";
+    document.body.appendChild(layer);
+  }
+
+  return layer;
+}
+
+function clampDraftPickFlyScale(scale: number): number {
+  return Math.max(0.85, Math.min(1.2, scale));
+}
+
+function computeDraftPickFlyScaleEnd(fromRect: DOMRect, toRect: DOMRect): number {
+  if (fromRect.width <= 0) return 1;
+  return clampDraftPickFlyScale(toRect.width / fromRect.width);
+}
+
+function shouldHideDraftPoolSlot(cardId: string): boolean {
+  if (isDraftDealVisualActive()) {
+    return cardId === draftHandPendingCardId || cardId === draftPoolFlyReturnCardId;
+  }
+
+  if (cardId === draftHandPendingCardId || cardId === draftPoolFlyReturnCardId) {
+    return true;
+  }
+
+  /*
+    Online draft giữ display pool cũ trong lúc pass animation.
+    Lá vừa pick đã nằm trên tay nhưng vẫn còn trong display pool → ẩn slot
+    cho tới khi pool mới được apply sau animation.
+  */
+  if (isPassingDraftCards || isOnlineFinalDraftReturnAnimating) {
+    return getConfirmedPickedDraftCards().some((card) => card.id === cardId);
+  }
+
+  return false;
+}
+
+function animateDraftPickFly(
+  fromRect: DOMRect,
+  toRect: DOMRect,
+  sourceInnerHtml: string,
+  scaleEnd: number,
+  options?: {
+    scaleStart?: number;
+    direction?: "to-hand" | "to-pool";
+    rotateStart?: number;
+    rotateEnd?: number;
+    flyWidth?: number;
+    flyHeight?: number;
+  }
+): Promise<void> {
+  const layer = ensureDraftPickFlyLayer();
+  const { cardW, cardH } = readDraftHandCardMetrics();
+  const flyWidth = options?.flyWidth ?? cardW;
+  const flyHeight = options?.flyHeight ?? cardH;
+  const fromCx = fromRect.left + fromRect.width / 2;
+  const fromCy = fromRect.top + fromRect.height / 2;
+  const toCx = toRect.left + toRect.width / 2;
+  const toCy = toRect.top + toRect.height / 2;
+  const scaleStart = options?.scaleStart ?? 1;
+  const rotateStart = options?.rotateStart ?? 0;
+  const rotateEnd = options?.rotateEnd ?? 0;
+
+  const fly = document.createElement("div");
+  fly.className = "draft-pick-fly-card";
+  if (options?.direction === "to-pool") {
+    fly.classList.add("draft-pick-fly-card--to-pool");
+  }
+  fly.style.left = `${fromCx - flyWidth / 2}px`;
+  fly.style.top = `${fromCy - flyHeight / 2}px`;
+  fly.style.width = `${flyWidth}px`;
+  fly.style.height = `${flyHeight}px`;
+  fly.style.setProperty("--fly-dx", `${toCx - fromCx}px`);
+  fly.style.setProperty("--fly-dy", `${toCy - fromCy}px`);
+  fly.style.setProperty("--fly-scale-start", String(scaleStart));
+  fly.style.setProperty("--fly-scale-end", String(scaleEnd));
+  fly.style.setProperty("--fly-rotate-start", `${rotateStart}deg`);
+  fly.style.setProperty("--fly-rotate-end", `${rotateEnd}deg`);
+  fly.innerHTML = sourceInnerHtml;
+
+  layer.appendChild(fly);
+  void fly.offsetHeight;
+  fly.classList.add("draft-pick-fly-card--animating");
+
+  return new Promise((resolve) => {
+    let settled = false;
+
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+
+      fly.remove();
+
+      if (layer.childElementCount === 0) {
+        layer.remove();
+      }
+
+      resolve();
+    };
+
+    fly.addEventListener("animationend", finish, { once: true });
+    window.setTimeout(finish, DRAFT_PICK_FLY_MS + 100);
+  });
+}
+
+async function playDraftPickFlyToHand(cardId: string) {
+  const card = findCardInDraftPool(cardId);
+  if (!card) {
+    revertDraftPickFlyToHand(cardId);
+    return;
+  }
+
+  const wrapper = getDraftCenterCardWrapper(cardId);
+  const poolCard = wrapper?.querySelector(".hand-card") as HTMLElement | null;
+  const fromRect = poolCard?.getBoundingClientRect();
+  const sourceHtml = poolCard?.outerHTML;
+
+  if (!fromRect || !sourceHtml || !poolCard || !wrapper || fromRect.width <= 0 || fromRect.height <= 0) {
+    revertDraftPickFlyToHand(cardId);
+    return;
+  }
+
+  draftHandPendingCardId = cardId;
+  wrapper.classList.add("draft-center-card-wrapper--flown-to-hand");
+  updateDraftPoolFlownVisualOnly();
+  updateDraftHandVisualOnly({ hiddenPendingMeasure: true });
+
+  await new Promise<void>((resolve) => {
+    window.requestAnimationFrame(() => window.requestAnimationFrame(() => resolve()));
+  });
+
+  const toTarget = getDraftHandFlyTargetForPending();
+
+  if (!toTarget) {
+    revertDraftPickFlyToHand(cardId);
+    return;
+  }
+
+  const poolScaleStart = clampDraftPickFlyScale(fromRect.width / readDraftHandCardMetrics().cardW);
+
+  await animateDraftPickFly(fromRect, toTarget.rect, sourceHtml, DRAFT_HAND_PICK_SCALE, {
+    direction: "to-hand",
+    scaleStart: poolScaleStart,
+    rotateStart: 0,
+    rotateEnd: toTarget.rotate,
+    flyWidth: readDraftHandCardMetrics().cardW,
+    flyHeight: readDraftHandCardMetrics().cardH,
+  });
+  updateDraftHandVisualOnly();
+}
+
+async function playDraftPickFlyToPool(cardId: string) {
+  const handCard = document.querySelector(
+    `[data-draft-hand-card-id="${cardId}"]`
+  ) as HTMLElement | null;
+  const sourceInnerHtml = handCard?.outerHTML;
+  const handFlySource = handCard ? getDraftHandFlySourceFromElement(handCard) : null;
+  const fromRect = handFlySource?.rect ?? handCard?.getBoundingClientRect();
+
+  if (!fromRect || !sourceInnerHtml || !handCard || fromRect.width <= 0 || fromRect.height <= 0) {
+    return;
+  }
+
+  handCard.classList.add("hand-card--picked-pending-hidden");
+
+  draftPoolFlyReturnCardId = cardId;
+  updateDraftPoolFlownVisualOnly();
+
+  const wrapper = getDraftCenterCardWrapper(cardId);
+  const poolCard = wrapper?.querySelector(".hand-card") as HTMLElement | null;
+  const poolTargetRect = poolCard?.getBoundingClientRect() ?? wrapper?.getBoundingClientRect();
+
+  if (!poolTargetRect) {
+    draftHandPendingCardId = null;
+    draftPoolFlyReturnCardId = null;
+    updateDraftHandVisualOnly();
+    updateDraftPoolFlownVisualOnly();
+    return;
+  }
+
+  const { cardW, cardH } = readDraftHandCardMetrics();
+  const poolScaleEnd = clampDraftPickFlyScale(poolTargetRect.width / cardW);
+
+  try {
+    await animateDraftPickFly(fromRect, poolTargetRect, sourceInnerHtml, poolScaleEnd, {
+      direction: "to-pool",
+      scaleStart: DRAFT_HAND_PICK_SCALE,
+      rotateStart: handFlySource?.rotate ?? 0,
+      rotateEnd: 0,
+      flyWidth: cardW,
+      flyHeight: cardH,
+    });
+  } finally {
+    draftHandPendingCardId = null;
+    draftPoolFlyReturnCardId = null;
+    updateDraftHandVisualOnly();
+    updateDraftPoolFlownVisualOnly();
+  }
+}
+
+async function playDraftPickSwap(fromCardId: string, toCardId: string) {
+  const fromHandEl = document.querySelector(
+    `[data-draft-hand-card-id="${fromCardId}"]`
+  ) as HTMLElement | null;
+  const fromHandFlySource = fromHandEl ? getDraftHandFlySourceFromElement(fromHandEl) : null;
+  const fromRect = fromHandFlySource?.rect ?? fromHandEl?.getBoundingClientRect();
+  const fromHtml = fromHandEl?.outerHTML;
+
+  const toPoolWrapper = getDraftCenterCardWrapper(toCardId);
+  const toPoolCard = toPoolWrapper?.querySelector(".hand-card") as HTMLElement | null;
+  const toPoolRect = toPoolCard?.getBoundingClientRect();
+  const toPoolHtml = toPoolCard?.outerHTML;
+
+  const fromPoolWrapper = getDraftCenterCardWrapper(fromCardId);
+  const fromPoolCard = fromPoolWrapper?.querySelector(".hand-card") as HTMLElement | null;
+  const fromPoolRect = fromPoolCard?.getBoundingClientRect();
+  const fromPoolHtml = fromPoolCard?.outerHTML;
+
+  if (
+    !fromRect ||
+    !fromHtml ||
+    !toPoolRect ||
+    !toPoolHtml ||
+    !fromPoolRect ||
+    !fromPoolHtml ||
+    !fromHandEl ||
+    fromRect.width <= 0 ||
+    toPoolRect.width <= 0 ||
+    fromPoolRect.width <= 0
+  ) {
+    return;
+  }
+
+  fromHandEl.classList.add("hand-card--picked-pending-hidden");
+
+  draftHandPendingCardId = toCardId;
+  draftPoolFlyReturnCardId = fromCardId;
+  updateDraftPoolFlownVisualOnly();
+  updateDraftHandVisualOnly({ hiddenPendingMeasure: true });
+
+  await new Promise<void>((resolve) => {
+    window.requestAnimationFrame(() => window.requestAnimationFrame(() => resolve()));
+  });
+
+  const toHandTarget = getDraftHandFlyTargetForPending();
+
+  if (!toHandTarget) {
+    fromHandEl.classList.remove("hand-card--picked-pending-hidden");
+    draftHandPendingCardId = fromCardId;
+    draftPoolFlyReturnCardId = null;
+    updateDraftPoolFlownVisualOnly();
+    updateDraftHandVisualOnly();
+    return;
+  }
+
+  const { cardW, cardH } = readDraftHandCardMetrics();
+  const returnScaleEnd = clampDraftPickFlyScale(fromPoolRect.width / cardW);
+  const poolPickScaleStart = clampDraftPickFlyScale(toPoolRect.width / cardW);
+
+  try {
+    await Promise.all([
+      animateDraftPickFly(fromRect, fromPoolRect, fromHtml, returnScaleEnd, {
+        direction: "to-pool",
+        scaleStart: DRAFT_HAND_PICK_SCALE,
+        rotateStart: fromHandFlySource?.rotate ?? 0,
+        rotateEnd: 0,
+        flyWidth: cardW,
+        flyHeight: cardH,
+      }),
+      animateDraftPickFly(toPoolRect, toHandTarget.rect, toPoolHtml, DRAFT_HAND_PICK_SCALE, {
+        scaleStart: poolPickScaleStart,
+        rotateStart: 0,
+        rotateEnd: toHandTarget.rotate,
+        flyWidth: cardW,
+        flyHeight: cardH,
+      }),
+    ]);
+  } finally {
+    draftPoolFlyReturnCardId = null;
+    updateDraftHandVisualOnly();
+    updateDraftPoolFlownVisualOnly();
+  }
+}
+
+function updateDraftHandVisualOnly(options?: { hiddenPendingMeasure?: boolean }) {
+  const cardsEl = document.querySelector(".player-hand__cards--draft") as HTMLElement | null;
+  if (!cardsEl) return;
+
+  const count = getDraftHandDisplayCount();
+  cardsEl.className = `player-hand__cards player-hand__cards--draft player-hand__cards--picked player-hand__cards--picked-count-${count}`;
+  cardsEl.innerHTML = renderPickedDraftCards(options);
+}
+
+function updateDraftPoolFlownVisualOnly() {
+  document.querySelectorAll(".draft-center-card-wrapper").forEach((wrapper) => {
+    const cardEl = wrapper.querySelector(
+      ".draft-center-card[data-draft-card-id]"
+    ) as HTMLElement | null;
+    const cardId = cardEl?.dataset.draftCardId;
+    if (!cardId) return;
+
+    wrapper.classList.remove("draft-center-card-wrapper--selected");
+    wrapper.classList.toggle("draft-center-card-wrapper--flown-to-hand", shouldHideDraftPoolSlot(cardId));
+
+    cardEl.style.removeProperty("z-index");
+    cardEl.style.removeProperty("isolation");
+
+    const innerCard = cardEl.querySelector(".hand-card") as HTMLElement | null;
+    innerCard?.classList.remove("hand-card--draft-selected");
+    innerCard?.style.removeProperty("z-index");
+    innerCard?.style.removeProperty("position");
+
+    const button = wrapper.querySelector(".draft-center-btn") as HTMLButtonElement | null;
+    if (button) {
+      button.textContent = "CHỌN";
+      button.classList.remove("daily-draft-card--selected");
+      button.style.removeProperty("z-index");
+      button.style.removeProperty("isolation");
+    }
+  });
+}
+
+async function handleDraftPickSelectionChange(
+  prevPending: string | null,
+  nextSelected: string | null,
+  cardId: string
+) {
+  isDraftPickFlying = true;
+
+  let didChangeHand = false;
+
+  try {
+    if (!nextSelected) {
+      if (prevPending) {
+        await playDraftPickFlyToPool(prevPending);
+        didChangeHand = true;
+      }
+    } else if (!prevPending) {
+      await playDraftPickFlyToHand(nextSelected);
+      didChangeHand = draftHandPendingCardId === nextSelected;
+    } else if (prevPending !== nextSelected) {
+      await playDraftPickSwap(prevPending, nextSelected);
+      didChangeHand = draftHandPendingCardId === nextSelected;
+    }
+
+    if (didChangeHand) {
+      updateDraftHandVisualOnly();
+    }
+
+    updateDraftSelectedVisualOnly();
+
+    if (isOnlineRoomActive()) {
+      selectOnlineDraftCard(cardId);
+    }
+  } finally {
+    isDraftPickFlying = false;
+    updateDraftConfirmButtonVisualOnly();
+    updateDraftPoolToggleVisualOnly();
+  }
 }
 
 function selectDraftCard(cardId: string) {
-  if (!isDraftPhase || isPassingDraftCards) return;
+  if (!isDraftPhase) return;
 
-  /*
-    Online dùng cùng cơ chế input cho mọi lượt 5/4/3/2/1:
-    - không bị dealing chặn click
-    - không full rerender hand khi chọn
-    - bấm lại cùng lá thì toggle hủy chọn
-  */
-  // Cho phép chọn bài ngay cả khi animation chia bài chưa gỡ class kịp.
-  // Nếu chặn bằng isInitialDealInProgress, chỉ cần animation bị kẹt là card không bấm được.
-  // if (!isOnlineRoomActive() && isInitialDealInProgress) return;
+  if (
+    isDraftPickFlying ||
+    isPassingDraftCards ||
+    isDraftDealVisualActive() ||
+    isDraftPoolCollapsed ||
+    isDraftPoolCollapseAnimating
+  ) {
+    return;
+  }
 
   if (suppressNextClick) {
     suppressNextClick = false;
@@ -2810,21 +4366,295 @@ function selectDraftCard(cardId: string) {
     }
   }
 
-  const nextSelectedCardId = draftSelectedCardId === cardId ? null : cardId;
+  const prevPending = draftHandPendingCardId;
+  const nextSelected = draftSelectedCardId === cardId ? null : cardId;
 
   playGameSound("cardSelect");
-  draftSelectedCardId = nextSelectedCardId;
+  draftSelectedCardId = nextSelected;
   focusedHandCardId = null;
   focusedBoardCard = null;
   focusedBoardPosition = null;
 
-  if (isOnlineRoomActive()) {
-    selectOnlineDraftCard(cardId);
-    updateDraftSelectedVisualOnly();
+  if (nextSelected && !prevPending) {
+    draftHandPendingCardId = nextSelected;
+    updateDraftPoolFlownVisualOnly();
+    updateDraftHandVisualOnly({ hiddenPendingMeasure: true });
+    updateDraftConfirmButtonVisualOnly();
+  }
+
+  void handleDraftPickSelectionChange(prevPending, nextSelected, cardId);
+}
+
+function confirmDraftPick() {
+  if (!isDraftPhase) return;
+
+  if (
+    isDraftPickFlying ||
+    isPassingDraftCards ||
+    !(draftHandPendingCardId || draftSelectedCardId)
+  ) {
     return;
   }
 
-  rerenderGameShell();
+  const cardId = draftSelectedCardId ?? draftHandPendingCardId;
+
+  if (!cardId) return;
+
+  if (isOnlineRoomActive()) {
+    confirmOnlineDraftPick();
+    return;
+  }
+
+  finishDraftPick(cardId);
+}
+
+function isOnlinePlanningPhase() {
+  return isOnlineRoomActive() && onlineClientState.roomState?.phase === "planning";
+}
+
+function getSelfPlanningConfirmLockSignature() {
+  const playerId = onlineClientState.playerId;
+  const state = onlineClientState.roomState;
+
+  if (!playerId || !state) {
+    return "";
+  }
+
+  const handIds = (state.self.hand ?? []).map((card) => card.id).join(",");
+  const dayIndex = state.dayIndex;
+  const board = state.players[playerId]?.board ?? [];
+  const dayBoard = board
+    .map((row) => row[dayIndex])
+    .map((cell) => cell?.cardId ?? "-")
+    .join(",");
+
+  return `${dayIndex}|${handIds}|${dayBoard}`;
+}
+
+function resetSelfPlanningConfirmLock() {
+  selfPlanningConfirmPending = false;
+  planningConfirmLockSignature = "";
+  planningConfirmRetryCount = 0;
+
+  if (planningConfirmRetryTimerId !== null) {
+    window.clearTimeout(planningConfirmRetryTimerId);
+    planningConfirmRetryTimerId = null;
+  }
+}
+
+function getServerPlanningConfirmProgress() {
+  const state = onlineClientState.roomState;
+
+  if (!state) {
+    return { total: 0, confirmed: 0 };
+  }
+
+  const connectedPlayerIds = playerIds.filter((playerId) => {
+    const player = state.players[playerId];
+
+    return player?.isConnected === true && player?.hasJoined === true;
+  });
+
+  const confirmedCount = connectedPlayerIds.filter((playerId) => {
+    return state.players[playerId]?.planningConfirmed === true;
+  }).length;
+
+  return {
+    total: connectedPlayerIds.length,
+    confirmed: confirmedCount,
+  };
+}
+
+function hasServerAckedPlanningConfirm() {
+  const playerId = onlineClientState.playerId;
+  const state = onlineClientState.roomState;
+
+  if (!playerId || !state) {
+    return false;
+  }
+
+  if (state.phase === "simulation" || state.phase === "result") {
+    return true;
+  }
+
+  return state.players[playerId]?.planningConfirmed === true;
+}
+
+function schedulePlanningConfirmRetry() {
+  if (planningConfirmRetryTimerId !== null) return;
+  if (!selfPlanningConfirmPending || !isOnlinePlanningPhase()) return;
+  if (hasServerAckedPlanningConfirm()) {
+    resetSelfPlanningConfirmLock();
+    return;
+  }
+
+  planningConfirmRetryTimerId = window.setTimeout(() => {
+    planningConfirmRetryTimerId = null;
+
+    if (
+      !selfPlanningConfirmPending ||
+      !isOnlinePlanningPhase() ||
+      hasServerAckedPlanningConfirm()
+    ) {
+      resetSelfPlanningConfirmLock();
+      updatePlanningConfirmButtonVisualOnly();
+      return;
+    }
+
+    planningConfirmRetryCount += 1;
+
+    if (planningConfirmRetryCount > 8) {
+      updatePlanningConfirmButtonVisualOnly();
+      return;
+    }
+
+    try {
+      confirmOnlinePlanning();
+    } catch {
+      resetSelfPlanningConfirmLock();
+      updatePlanningConfirmButtonVisualOnly();
+      return;
+    }
+
+    schedulePlanningConfirmRetry();
+  }, 2000);
+}
+
+function syncSelfPlanningConfirmLockFromServer() {
+  const state = onlineClientState.roomState;
+  const playerId = onlineClientState.playerId;
+
+  if (!state || !playerId) {
+    resetSelfPlanningConfirmLock();
+    return;
+  }
+
+  if (state.phase !== "planning") {
+    resetSelfPlanningConfirmLock();
+    lastOnlinePlanningDayIndex = null;
+    return;
+  }
+
+  if (
+    lastOnlinePlanningDayIndex !== null &&
+    lastOnlinePlanningDayIndex !== state.dayIndex
+  ) {
+    resetSelfPlanningConfirmLock();
+  }
+
+  lastOnlinePlanningDayIndex = state.dayIndex;
+
+  if (state.players[playerId]?.planningConfirmed === true) {
+    resetSelfPlanningConfirmLock();
+    return;
+  }
+
+  if (selfPlanningConfirmPending) {
+    schedulePlanningConfirmRetry();
+  }
+
+  if (
+    selfPlanningConfirmPending &&
+    planningConfirmLockSignature !== getSelfPlanningConfirmLockSignature()
+  ) {
+    resetSelfPlanningConfirmLock();
+  }
+}
+
+function isSelfPlanningConfirmed() {
+  const playerId = onlineClientState.playerId;
+  const state = onlineClientState.roomState;
+
+  if (!playerId || !state?.players[playerId]) {
+    return false;
+  }
+
+  if (state.players[playerId].planningConfirmed === true) {
+    return true;
+  }
+
+  return (
+    selfPlanningConfirmPending &&
+    planningConfirmLockSignature !== "" &&
+    planningConfirmLockSignature === getSelfPlanningConfirmLockSignature()
+  );
+}
+
+function getPlanningConfirmStatusLabel() {
+  const state = onlineClientState.roomState;
+  const serverProgress = getServerPlanningConfirmProgress();
+
+  if (state?.phase === "simulation") {
+    return "Đang quét...";
+  }
+
+  if (serverProgress.total <= 0) {
+    return "";
+  }
+
+  const selfServerConfirmed =
+    state?.players[onlineClientState.playerId ?? "p1"]?.planningConfirmed === true;
+
+  if (isSelfPlanningConfirmed() && !selfServerConfirmed) {
+    if (planningConfirmRetryCount > 8) {
+      if (serverProgress.total <= 1) {
+        return "Không kết nối server • chạy: cd TREKPOLOGY/server && npm start";
+      }
+
+      return "Không nhận phản hồi server • thử reload trang";
+    }
+
+    if (serverProgress.total <= 1) {
+      return "Đã xác nhận • đang chạy lịch trình...";
+    }
+
+    if (serverProgress.total > 1) {
+      const waitingCount = Math.max(0, serverProgress.total - serverProgress.confirmed - 1);
+
+      return `Đã xác nhận • chờ ${waitingCount} người (${serverProgress.confirmed + 1}/${serverProgress.total})`;
+    }
+
+    return "Đã xác nhận • đang đồng bộ server...";
+  }
+
+  if (serverProgress.confirmed >= serverProgress.total) {
+    return "Đủ người xác nhận • đang quét...";
+  }
+
+  if (isSelfPlanningConfirmed()) {
+    const waitingCount = serverProgress.total - serverProgress.confirmed;
+
+    return `Đã xác nhận • chờ ${waitingCount} người (${serverProgress.confirmed}/${serverProgress.total})`;
+  }
+
+  if (serverProgress.total > 1) {
+    return `Cần tất cả online xác nhận (${serverProgress.confirmed}/${serverProgress.total})`;
+  }
+
+  return "";
+}
+
+function confirmPlanningPick() {
+  if (!isOnlinePlanningPhase()) return;
+  if (isSelfPlanningConfirmed()) return;
+
+  selfPlanningConfirmPending = true;
+  planningConfirmLockSignature = getSelfPlanningConfirmLockSignature();
+  planningConfirmRetryCount = 0;
+
+  try {
+    confirmOnlinePlanning();
+  } catch (error) {
+    resetSelfPlanningConfirmLock();
+
+    const message = error instanceof Error ? error.message : "Không gửi được xác nhận.";
+    alert(message);
+    updatePlanningConfirmButtonVisualOnly();
+    return;
+  }
+
+  updatePlanningConfirmButtonVisualOnly();
+  schedulePlanningConfirmRetry();
 }
 
 
@@ -2911,14 +4741,7 @@ function clearDailyDealTimer() {
 }
 
 function activateDraftDealAnimation() {
-  playGameSound("deal");
-
-  window.requestAnimationFrame(() => {
-    window.requestAnimationFrame(() => {
-      const handElement = document.querySelector(".player-hand--draft.player-hand--dealing");
-      handElement?.classList.add("deal-active");
-    });
-  });
+  startDraftCenterDealAnimation(getDraftCenterDealDurationForCurrentPool());
 }
 
 function ensureOnlineDraftDealAnimationStarted() {
@@ -2929,6 +4752,90 @@ function ensureOnlineDraftDealAnimationStarted() {
   if (!handElement || handElement.classList.contains("deal-active")) return;
 
   handElement.classList.add("deal-active");
+}
+
+function applyDraftReturnGatherVars(
+  cards: HTMLElement[],
+  gatherCenterX: number,
+  gatherCenterY: number,
+  deckInsertX: number,
+  deckInsertY: number
+) {
+  cards.forEach((card, index) => {
+    const cardRect = card.getBoundingClientRect();
+    const cardCenterX = cardRect.left + cardRect.width * 0.5;
+    const cardCenterY = cardRect.top + cardRect.height * 0.5;
+    const stackOffset = index - (cards.length - 1) / 2;
+
+    const gatherX = gatherCenterX - cardCenterX + stackOffset * 5;
+    const gatherY = gatherCenterY - cardCenterY + Math.abs(stackOffset) * 3;
+    const deckX = deckInsertX - cardCenterX + stackOffset * 2;
+    const deckY = deckInsertY - cardCenterY + stackOffset * 2;
+
+    const arc1X = gatherX + (deckX - gatherX) * 0.34;
+    const arc1Y = Math.min(gatherY, deckY) - 150 - Math.abs(stackOffset) * 7;
+    const arc2X = gatherX + (deckX - gatherX) * 0.72;
+    const arc2Y = Math.min(gatherY, deckY) - 185 - Math.abs(stackOffset) * 5;
+
+    card.style.setProperty("--gather-x", `${gatherX}px`);
+    card.style.setProperty("--gather-y", `${gatherY}px`);
+    card.style.setProperty("--gather-r", `${stackOffset * 4}deg`);
+
+    card.style.setProperty("--arc1-x", `${arc1X}px`);
+    card.style.setProperty("--arc1-y", `${arc1Y}px`);
+    card.style.setProperty("--arc2-x", `${arc2X}px`);
+    card.style.setProperty("--arc2-y", `${arc2Y}px`);
+
+    card.style.setProperty("--deck-in-x", `${deckX}px`);
+    card.style.setProperty("--deck-in-y", `${deckY}px`);
+    card.style.setProperty("--deck-r", `${-6 + stackOffset * 3}deg`);
+  });
+}
+
+function activateDraftCenterPoolPassAnimation() {
+  playGameSound("returnDeck");
+
+  window.requestAnimationFrame(() => {
+    window.requestAnimationFrame(() => {
+      const overlayElement =
+        (document.querySelector(
+          ".draft-center-overlay--passing:not(.draft-center-overlay--returning)"
+        ) as HTMLElement | null) ??
+        (document.querySelector(".draft-center-overlay:not(.draft-center-overlay--returning)") as HTMLElement | null);
+      const deckStackElement = document.querySelector(".deck-card-stack") as HTMLElement | null;
+
+      if (!overlayElement || !deckStackElement) return;
+
+      const passingCards = Array.from(
+        overlayElement.querySelectorAll(
+          ".draft-center-card-wrapper:not(.draft-center-card-wrapper--flown-to-hand)"
+        )
+      ) as HTMLElement[];
+
+      if (passingCards.length === 0) return;
+
+      overlayElement.classList.add("draft-center-overlay--passing");
+
+      const overlayRect = overlayElement.getBoundingClientRect();
+      const deckRect = deckStackElement.getBoundingClientRect();
+
+      const gatherCenterX = overlayRect.left + overlayRect.width * 0.5;
+      const gatherCenterY = overlayRect.top + overlayRect.height * 0.38;
+      const deckInsertX = deckRect.left + deckRect.width * 0.34;
+      const deckInsertY = deckRect.top + deckRect.height * 0.54;
+
+      applyDraftReturnGatherVars(
+        passingCards,
+        gatherCenterX,
+        gatherCenterY,
+        deckInsertX,
+        deckInsertY
+      );
+
+      deckStackElement.closest(".deck-pile-panel")?.classList.add("deck-receiving");
+      overlayElement.classList.add("pass-active");
+    });
+  });
 }
 
 function activateDraftPassAnimation() {
@@ -2998,16 +4905,59 @@ function activateDraftPassAnimation() {
   });
 }
 
+function activateDraftCenterReturnAnimation() {
+  playGameSound("returnDeck");
+
+  window.requestAnimationFrame(() => {
+    window.requestAnimationFrame(() => {
+      const overlayElement = document.querySelector(
+        ".draft-center-overlay--returning"
+      ) as HTMLElement | null;
+      const deckStackElement = document.querySelector(".deck-card-stack") as HTMLElement | null;
+
+      if (!overlayElement || !deckStackElement) return;
+
+      const returnCards = Array.from(
+        overlayElement.querySelectorAll(".draft-center-card-wrapper--return")
+      ) as HTMLElement[];
+
+      const overlayRect = overlayElement.getBoundingClientRect();
+      const deckRect = deckStackElement.getBoundingClientRect();
+
+      const gatherCenterX = overlayRect.left + overlayRect.width * 0.5;
+      const gatherCenterY = overlayRect.top + overlayRect.height * 0.38;
+
+      const deckInsertX = deckRect.left + deckRect.width * 0.34;
+      const deckInsertY = deckRect.top + deckRect.height * 0.54;
+
+      applyDraftReturnGatherVars(
+        returnCards,
+        gatherCenterX,
+        gatherCenterY,
+        deckInsertX,
+        deckInsertY
+      );
+
+      deckStackElement.closest(".deck-pile-panel")?.classList.add("deck-receiving");
+      overlayElement.classList.add("pass-active");
+    });
+  });
+}
+
 function finishDraftDealWithoutFullRerender() {
   isInitialDealInProgress = false;
   dailyDealTimerId = null;
+  clearDraftCenterDealAnimation();
+  draftDealVisualEndsAt = 0;
 
   const handElement = document.querySelector(".player-hand");
   handElement?.classList.remove("player-hand--dealing", "is-dealing", "deal-active");
 
   const handMeta = handElement?.querySelector(".player-hand__meta");
   if (handMeta) {
-    handMeta.textContent = `Còn ${draftPickSecondsLeft}s • bấm 1 lá để chọn`;
+    handMeta.textContent = isDraftPickTimerFrozen()
+      ? "Đang chia bài..."
+      : `Còn ${getDraftTimerDisplayLabel()} • bấm 1 lá để chọn`;
   }
 
   const draftInfo = handElement?.querySelector(".draft-hand-meta__info em");
@@ -3016,18 +4966,23 @@ function finishDraftDealWithoutFullRerender() {
   }
 
   startDraftTimer();
+  updateDraftPoolToggleVisualOnly();
 }
 
 function finishOnlineDraftDealVisualOnly() {
   isInitialDealInProgress = false;
   onlineDraftAnimationTimerId = null;
+  clearDraftCenterDealAnimation();
+  draftDealVisualEndsAt = 0;
 
   const handElement = document.querySelector(".player-hand");
   handElement?.classList.remove("player-hand--dealing", "is-dealing", "deal-active");
 
   const handMeta = handElement?.querySelector(".player-hand__meta");
   if (handMeta) {
-    handMeta.textContent = `Còn ${draftPickSecondsLeft}s • bấm 1 lá để chọn`;
+    handMeta.textContent = isDraftPickTimerFrozen()
+      ? "Đang chia bài..."
+      : `Còn ${getDraftTimerDisplayLabel()} • bấm 1 lá để chọn`;
   }
 
   const draftInfo = handElement?.querySelector(".draft-hand-meta__info em");
@@ -3036,6 +4991,8 @@ function finishOnlineDraftDealVisualOnly() {
   }
 
   updateDraftSelectedVisualOnly();
+  updateDraftConfirmButtonVisualOnly();
+  updateDraftPoolToggleVisualOnly();
 }
 
 function playOnlinePlanningHandDealAfterDraft() {
@@ -3084,18 +5041,20 @@ function playDraftDealAnimationAndStartTimer() {
   stopDraftTimer();
   clearDailyDealTimer();
 
+  resetDraftPoolCollapseState();
   isInitialDealInProgress = true;
   draftSelectedCardId = null;
   rerenderArena();
-  activateDraftDealAnimation();
+  const dealMs = getDraftCenterDealDurationForCurrentPool();
+  startDraftCenterDealAnimation(dealMs);
 
   /*
-    CSS draft deal 7 lá: animation chạy trực tiếp trên 7 wrapper.
+    CSS draft deal: animation chạy trên từng wrapper theo số lá pool hiện tại.
     Không rerender toàn arena ở frame cuối; chỉ gỡ class để tránh snap/jank.
   */
   dailyDealTimerId = window.setTimeout(() => {
     finishDraftDealWithoutFullRerender();
-  }, 1320);
+  }, dealMs);
 }
 
 function finishDailyDealAndStartTimer() {
@@ -3398,11 +5357,11 @@ function renderScoreBreakdownPanel() {
           : isDraftPhase
             ? `
               <div
-                class="score-breakdown__timer ${draftPickSecondsLeft <= 3 ? "score-breakdown__timer--danger" : ""}"
+                class="score-breakdown__timer ${isDraftTimerDanger() ? "score-breakdown__timer--danger" : ""}"
                 title="Thời gian chọn bài trong phase chia bài."
               >
                 <span>DRAFT</span>
-                <strong>${draftPickSecondsLeft}s</strong>
+                <strong>${getDraftTimerDisplayLabel()}</strong>
               </div>
             `
             : `
@@ -3428,7 +5387,7 @@ function renderResourceOrbs() {
 
   return `
     <div class="resource-orbs" aria-label="Tài nguyên hiện tại">
-      <div class="resource-orb resource-orb--coin" title="Xu hiện có">
+      <div class="resource-orb resource-orb--coin ${resourceOrbFlashType === "coin" ? "resource-orb--effect-pulse" : ""}" title="Xu hiện có">
         <div class="resource-orb__frame">
           <div class="resource-orb__icon resource-orb__icon--coin">💰</div>
           <div class="resource-orb__value">${remaining.coin}</div>
@@ -3436,7 +5395,7 @@ function renderResourceOrbs() {
         <div class="resource-orb__label">TIỀN</div>
       </div>
 
-      <div class="resource-orb resource-orb--stamina" title="Thể lực hiện có">
+      <div class="resource-orb resource-orb--stamina ${resourceOrbFlashType === "stamina" ? "resource-orb--effect-pulse" : ""}" title="Thể lực hiện có">
         <div class="resource-orb__frame">
           <div class="resource-orb__icon resource-orb__icon--stamina">🏃</div>
           <div class="resource-orb__value">${remaining.stamina}</div>
@@ -4029,11 +5988,7 @@ function renderPlayerEffectTokens() {
   }
 
   if (!effectTokens.length) {
-    return `
-      <div class="player-effect-dock player-effect-dock--empty">
-        <div class="player-effect-dock__placeholder">Hiệu ứng đang có</div>
-      </div>
-    `;
+    return "";
   }
 
   return `
@@ -4047,14 +6002,66 @@ function renderDeckPilePanel() {
   const deckCount = isOnlineRoomActive() ? 0 : deck.length;
   const handCount =
     (isOnlineRoomActive() ? getOnlineSelfHand() : null)?.length ?? playerHand.length;
+  const canConfirm =
+    !!(draftHandPendingCardId || draftSelectedCardId) &&
+    !isDraftPickFlying &&
+    !isPassingDraftCards &&
+    !isDraftDealVisualActive() &&
+    !isDraftPoolCollapseAnimating;
+  const isOnlinePlanning = isOnlinePlanningPhase();
+  const selfPlanningConfirmed = isSelfPlanningConfirmed();
+  const serverPhase = onlineClientState.roomState?.phase;
+  const showDraftConfirm = isDraftPhase && serverPhase === "draft";
+  const showPlanningConfirm = isOnlinePlanning && serverPhase === "planning";
+  const planningStatusLabel = showPlanningConfirm ? getPlanningConfirmStatusLabel() : "";
+  const planningConfirmButton = showPlanningConfirm
+    ? `
+      <div class="deck-pile-panel__planning-actions">
+        <button
+          type="button"
+          class="deck-pile-panel__planning-confirm"
+          onclick="event.stopPropagation(); confirmPlanningPick()"
+          ${selfPlanningConfirmed ? "disabled" : ""}
+        >
+          ${selfPlanningConfirmed ? "Đã xác nhận" : "Xác nhận"}
+        </button>
+        ${planningStatusLabel ? `<div class="deck-pile-panel__planning-status">${planningStatusLabel}</div>` : ""}
+      </div>
+    `
+    : "";
+  const draftConfirmButton = showDraftConfirm
+    ? `
+      <button
+        type="button"
+        class="deck-pile-panel__draft-confirm"
+        onclick="event.stopPropagation(); confirmDraftPick()"
+        ${canConfirm ? "" : "disabled"}
+      >
+        Kết thúc lượt
+      </button>
+    `
+    : "";
+  const phaseConfirmButton = draftConfirmButton || planningConfirmButton;
+
+  const effectTokensHtml = renderPlayerEffectTokens();
+  const poolToggleButton = renderDraftPoolCollapseButton();
+  const showDeckHeader = showDraftConfirm || showPlanningConfirm || effectTokensHtml.length > 0;
+  const deckPanelHeader = showDeckHeader
+    ? `
+      <div class="deck-pile-panel__header">
+        <div class="deck-pile-panel__header-left">${poolToggleButton}${effectTokensHtml}</div>
+        <div class="deck-pile-panel__header-right">${phaseConfirmButton}</div>
+      </div>
+    `
+    : "";
 
   return `
     <section
-      class="deck-pile-panel"
+      class="deck-pile-panel${isDraftPhase ? " deck-pile-panel--draft" : ""}"
       data-discard-drop-zone="true"
       title="Kéo thả lá bài trên tay vào đây để discard và nhận lại Xu/Thể lực bằng chi phí của lá."
     >
-      ${renderPlayerEffectTokens()}
+      ${deckPanelHeader}
 
       <div class="deck-pile-panel__visual">
         <div class="deck-card-stack">
@@ -4124,6 +6131,7 @@ function renderMainArena() {
         ${renderScoreBreakdownPanel()}
       </div>
 
+
       ${renderResourceOrbs()}
 
       <div class="arena__main">
@@ -4155,6 +6163,7 @@ function renderMainArena() {
                             title="${isCurrentDayColumn ? (isPlaceable ? "Thả lá đang kéo vào ô ngày hiện tại" : "Chỉ xếp bài cho ngày hiện tại") : "Không phải ngày hiện tại"}"
                           >
                             <span class="empty-plus">+</span>
+                            ${renderUtilityEffectFlash(rowIndex, colIndex)}
                           </div>
                         `;
                       }
@@ -4169,6 +6178,7 @@ function renderMainArena() {
                           title="Ô đã có bài - bấm để xem lớn"
                         >
                           ${renderBoardMiniCard(card, getReplayStepForBoardCell(rowIndex, colIndex))}
+                            ${renderUtilityEffectFlash(rowIndex, colIndex)}
                         </div>
                       `;
                     })
@@ -4177,6 +6187,7 @@ function renderMainArena() {
               })
               .join("")}
           </section>
+          ${renderDraftCenterOverlay()}${renderDraftLeftoverReturnOverlay()}
         </div>
 
         ${isOnlineGameOver() ? renderFinalRankingPanel() : isDraftPhase ? "" : renderSimulationResultPanel()}
@@ -4186,7 +6197,7 @@ function renderMainArena() {
             ? ""
             : `
               <section
-          class="player-hand ${isInitialDealInProgress ? "player-hand--dealing is-dealing" : ""} ${isDraftPhase ? "player-hand--draft" : ""}"
+          class="player-hand ${isDraftPhase ? "player-hand--draft" : ""} ${!isDraftPhase && isInitialDealInProgress ? "player-hand--dealing is-dealing" : ""}"
           onclick="${isDraftPhase ? "" : "clearSelectedHandCard()"}"
         >
           <div class="player-hand__top">
@@ -4201,11 +6212,11 @@ function renderMainArena() {
               </h2>
             </div>
 
-            <div class="player-hand__meta ${isDraftPhase && draftPickSecondsLeft <= 3 ? "player-hand__meta--danger" : ""}">
+            <div class="player-hand__meta ${isDraftPhase && isDraftTimerDanger() ? "player-hand__meta--danger" : ""}">
               ${
                 isDraftPhase
-                  ? isInitialDealInProgress
-                    ? "Đang phát bài..."
+                  ? isDraftPickTimerFrozen()
+                    ? "Đang chia bài..."
                     : `Còn ${draftPickSecondsLeft}s • ${isPassingDraftCards ? "Đang chuyền bài..." : "bấm 1 lá để chọn"}`
                   : isInitialDealInProgress
                     ? "Đang chia bài..."
@@ -4216,8 +6227,8 @@ function renderMainArena() {
 
           ${isDraftPhase ? renderDraftHandTopMeta() : ""}
 
-          <div class="player-hand__cards ${isDraftPhase && isPassingDraftCards ? "is-passing" : ""}">
-            ${isDraftPhase ? renderDraftHandCards() : playerHand.map((card, index) => renderHandCard(card, index)).join("")}
+          <div class="player-hand__cards ${isDraftPhase ? `player-hand__cards--draft player-hand__cards--picked player-hand__cards--picked-count-${getDraftHandDisplayCount()}` : ""}">
+            ${isDraftPhase ? renderPickedDraftCards() : playerHand.map((card, index) => renderHandCard(card, index)).join("")}
           </div>
         </section>
             `
@@ -4236,11 +6247,47 @@ function clearHoldTimer() {
   }
 }
 
+let lastAnimatedCoin = -1;
+let lastAnimatedStamina = -1;
+
+function spawnFloatingText(selector: string, delta: number, type: 'coin' | 'stamina') {
+  const container = document.querySelector(selector);
+  if (!container) return;
+  const textNode = document.createElement('div');
+  textNode.className = `floating-text floating-text--${type}`;
+  textNode.textContent = `${delta > 0 ? '+' : ''}${delta}`;
+  container.appendChild(textNode);
+  container.classList.remove('resource-pulse');
+  void container.clientWidth; // force reflow
+  container.classList.add('resource-pulse');
+  setTimeout(() => textNode.remove(), 1200);
+}
+
 function rerenderArena() {
   const arena = document.querySelector(".arena");
   if (!arena) return;
 
   arena.outerHTML = renderMainArena();
+
+  if (isDraftDealVisualActive()) {
+    window.requestAnimationFrame(() => {
+      window.requestAnimationFrame(() => {
+        restartDraftCenterDealVisuals();
+      });
+    });
+  }
+
+  requestAnimationFrame(() => {
+    const remaining = getRemainingResources();
+    if (lastAnimatedCoin !== -1 && remaining.coin !== lastAnimatedCoin) {
+      spawnFloatingText('.resource-orb--coin .resource-orb__frame', remaining.coin - lastAnimatedCoin, 'coin');
+    }
+    if (lastAnimatedStamina !== -1 && remaining.stamina !== lastAnimatedStamina) {
+      spawnFloatingText('.resource-orb--stamina .resource-orb__frame', remaining.stamina - lastAnimatedStamina, 'stamina');
+    }
+    lastAnimatedCoin = remaining.coin;
+    lastAnimatedStamina = remaining.stamina;
+  });
 }
 
 function placeHandCardOnBoard(cardId: string, rowIndex: number, colIndex: number) {
@@ -4255,6 +6302,17 @@ function placeHandCardOnBoard(cardId: string, rowIndex: number, colIndex: number
 
   if (isOnlineRoomActive()) {
     playGameSound("cardPlace");
+
+    const onlineUtilityEffect = getUtilityPlacementEffect(selectedCard);
+
+    if (onlineUtilityEffect) {
+      triggerUtilityEffectFlash({
+        rowIndex,
+        colIndex,
+        type: onlineUtilityEffect.type,
+        value: onlineUtilityEffect.value,
+      });
+    }
 
     sendPlaceCard({
       cardId: selectedCard.id,
@@ -4275,6 +6333,10 @@ function placeHandCardOnBoard(cardId: string, rowIndex: number, colIndex: number
     focusedBoardPosition = null;
     suppressNextClick = false;
 
+    if (onlineUtilityEffect) {
+      rerenderArena();
+    }
+
     return;
   }
 
@@ -4285,15 +6347,20 @@ function placeHandCardOnBoard(cardId: string, rowIndex: number, colIndex: number
   playGameSound("cardPlace");
 
   playerHand.splice(handIndex, 1);
-  getBoardSlots()[rowIndex][colIndex] = selectedCard;
 
-  addLocalDebtOrExhaustToken({
-    rowIndex,
-    colIndex,
-    card: selectedCard,
-    coinDebt,
-    staminaDebt,
-  });
+  const didApplyUtilityEffect = applyUtilityPlacementEffect(selectedCard, rowIndex, colIndex);
+
+  if (!didApplyUtilityEffect) {
+    getBoardSlots()[rowIndex][colIndex] = selectedCard;
+
+    addLocalDebtOrExhaustToken({
+      rowIndex,
+      colIndex,
+      card: selectedCard,
+      coinDebt,
+      staminaDebt,
+    });
+  }
 
   sendPlaceCard({
     cardId: selectedCard.id,
@@ -4556,6 +6623,9 @@ function clearCustomHandDragVisuals() {
   handPointerDragState?.clone?.remove();
   handPointerDragState = null;
   draggedHandCardId = null;
+  
+  // Valid Slot Highlight Remove
+  document.querySelectorAll('.board-cell--placeable').forEach(el => el.classList.remove('board-cell--placeable'));
 }
 
 function handleHandPointerMove(event: PointerEvent) {
@@ -4823,6 +6893,15 @@ function clearBoardDragHoverClass() {
   document.addEventListener("pointermove", handleHandPointerMove);
   document.addEventListener("pointerup", handleHandPointerUp);
   document.addEventListener("pointercancel", handleHandPointerCancel);
+
+  // Valid Slot Highlight
+  document.querySelectorAll('.board-cell').forEach((el) => {
+    const r = parseInt(el.getAttribute('data-row-index') || '-1');
+    const c = parseInt(el.getAttribute('data-col-index') || '-1');
+    if (r >= 0 && c >= 0 && canPlaceOnBoardCell(r, c)) {
+      el.classList.add('board-cell--placeable');
+    }
+  });
 };
 
 (window as any).openDebtTokenModal = () => {
@@ -4839,10 +6918,12 @@ function clearBoardDragHoverClass() {
 
 (window as any).selectDraftCard = selectDraftCard;
 
-(window as any).confirmDraftPick = () => {
-  // Draft phase: click card = select only.
-  // Cards are passed only when the 10s timer reaches 0.
-};
+(window as any).confirmDraftPick = confirmDraftPick;
+(globalThis as any).confirmDraftPick = confirmDraftPick;
+(window as any).confirmPlanningPick = confirmPlanningPick;
+(globalThis as any).confirmPlanningPick = confirmPlanningPick;
+(window as any).toggleDraftPoolCollapse = toggleDraftPoolCollapse;
+(globalThis as any).toggleDraftPoolCollapse = toggleDraftPoolCollapse;
 
 (window as any).startHoldHandCard = (id: string) => {
   if (isPassingDraftCards || isInitialDealInProgress) return;
@@ -5117,7 +7198,7 @@ function renderMidGameRankingModal() {
    - Menu phòng có nút bật/tắt + thanh âm lượng.
    ========================================= */
 
-const IN_GAME_BACKGROUND_MUSIC_SRC = "/assets/audio/music/in-game-background.mp3";
+const IN_GAME_BACKGROUND_MUSIC_SRC = "assets/sounds/in-game-background.mp3";
 const IN_GAME_MUSIC_MUTED_KEY = "travelDeck.inGameMusicMuted";
 const IN_GAME_MUSIC_VOLUME_KEY = "travelDeck.inGameMusicVolume";
 const DEFAULT_IN_GAME_MUSIC_VOLUME = 0.5;
@@ -5167,6 +7248,7 @@ function stopOutsideBackgroundMedia() {
     Tắt hẳn audio/video nền ngoài màn chơi, đặc biệt là video hero ở dashboard.
     Không đụng tới audio nền riêng trong game.
   */
+  cleanupDashboardHub();
   document.querySelectorAll("audio, video").forEach((media) => {
     if (media === inGameBackgroundMusic) return;
 
@@ -5388,21 +7470,25 @@ function transitionToScreen(newScreen: AppScreen) {
   });
 }
 
+let isTransitioning = false;
+
 (window as any).gotoMapSelection = () => {
+  if (isTransitioning) return;
   if (!authClientState.user) {
     (window as any).focusHubAuthPanel();
     setAuthStatus("Đăng nhập hoặc đăng ký để bắt đầu hành trình.");
     return;
   }
+  isTransitioning = true;
 
   // 1. Create overlay video — plays from beginning (smoke effect)
   const vid = document.createElement("video");
-  vid.src = "/assets/videos/chuyencanh.mp4";
+  vid.src = "./assets/chuyencanh.mp4";
   vid.muted = true;
   vid.playsInline = true;
   vid.style.cssText = [
     "position:fixed", "inset:0", "width:100%", "height:100%",
-    "object-fit:cover", "z-index:9999", "pointer-events:none",
+    "object-fit:cover", "z-index:9999", "pointer-events:auto",
     "opacity:0", "transition:opacity 0.4s ease"
   ].join(";");
   document.body.appendChild(vid);
@@ -5418,6 +7504,7 @@ function transitionToScreen(newScreen: AppScreen) {
     // 2. When smoke covers screen (~3.5s), swap to map selection
     if (!transitioned && vid.currentTime >= 3.5) {
       transitioned = true;
+      isTransitioning = false;
       bgSmokeVideo = vid;
 
       // Remove from body — rerenderGameShell will re-insert it into the screen
@@ -5595,6 +7682,14 @@ function triggerCinematicLobbyToGameTransition() {
   console.log("TRIGGERING CINEMATIC TRANSITION!");
   isCinematicTransitioning = true;
   
+  const blocker = document.createElement("div");
+  blocker.id = "cinematic-blocker";
+  blocker.style.cssText = "position:fixed;inset:0;z-index:99999999;cursor:wait;";
+  blocker.addEventListener("mousedown", (e) => { e.preventDefault(); e.stopPropagation(); });
+  blocker.addEventListener("click", (e) => { e.preventDefault(); e.stopPropagation(); });
+  blocker.addEventListener("touchstart", (e) => { e.preventDefault(); e.stopPropagation(); }, {passive: false});
+  document.body.appendChild(blocker);
+  
   const lobbyCard = document.querySelector(".online-lobby-card");
   if (lobbyCard) lobbyCard.classList.add("is-exiting");
 
@@ -5610,6 +7705,7 @@ function triggerCinematicLobbyToGameTransition() {
 
   setTimeout(() => {
     video.style.display = "block";
+    video.style.pointerEvents = "none";
     video.currentTime = 0;
     
     // Play with sound, fallback to muted if autoplay blocked
@@ -5621,6 +7717,13 @@ function triggerCinematicLobbyToGameTransition() {
         });
     });
 
+    video.onpause = () => {
+      if (isCinematicTransitioning) {
+          console.warn("Video paused unexpectedly, resuming...");
+          video.play().catch(err => console.error(err));
+      }
+    };
+
     const finishTransition = () => {
       if (!isCinematicTransitioning) return;
       isCinematicTransitioning = false;
@@ -5629,6 +7732,9 @@ function triggerCinematicLobbyToGameTransition() {
       overlay.style.opacity = "1";
       video.style.display = "none";
       video.ontimeupdate = null; // cleanup
+      
+      const b = document.getElementById("cinematic-blocker");
+      if (b) b.remove();
       
       rerenderGameShell();
       
@@ -5749,10 +7855,28 @@ function renderGameShell() {
 }
 
 (window as any).rerenderGameShell = rerenderGameShell;
+function applyLobbyBackground() {
+  const isLobbyScreen =
+    !isOnlineRoomActive() ||
+    onlineClientState.roomState?.phase === "lobby";
+
+  if (isLobbyScreen) {
+    // Set background directly on #app — inline style beats CSS !important
+    app.style.setProperty("background",
+      "url('./assets/backgrounds/lobby-background.jpg') center/cover no-repeat #0c0b11",
+      "important"
+    );
+  } else {
+    // Remove inline override, let CSS handle game background
+    app.style.removeProperty("background");
+  }
+}
+
 function rerenderGameShell() {
   stopOutsideBackgroundMedia();
 
   app.innerHTML = renderGameShell();
+  applyLobbyBackground();
   setupSaigonCollageHover();
   syncInGameBackgroundMusic();
   initDashboardHub();
@@ -5764,21 +7888,129 @@ function rerenderGameShell() {
       screen.insertBefore(bgSmokeVideo, screen.firstChild);
     }
   }
+
+  if (isDraftDealVisualActive()) {
+    window.requestAnimationFrame(() => {
+      window.requestAnimationFrame(() => {
+        restartDraftCenterDealVisuals();
+      });
+    });
+  }
 }
 
 let lastOnlineRenderSignature = "";
 let lastOnlineAnimationPhase: string | null = null;
+let selfPlanningConfirmPending = false;
+let planningConfirmLockSignature = "";
+let lastOnlinePlanningDayIndex: number | null = null;
+let planningConfirmRetryTimerId: number | null = null;
+let planningConfirmRetryCount = 0;
 let lastOnlineAnimationDraftRound = 0;
 let lastOnlineAnimationPoolSignature = "";
 let onlineDraftAnimationTimerId: number | null = null;
 let hasStartedOnlineSimulationReplay = false;
 let onlineDraftDisplayPool: TravelCardData[] | null = null;
+let onlineDraftPassSnapshotPool: TravelCardData[] | null = null;
 let onlineDraftPendingPool: TravelCardData[] | null = null;
+let onlinePassCompleteRetryCount = 0;
+
+let isDraftCenterDealing = false;
+let draftDealVisualEndsAt = 0;
+let isDraftPickFlying = false;
+let draftHandPendingCardId: string | null = null;
+let draftPoolFlyReturnCardId: string | null = null;
+let lastOnlinePickedDraftCount = 0;
+const DRAFT_PICK_FLY_MS = 750;
+const DRAFT_POOL_COLLAPSE_MS = 1350;
+const DRAFT_HAND_PICK_SCALE = 0.84;
 let shouldActivateOnlineDealAnimation = false;
 let shouldActivateOnlinePassAnimation = false;
 let isOnlineFinalDraftReturnAnimating = false;
 let onlineFinalDraftReturnTimerId: number | null = null;
 let hasPlayedOnlinePlanningDealAfterDraft = false;
+let draftCenterDealEndTimerId: number | null = null;
+let draftCenterDealGeneration = 0;
+
+function isDraftDealVisualActive(): boolean {
+  return (
+    isDraftCenterDealing ||
+    isInitialDealInProgress ||
+    Date.now() < draftDealVisualEndsAt
+  );
+}
+
+function restartDraftCenterDealVisuals(): boolean {
+  const overlay = document.querySelector(".draft-center-overlay") as HTMLElement | null;
+  if (!overlay) return false;
+
+  overlay.classList.remove("draft-center-overlay--dealing");
+
+  const wrappers = overlay.querySelectorAll(".draft-center-card-wrapper");
+  wrappers.forEach((node) => {
+    const wrapper = node as HTMLElement;
+    wrapper.classList.remove("draft-center-card-wrapper--flown-to-hand");
+    wrapper.style.animation = "none";
+  });
+
+  void overlay.offsetWidth;
+
+  wrappers.forEach((node) => {
+    (node as HTMLElement).style.removeProperty("animation");
+  });
+
+  overlay.classList.add("draft-center-overlay--dealing");
+  return true;
+}
+
+function clearDraftCenterDealAnimation() {
+  draftCenterDealGeneration += 1;
+
+  if (draftCenterDealEndTimerId !== null) {
+    window.clearTimeout(draftCenterDealEndTimerId);
+    draftCenterDealEndTimerId = null;
+  }
+
+  isDraftCenterDealing = false;
+  document.querySelector(".draft-center-overlay")?.classList.remove("draft-center-overlay--dealing");
+}
+
+function getDraftCenterPoolSignature(): string {
+  const pool = isOnlineRoomActive()
+    ? (getOnlineDraftDisplayPool() ?? getOnlineSelfDraftPool() ?? [])
+    : (getCurrentDraftPlayer()?.pool ?? []);
+  return pool.map((c) => c.id).join(",");
+}
+
+function startDraftCenterDealAnimation(
+  durationMs = getDraftCenterDealDurationForCurrentPool(),
+) {
+  if (draftCenterDealEndTimerId !== null) {
+    window.clearTimeout(draftCenterDealEndTimerId);
+    draftCenterDealEndTimerId = null;
+  }
+
+  const generation = ++draftCenterDealGeneration;
+  isDraftCenterDealing = true;
+  draftDealVisualEndsAt = Date.now() + durationMs;
+  playGameSound("deal");
+
+  const activate = () => {
+    if (generation !== draftCenterDealGeneration) return;
+    restartDraftCenterDealVisuals();
+  };
+
+  window.requestAnimationFrame(() => {
+    window.requestAnimationFrame(activate);
+  });
+
+  draftCenterDealEndTimerId = window.setTimeout(() => {
+    if (generation !== draftCenterDealGeneration) return;
+
+    draftCenterDealEndTimerId = null;
+    isDraftCenterDealing = false;
+    document.querySelector(".draft-center-overlay")?.classList.remove("draft-center-overlay--dealing");
+  }, durationMs);
+}
 
 function clearOnlineDraftAnimationTimer() {
   if (onlineDraftAnimationTimerId !== null) {
@@ -5790,6 +8022,8 @@ function clearOnlineDraftAnimationTimer() {
     window.clearTimeout(onlineFinalDraftReturnTimerId);
     onlineFinalDraftReturnTimerId = null;
   }
+
+  clearDraftCenterDealAnimation();
 }
 
 function getOnlineRenderSignature() {
@@ -5818,6 +8052,7 @@ function getOnlineRenderSignature() {
         player.usedSlots,
         player.isConnected ? "1" : "0",
         player.isReady ? "1" : "0",
+        player.planningConfirmed ? "1" : "0",
         boardSignature,
       ].join("~");
     })
@@ -5828,6 +8063,7 @@ function getOnlineRenderSignature() {
     state.phaseNumber ?? 1,
     state.dayIndex,
     state.draftRound,
+    state.timer,
     self.draftPool.map((card) => card.id).join(","),
     self.pickedDraftCards.map((card) => card.id).join(","),
     self.hand.map((card) => card.id).join(","),
@@ -5843,14 +8079,20 @@ function updateOnlineTimerOnly() {
   if (!state || !timerElement || !timerValueElement) return;
 
   if (state.phase === "draft") {
-    timerValueElement.textContent = `${state.timer}s`;
-    timerElement.classList.toggle("score-breakdown__timer--danger", state.timer <= 3);
+    timerValueElement.textContent = getDraftTimerDisplayLabel();
+    timerElement.classList.toggle(
+      "score-breakdown__timer--danger",
+      !isDraftPickTimerFrozen() && draftPickSecondsLeft <= 3
+    );
+    updateDraftTimerDisplayVisualOnly();
+    updateDraftPoolToggleVisualOnly();
     return;
   }
 
   if (state.phase === "planning") {
     timerValueElement.textContent = formatTurnTimer(state.timer);
     timerElement.classList.toggle("score-breakdown__timer--danger", state.timer <= 10);
+    updatePlanningConfirmButtonVisualOnly();
     return;
   }
 
@@ -5875,23 +8117,60 @@ function renderAfterOnlineStateChange() {
     }
     
     lastOnlinePhase = currentPhase;
-    
+
+    const shouldDeferRerenderForActiveDeal =
+      (isDraftDealVisualActive() || isDraftPickFlying) &&
+      !shouldActivateOnlineDealAnimation &&
+      !shouldActivateOnlinePassAnimation;
+
+    const shouldDeferRerenderForDraftTransition =
+      (isPassingDraftCards ||
+        isInitialDealInProgress ||
+        isDraftCenterDealing) &&
+      !shouldActivateOnlinePassAnimation &&
+      !shouldActivateOnlineDealAnimation;
+
+    const passVisualRunning =
+      isOnlineInterRoundPoolPassActive() &&
+      document.querySelector(".draft-center-overlay--passing.pass-active");
+
+    const poolCollapseVisualRunning =
+      isDraftPoolCollapseAnimating &&
+      document.querySelector(
+        ".draft-center-overlay--collapsing.pass-active, .draft-center-overlay--expanding.pass-active"
+      );
+
     if (!isCinematicTransitioning) {
+      if (shouldDeferRerenderForActiveDeal || shouldDeferRerenderForDraftTransition) {
+        updateDraftSelectedVisualOnly();
+        updateDraftHandVisualOnly();
+        updateDraftPoolFlownVisualOnly();
+        updateOnlineTimerOnly();
+        updateDraftConfirmButtonVisualOnly();
+      } else if (
+        (passVisualRunning || poolCollapseVisualRunning) &&
+        !shouldActivateOnlinePassAnimation &&
+        !shouldActivateOnlineDealAnimation
+      ) {
+        updateOnlineTimerOnly();
+        updateDraftPoolToggleVisualOnly();
+      } else {
         rerenderGameShell();
+      }
     }
 
     if (shouldActivateOnlineDealAnimation) {
       shouldActivateOnlineDealAnimation = false;
-      activateDraftDealAnimation();
-
-      window.setTimeout(() => {
-        ensureOnlineDraftDealAnimationStarted();
-      }, 80);
+      startDraftCenterDealAnimation(getDraftCenterDealDurationForCurrentPool());
     }
 
     if (shouldActivateOnlinePassAnimation) {
       shouldActivateOnlinePassAnimation = false;
-      activateDraftPassAnimation();
+      if (isOnlineFinalDraftReturnAnimating) {
+        activateDraftCenterReturnAnimation();
+      } else {
+        activateDraftCenterPoolPassAnimation();
+      }
     }
 
     return;
@@ -6054,10 +8333,16 @@ setupAuthFormDelegation();
 setupGameAudioDelegation();
 setupInGameMusicDelegation();
 
-initOnlineClient(() => {
-  applyOnlineRoomStateToLocal();
-  renderAfterOnlineStateChange();
-});
+initOnlineClient(
+  () => {
+    applyOnlineRoomStateToLocal();
+    renderAfterOnlineStateChange();
+  },
+  () => {
+    resetSelfPlanningConfirmLock();
+    updatePlanningConfirmButtonVisualOnly();
+  }
+);
 
 (window as any).createOnlineRoom = (playerName = "An") => {
   createOnlineRoom(playerName);
@@ -6422,5 +8707,10 @@ function setupAuthFormDelegation() {
 (globalThis as any).playGameSound = playGameSound;
 (globalThis as any).debugOnlineBoards = (window as any).debugOnlineBoards;
 (globalThis as any).selectDraftCard = (window as any).selectDraftCard;
+
+
+document.addEventListener("visibilitychange", syncOnlineDraftDisplayAfterTabVisible);
+window.addEventListener("focus", syncOnlineDraftDisplayAfterTabVisible);
+
 
 rerenderGameShell();

--- a/TREKPOLOGY/src/audio/gameAudio.ts
+++ b/TREKPOLOGY/src/audio/gameAudio.ts
@@ -13,17 +13,17 @@ export type GameSoundName =
   | "reject";
 
 const GAME_SOUND_FILES = {
-  deal: "/assets/audio/sounds/card-deal.mp3",
-  returnDeck: "/assets/audio/sounds/card-return-deck.mp3",
-  cardSelect: "/assets/audio/sounds/card-select.mp3",
-  cardPlace: "/assets/audio/sounds/card-place.mp3",
-  button: "/assets/audio/sounds/ui-click.mp3",
-  scanCell: "/assets/audio/sounds/scan-cell.mp3",
-  scanBad: "/assets/audio/sounds/scan-bad.mp3",
-  eventTraffic: "/assets/audio/sounds/event-traffic.mp3",
-  eventDistance: "/assets/audio/sounds/event-distance.mp3",
-  eventStorm: "/assets/audio/sounds/event-storm.mp3",
-  eventPromo: "/assets/audio/sounds/event-promo.mp3",
+  deal: "assets/sounds/card-deal.mp3",
+  returnDeck: "assets/sounds/card-return-deck.mp3",
+  cardSelect: "assets/sounds/card-select.mp3",
+  cardPlace: "assets/sounds/card-place.mp3",
+  button: "assets/sounds/ui-click.mp3",
+  scanCell: "assets/sounds/scan-cell.mp3",
+  scanBad: "assets/sounds/scan-bad.mp3",
+  eventTraffic: "assets/sounds/event-traffic.mp3",
+  eventDistance: "assets/sounds/event-distance.mp3",
+  eventStorm: "assets/sounds/event-storm.mp3",
+  eventPromo: "assets/sounds/event-promo.mp3",
 } as const;
 
 let gameAudioContext: AudioContext | null = null;
@@ -179,7 +179,7 @@ function createCardPaperBuffer(audioContext: AudioContext, duration: number, rou
   for (let index = 0; index < frameCount; index += 1) {
     const progress = index / frameCount;
     const attack = Math.min(1, progress / 0.045);
-    const release = (1 - progress) ** 2.05;
+    const release = Math.pow(1 - progress, 2.05);
     const white = Math.random() * 2 - 1;
 
     brown = (brown + 0.035 * white) / 1.035;

--- a/TREKPOLOGY/src/game/constants.ts
+++ b/TREKPOLOGY/src/game/constants.ts
@@ -1,10 +1,36 @@
-export const STARTING_COIN = 3;
-export const STARTING_STAMINA = 2;
+export const STARTING_COIN = 30;
+export const STARTING_STAMINA = 15;
 export const HAND_SIZE = 5;
 export const TURN_DURATION_SECONDS = 15;
 export const PHASE_DAYS = 5;
 export const PLAYER_COUNT = 4;
-export const DRAFT_PICK_SECONDS = 10;
+export const DRAFT_PICK_SECONDS = 90;
+
+/** Draft center deal animation — keep in sync with server/draftEngine.ts */
+export const DRAFT_CENTER_DEAL_CARD_MS = 900;
+export const DRAFT_CENTER_DEAL_GAP_MS = 150;
+export const DRAFT_CENTER_DEAL_STEP_MS =
+	DRAFT_CENTER_DEAL_CARD_MS + DRAFT_CENTER_DEAL_GAP_MS;
+export const DRAFT_PASS_ANIMATION_MS = 1500;
+export const DRAFT_STARTING_POOL_SIZE = 7;
+
+/** Total ms until the last card finishes flying in (1–7 cards). */
+export function getDraftCenterDealDurationMs(cardCount: number): number {
+	const n = Math.max(1, Math.min(DRAFT_STARTING_POOL_SIZE, cardCount));
+	return (
+		DRAFT_CENTER_DEAL_STEP_MS * (n - 1) + DRAFT_CENTER_DEAL_CARD_MS + 250
+	);
+}
+
+/** Server timer hold (seconds) while deal/pass animation runs. */
+export function getDraftDealHoldSeconds(
+	cardCount: number,
+	includePass = false,
+): number {
+	const dealMs = getDraftCenterDealDurationMs(cardCount);
+	const extraMs = includePass ? DRAFT_PASS_ANIMATION_MS + 300 : 300;
+	return Math.max(1, Math.ceil((dealMs + extraMs) / 1000));
+}
 
 export const days = [1, 2, 3, 4, 5];
 export const rows = ["Sáng", "Trưa", "Chiều", "Tối", "Khuya"];

--- a/TREKPOLOGY/src/online/socketClient.ts
+++ b/TREKPOLOGY/src/online/socketClient.ts
@@ -48,6 +48,7 @@ export type PlayerPublicState = {
   isConnected: boolean;
   isReady: boolean;
   hasJoined: boolean;
+  planningConfirmed?: boolean;
   board: PublicBoardCell[][];
 };
 
@@ -58,6 +59,7 @@ export type OnlineRoomState = {
   dayIndex: number;
   draftRound: number;
   timer: number;
+  draftTimerHold: number;
   selfPlayerId: PlayerId;
   players: Record<PlayerId, PlayerPublicState>;
   self: {
@@ -248,7 +250,10 @@ export function clearSavedOnlineSession() {
 
 
 
-export function initOnlineClient(onStateChange: () => void) {
+export function initOnlineClient(
+  onStateChange: () => void,
+  onGameError?: (message: string) => void
+) {
   const savedUser = loadSavedAuthUser();
 
   authClientState.user = savedUser;
@@ -258,7 +263,7 @@ export function initOnlineClient(onStateChange: () => void) {
   socket.on("connect", () => {
     const savedSession = getSavedOnlineSession();
 
-    if (!savedSession || onlineClientState.roomState) return;
+    if (!savedSession) return;
 
     socket.emit("room:reconnect", savedSession);
   });
@@ -283,6 +288,7 @@ export function initOnlineClient(onStateChange: () => void) {
   });
 
   socket.on("game:error", (payload: { message: string }) => {
+    onGameError?.(payload.message);
     alert(payload.message);
   });
 
@@ -375,6 +381,42 @@ export function selectOnlineDraftCard(cardId: string) {
     roomId: onlineClientState.roomId,
     playerId: onlineClientState.playerId,
     cardId,
+  });
+}
+
+export function confirmOnlineDraftPick() {
+  if (!onlineClientState.roomId || !onlineClientState.playerId) {
+    return;
+  }
+
+  socket.emit("draft:confirmPick", {
+    roomId: onlineClientState.roomId,
+    playerId: onlineClientState.playerId,
+  });
+}
+
+export function isOnlineSocketConnected() {
+  return Boolean(socket.connected);
+}
+
+export function confirmOnlinePlanning() {
+  if (!onlineClientState.roomId || !onlineClientState.playerId) {
+    throw new Error("Chưa vào phòng online.");
+  }
+
+  if (!socket.connected) {
+    throw new Error("Mất kết nối server. Hãy chạy server port 3001 rồi reload trang.");
+  }
+
+  const savedSession = getSavedOnlineSession();
+
+  if (savedSession) {
+    reconnectOnlineRoom(savedSession.roomId, savedSession.playerId, savedSession.playerName);
+  }
+
+  socket.emit("planning:confirm", {
+    roomId: onlineClientState.roomId,
+    playerId: onlineClientState.playerId,
   });
 }
 

--- a/TREKPOLOGY/src/styles/client.less
+++ b/TREKPOLOGY/src/styles/client.less
@@ -7,8 +7,8 @@
 
 @paper: #f3ede3;
 @paper-light: #fbf8f1;
-@ink: #4e3a2b;
-@dash: #c6ad8f;
+@ink: #1a3a4a;
+@dash: rgba(0, 150, 160, 0.35);
 
 * {
   box-sizing: border-box;
@@ -100,13 +100,8 @@ body {
   height: 100vh;
   overflow: hidden;
   padding: var(--arena-padding-y) var(--arena-padding-x);
-  background:
-    radial-gradient(circle at 50% 10%, rgba(255, 255, 255, 0.92), transparent 34%),
-    radial-gradient(circle at 50% 52%, rgba(255, 246, 210, 0.35), transparent 50%),
-    linear-gradient(180deg, #f5efe6, #e9dece);
-  box-shadow:
-    inset 0 0 100px rgba(70, 45, 20, 0.07),
-    inset 0 0 8px rgba(70, 45, 20, 0.05);
+  background: transparent;
+  box-shadow: none;
 }
 
 .arena::before {
@@ -146,7 +141,7 @@ body {
 .arena__title-block h1 {
   font-size: 26px;
   line-height: 0.92;
-  color: #604431;
+  color: #2F6F73;
   letter-spacing: -0.5px;
 }
 
@@ -183,6 +178,9 @@ body {
   width: fit-content;
   margin: 0 auto;
   flex: 0 0 auto;
+  position: relative;
+  z-index: 11;
+  overflow: visible;
 }
 
 /* =========================================
@@ -254,7 +252,7 @@ body {
   align-items: center;
   gap: 7px;
   padding-bottom: 10px;
-  color: #5d4633;
+  color: #1a3a4a;
   font-weight: 700;
   font-size: 12px;
 }
@@ -282,10 +280,10 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: rgba(255, 252, 244, 0.68);
+  background: rgba(255, 255, 255, 0.72);
   font-size: 12px;
   font-weight: 800;
-  color: #9b7b5c;
+  color: #1a6070;
 }
 
 /* =========================================
@@ -308,16 +306,17 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  border: 2px solid #d4c4ad;
+  border: 2px solid rgba(180, 120, 60, 0.5);
   border-radius: 13px;
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.52), rgba(239, 232, 220, 0.92));
+    linear-gradient(180deg, #fff8ef, #f5e6d0);
   font-size: 12px;
   font-weight: 900;
   letter-spacing: 0.7px;
+  color: #3d2815;
   box-shadow:
-    0 6px 14px rgba(80, 55, 25, 0.04),
-    inset 0 2px 0 rgba(255, 255, 255, 0.45);
+    0 3px 10px rgba(120, 70, 20, 0.18),
+    inset 0 2px 0 rgba(255, 255, 255, 0.8);
 }
 
 .board-grid {
@@ -337,15 +336,15 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  border: 2px solid #d4c4ad;
+  border: 2px solid #2F6F73;
   border-radius: 14px;
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.48), rgba(244, 238, 229, 0.92));
-  font-size: 12px;
+  background: rgba(244, 241, 230, 0.95);
+  font-size: 13px;
   font-weight: 900;
+  color: #2D2D2D;
   box-shadow:
-    0 6px 14px rgba(80, 55, 25, 0.04),
-    inset 0 2px 0 rgba(255, 255, 255, 0.45);
+    0 2px 4px rgba(0, 80, 100, 0.1),
+    inset 0 1px 0 rgba(255, 255, 255, 0.4);
 }
 
 .board-cell {
@@ -355,11 +354,12 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  border: 3px dashed @dash;
+  border: 2px solid #2F6F73;
   border-radius: 16px;
-  background:
-    radial-gradient(circle at top, rgba(255, 255, 255, 0.48), rgba(255, 255, 255, 0.1));
-  box-shadow: inset 0 0 20px rgba(80, 55, 25, 0.02);
+  background: rgba(244, 241, 230, 0.95);
+  box-shadow:
+    inset 0 0 16px rgba(0, 100, 120, 0.08),
+    0 2px 8px rgba(0, 60, 80, 0.12);
 }
 
 .board-cell--occupied {
@@ -368,10 +368,12 @@ body {
   align-items: stretch;
   justify-content: stretch;
   overflow: hidden;
+  background: rgba(47, 111, 115, 0.12);
+  border: 2px solid #2F6F73;
 }
 
 .empty-plus {
-  color: #8f735d;
+  color: rgba(0, 120, 130, 0.65);
   font-size: 15px;
   font-weight: 900;
 }
@@ -388,6 +390,8 @@ body {
   align-items: stretch;
   justify-content: stretch;
   overflow: hidden;
+  background: rgba(47, 111, 115, 0.12);
+  border: 2px solid #2F6F73;
 }
 
 .board-cell--clickable {
@@ -416,15 +420,13 @@ body {
   border-radius: 16px;
   border: 3px solid @rarity-common;
 
-  background:
-    radial-gradient(circle at 50% 0%, rgba(255, 255, 255, 0.64), transparent 46%),
-    linear-gradient(180deg, #fff7e8 0%, #f2dfbf 100%);
+  background: #F4F1E6;
 
-  color: #35271d;
+  color: #2D2D2D;
 
   box-shadow:
-    0 3px 0 rgba(119, 90, 60, 0.18),
-    inset 0 1px 0 rgba(255, 255, 255, 0.68);
+    0 3px 0 rgba(0, 100, 120, 0.12),
+    inset 0 1px 0 rgba(255, 255, 255, 0.8);
 
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
@@ -485,10 +487,10 @@ body {
   justify-content: center;
 
   border-radius: 9px;
-  border: 2px solid #c8aa7e;
+  border: 2px solid rgba(0, 150, 160, 0.5);
 
-  background: rgba(255, 249, 236, 0.96);
-  color: #3a2a1f;
+  background: rgba(255, 255, 255, 0.96);
+  color: #1a3a4a;
 
   font-size: 10.5px;
   line-height: 1;
@@ -496,8 +498,8 @@ body {
   white-space: nowrap;
 
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.8),
-    0 2px 4px rgba(90, 60, 30, 0.12);
+    inset 0 1px 0 rgba(255, 255, 255, 0.9),
+    0 2px 4px rgba(0, 80, 100, 0.12);
 }
 
 .board-mini__info {
@@ -519,7 +521,7 @@ body {
   margin: 0;
   padding-right: 43px;
 
-  color: #35271d;
+  color: #2D2D2D;
 
   font-size: 16px;
   line-height: 1.02;
@@ -589,10 +591,8 @@ body {
   grid-template-columns: 1fr 1px 1fr;
   align-items: center;
 
-  background:
-    linear-gradient(180deg, #eddcc3, #dec49c);
-
-  border-top: 2px solid rgba(126, 92, 56, 0.36);
+  background: transparent;
+  border-top: 2px solid #C89B3C;
 }
 
 .board-mini__cost {
@@ -603,7 +603,7 @@ body {
   justify-content: center;
   gap: 5px;
 
-  color: #33261d;
+  color: #C89B3C;
 }
 
 .board-mini__cost span {
@@ -760,14 +760,9 @@ body {
   flex: 0 0 var(--hand-height);
   height: var(--hand-height);
   min-height: var(--hand-height);
-  border: 2px solid rgba(204, 180, 145, 0.6);
-  border-radius: 18px;
-  background:
-    radial-gradient(circle at 50% 0%, rgba(255, 255, 255, 0.5), transparent 55%),
-    linear-gradient(180deg, rgba(255, 255, 255, 0.38), rgba(245, 236, 222, 0.76));
-  box-shadow:
-    inset 0 0 30px rgba(255, 255, 255, 0.22),
-    0 8px 18px rgba(80, 55, 25, 0.04);
+  border: none;
+  background: transparent;
+  box-shadow: none;
   padding: 8px 12px 8px;
   display: flex;
   flex-direction: column;
@@ -805,13 +800,24 @@ body {
 
 .player-hand__title h2 {
   font-size: 14px;
-  color: #5b4331;
+  color: white;
+  background: #8b5cf6;
+  padding: 4px 12px;
+  border-radius: 999px;
+  box-shadow: inset 0 1px 1px rgba(255,255,255,0.3);
+  margin: 0;
+  display: inline-block;
 }
 
 .player-hand__meta {
-  font-size: 9px;
-  font-weight: 700;
-  color: #7b6654;
+  font-size: 11px;
+  font-weight: 900;
+  color: white;
+  background: #8b5cf6;
+  padding: 4px 12px;
+  border-radius: 999px;
+  box-shadow: inset 0 1px 1px rgba(255,255,255,0.3);
+  display: inline-block;
 }
 
 .player-hand__cards {
@@ -849,7 +855,7 @@ body {
   border-radius: 16px;
   background: #f9f1e2;
   border: 3px solid @rarity-common;
-  box-shadow: 0 8px 18px rgba(70, 45, 20, 0.14);
+  box-shadow: 0px 8px 20px rgba(0,0,0,0.18);
   transform-origin: 50% 110%;
   transition:
     transform 260ms cubic-bezier(0.2, 0.95, 0.22, 1.08),
@@ -1693,21 +1699,24 @@ body {
     filter 160ms ease;
 }
 
+@keyframes validSlotPulse {
+  0% { box-shadow: 0 0 0px rgba(122, 175, 178, 0.2); }
+  50% { box-shadow: 0 0 18px rgba(122, 175, 178, 0.6); }
+  100% { box-shadow: 0 0 0px rgba(122, 175, 178, 0.2); }
+}
+
 .board-cell--placeable {
-  border-color: rgba(139, 92, 246, 0.55);
-  background:
-    radial-gradient(circle at center, rgba(139, 92, 246, 0.1), transparent 62%),
-    rgba(255, 255, 255, 0.72);
+  border-color: #7AAFB2 !important;
+  background: rgba(255, 255, 255, 0.5) !important;
+  animation: validSlotPulse 1.5s infinite ease-in-out;
 }
 
 .board-cell--drag-hover {
-  border-color: #8b5cf6 !important;
-  background:
-    radial-gradient(circle at center, rgba(139, 92, 246, 0.2), transparent 62%),
-    rgba(139, 92, 246, 0.11) !important;
+  border: 2px solid #C89B3C !important;
+  background: rgba(200, 155, 60, 0.15) !important;
   box-shadow:
-    inset 0 0 0 2px rgba(139, 92, 246, 0.42),
-    0 0 20px rgba(139, 92, 246, 0.28) !important;
+    inset 0 0 0 2px rgba(200, 155, 60, 0.42),
+    0 0 20px rgba(200, 155, 60, 0.28) !important;
   transform: translateY(-2px) scale(1.015);
 }
 
@@ -4671,6 +4680,11 @@ body {
   width: 122px;
   height: 170px;
   perspective: 700px;
+  transform: scale(1.15);
+  transform-origin: center;
+}
+.deck-card-stack__card {
+  box-shadow: 0px 6px 18px rgba(0,0,0,0.15);
 }
 
 .deck-card-stack__card {
@@ -4920,6 +4934,10 @@ body {
 .player-hand.player-hand--dealing .hand-card:hover,
 .player-hand.player-hand--dealing .hand-card--selected {
   filter: none !important;
+}
+
+.player-hand.player-hand--dealing.player-hand--draft .hand-card {
+  animation: none !important;
 }
 
 /* Mỗi card thật bay từ deck về đúng vị trí fan cuối */
@@ -5401,8 +5419,9 @@ body {
   padding: 9px 10px;
 
   border-radius: 14px;
-  border: 1px solid rgba(161, 125, 83, 0.18);
-  background: rgba(255, 255, 255, 0.56);
+  border: 2px solid #C89B3C;
+  background: #F4F1E6;
+  color: #2D2D2D;
 }
 
 .deck-pile-panel__info span {
@@ -5491,28 +5510,30 @@ body {
 
 .day-pill--current {
   color: #fff !important;
-  background: linear-gradient(135deg, #7c3aed, #4f46e5) !important;
+  background: #2F6F73 !important;
+  border-color: #2F6F73 !important;
   box-shadow:
-    0 10px 22px rgba(79, 70, 229, 0.28),
+    0 4px 10px rgba(47, 111, 115, 0.25),
     inset 0 1px 0 rgba(255, 255, 255, 0.28) !important;
   transform: translateY(-2px);
 }
 
 .day-pill--done {
-  color: #6b5542 !important;
-  background: rgba(225, 213, 196, 0.72) !important;
+  color: #2D2D2D !important;
+  background: #F4F1E6 !important;
+  border-color: #C89B3C !important;
 }
 
 .board-cell--not-current-day {
-  opacity: 0.48;
+  opacity: 0.65;
   cursor: not-allowed;
   background:
     repeating-linear-gradient(
       -45deg,
-      rgba(120, 98, 72, 0.04) 0 7px,
-      rgba(120, 98, 72, 0.09) 7px 14px
+      rgba(0, 120, 140, 0.04) 0 7px,
+      rgba(0, 120, 140, 0.09) 7px 14px
     ),
-    rgba(246, 239, 228, 0.72) !important;
+    #E8E5DA !important;
 }
 
 .board-cell--not-current-day .empty-plus {
@@ -5636,45 +5657,30 @@ body {
 }
 
 .draft-hand-meta__info {
-  min-width: 0;
-  display: grid;
-  grid-template-columns: 70px minmax(0, 1fr) minmax(160px, 0.9fr);
-  gap: 8px;
+  display: flex;
   align-items: center;
 }
 
 .draft-hand-meta__info span {
-  color: #8b5cf6;
-  font-size: 8px;
+  color: white;
+  background: #8b5cf6;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 10px;
   line-height: 1;
   font-weight: 1000;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.05em;
   text-transform: uppercase;
+  text-align: center;
+  box-shadow: inset 0 1px 1px rgba(255,255,255,0.3);
 }
 
 .draft-hand-meta__info strong {
-  min-width: 0;
-  color: #4e3a2b;
-  font-size: 11px;
-  line-height: 1;
-  font-weight: 1000;
-
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
+  display: none;
 }
 
 .draft-hand-meta__info em {
-  min-width: 0;
-  color: #6b5542;
-  font-size: 9px;
-  line-height: 1.1;
-  font-style: normal;
-  font-weight: 800;
-
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
+  display: none;
 }
 
 .draft-hand-meta__confirm {
@@ -6098,17 +6104,17 @@ body {
 
 .online-entry-screen,
 .online-lobby-screen {
-  width: 100vw;
-  height: 100vh;
-  display: grid;
-  place-items: center;
+  /* Background is handled by #lobby-bg element in HTML */
+  position: absolute !important;
+  inset: 0 !important;
+  width: 100vw !important;
+  height: 100vh !important;
+  display: grid !important;
+  place-items: center !important;
   padding: 28px;
-  background-image: 
-    radial-gradient(circle at center, transparent 20%, rgba(30, 20, 10, 0.65) 120%),
-    url('/assets/images/backgrounds/lobby-bg.jpg');
-  background-size: cover;
-  background-position: top center;
-  background-repeat: no-repeat;
+  overflow: hidden !important;
+  background: transparent !important;
+  zoom: 1 !important;
 }
 
 .online-entry-card,
@@ -6842,10 +6848,8 @@ body {
   position: relative;
   isolation: isolate;
   border-radius: 19px !important;
-  border: 2px solid rgba(189, 139, 70, 0.42) !important;
-  background:
-    radial-gradient(circle at 50% 0%, rgba(255, 255, 255, 0.94), transparent 42%),
-    linear-gradient(180deg, rgba(255, 250, 239, 0.98), rgba(245, 229, 201, 0.9)) !important;
+  border: 2px solid #C89B3C !important;
+  background: #F4F1E6 !important;
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.86),
     inset 0 -3px 7px rgba(143, 95, 45, 0.08),
@@ -6878,7 +6882,7 @@ body {
 .score-breakdown__header span,
 .score-breakdown__item span,
 .score-breakdown__details span {
-  color: #8a6b52 !important;
+  color: #2D2D2D !important;
   font-size: 8px !important;
   line-height: 1 !important;
   font-weight: 1000 !important;
@@ -6890,7 +6894,7 @@ body {
 .score-breakdown__item strong,
 .score-breakdown__details strong {
   margin-top: 2px;
-  color: #5a3c2c !important;
+  color: #2D2D2D !important;
   font-size: 18px !important;
   line-height: 1 !important;
   font-weight: 1000 !important;
@@ -6901,7 +6905,7 @@ body {
 }
 
 .score-breakdown__capsule--score strong {
-  color: #d97706 !important;
+  color: #C89B3C !important;
   font-size: 22px !important;
 }
 
@@ -6919,15 +6923,18 @@ body {
   justify-self: stretch !important;
   min-width: 86px !important;
   border-radius: 19px !important;
+  background: #2F6F73 !important;
 }
 
 .score-breakdown__timer span {
   font-size: 8px !important;
   letter-spacing: 0.14em !important;
+  color: white !important;
 }
 
 .score-breakdown__timer strong {
   font-size: 18px !important;
+  color: white !important;
 }
 
 .score-breakdown__lobby-actions {
@@ -6973,15 +6980,13 @@ body {
   display: grid;
   place-items: center;
   border-radius: 50%;
-  border: 5px solid rgba(130, 88, 48, 0.78);
-  background:
-    radial-gradient(circle at 44% 35%, rgba(255, 255, 255, 0.66), transparent 24%),
-    radial-gradient(circle at 50% 52%, rgba(82, 49, 28, 0.22), transparent 58%),
-    linear-gradient(135deg, #f8e8ba, #9a6a34 42%, #5d3924 68%, #f0cc82);
+  border: 5px solid #C89B3C;
+  background: #6B4E3D;
   box-shadow:
     inset 0 0 0 4px rgba(255, 237, 184, 0.92),
     inset 0 -18px 30px rgba(57, 31, 19, 0.34),
     inset 0 10px 20px rgba(255, 255, 255, 0.32),
+    0 0 15px rgba(200, 155, 60, 0.25),
     0 4px 0 rgba(96, 67, 41, 0.7);
 }
 
@@ -7022,8 +7027,14 @@ body {
     0 0 18px rgba(255, 245, 198, 0.36);
 }
 
-.resource-orb__icon--stamina {
-  filter: hue-rotate(175deg) saturate(1.1);
+.resource-orb--stamina .resource-orb__frame {
+  background: #2F6F73;
+  box-shadow:
+    inset 0 0 0 4px rgba(255, 237, 184, 0.92),
+    inset 0 -18px 30px rgba(57, 31, 19, 0.34),
+    inset 0 10px 20px rgba(255, 255, 255, 0.32),
+    0 0 15px rgba(47, 111, 115, 0.25),
+    0 4px 0 rgba(96, 67, 41, 0.7);
 }
 
 .resource-orb__value {
@@ -7036,10 +7047,9 @@ body {
   display: grid;
   place-items: center;
   border-radius: 999px;
-  border: 2px solid rgba(231, 191, 111, 0.86);
-  background:
-    linear-gradient(180deg, rgba(91, 57, 33, 0.98), rgba(52, 32, 22, 0.98));
-  color: #fff6d4;
+  border: 2px solid #C89B3C;
+  background: #6B4E3D;
+  color: #F4F1E6;
   font-size: clamp(16px, 1.6vw, 24px);
   font-weight: 1000;
   letter-spacing: 0.02em;
@@ -8404,12 +8414,7 @@ body,
   height: calc(900px - (var(--arena-padding-y) * 2) - var(--top-height)) !important;
 }
 
-.auth-screen,
-.online-entry-screen {
-  width: 1600px !important;
-  height: 900px !important;
-  min-height: 900px !important;
-}
+.auth-screen { width: 1600px !important; height: 900px !important; min-height: 900px !important; }
 
 /* 
   Scale theo các viewport desktop phổ biến.
@@ -10969,6 +10974,9 @@ body,
 }
 
 /* Combo mặc định: nếu chỉ có combo thì ở giữa */
+.arena {
+  background: transparent !important;
+}
 .flow-node__badge {
   position: absolute !important;
   left: 50% !important;
@@ -11054,13 +11062,14 @@ body,
    - hover làm tối background xung quanh rõ hơn
    - glow không scale/translate, chỉ sáng theo viền mask
    ========================================= */
-@saigon-collage-bg: "/assets/images/backgrounds/saigon-collage-hover/saigon-collage-bg.png";
+@saigon-collage-bg: "../assets/backgrounds/saigon-collage-hover/backgroundboard.jpg";
 
 .game-shell {
   position: relative;
   isolation: isolate;
   background:
-    radial-gradient(circle at center, rgba(255, 255, 255, 0.16), transparent 58%),
+    linear-gradient(rgba(80, 55, 40, 0.75), rgba(60, 40, 25, 0.85)),
+    radial-gradient(circle at center, rgba(200, 150, 100, 0.1), transparent 58%),
     url(@saigon-collage-bg) center / cover no-repeat,
     linear-gradient(180deg, #f5efe6, #e8dccb);
 }
@@ -11074,30 +11083,34 @@ body,
 /* Cho background đi xuyên qua cả hai thanh bên, nhưng UI vẫn dễ đọc */
 .players-column {
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.46), rgba(245, 238, 228, 0.70)),
-    rgba(251, 248, 241, 0.28);
-  backdrop-filter: blur(0.55px);
+    linear-gradient(180deg, rgba(255, 255, 255, 0.50), rgba(230, 248, 250, 0.60)),
+    rgba(240, 252, 254, 0.30);
+  backdrop-filter: blur(1px);
 }
 
 .side-player {
   background:
-    linear-gradient(90deg, rgba(255, 255, 255, 0.34), rgba(246, 240, 230, 0.54));
-  backdrop-filter: blur(0.55px);
+    linear-gradient(90deg, rgba(255, 255, 255, 0.38), rgba(230, 248, 250, 0.50));
+  backdrop-filter: blur(1px);
 }
 
 .players-column--right .deck-pile-panel {
   background:
-    radial-gradient(circle at 50% 18%, rgba(255, 242, 196, 0.16), transparent 44%),
-    linear-gradient(180deg, rgba(255, 255, 255, 0.32), rgba(243, 237, 225, 0.56));
-  backdrop-filter: blur(0.55px);
+    radial-gradient(circle at 50% 18%, rgba(200, 240, 245, 0.16), transparent 44%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.36), rgba(230, 248, 250, 0.50));
+  backdrop-filter: blur(1px);
 }
 
 .arena {
-  background:
-    radial-gradient(circle at 50% 10%, rgba(255, 255, 255, 0.62), transparent 34%),
-    radial-gradient(circle at 50% 52%, rgba(255, 246, 210, 0.12), transparent 50%),
-    linear-gradient(180deg, rgba(245, 239, 230, 0.36), rgba(233, 222, 206, 0.46));
+  background: transparent;
 }
+
+
+
+
+
+
+
 
 .saigon-collage-bg {
   position: absolute;
@@ -11332,36 +11345,65 @@ body,
    EFFECT DOCK
    ========================= */
 
-.player-effect-dock {
-  min-height: 82px;
+.deck-pile-panel__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
   width: 100%;
+  min-height: 0;
+  box-sizing: border-box;
+  position: relative;
+  z-index: 3;
+}
+
+.deck-pile-panel--draft .deck-pile-panel__header {
+  min-height: 38px;
+}
+
+.deck-pile-panel__header-left {
+  flex: 1 1 50%;
+  min-width: 0;
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-start;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.deck-pile-panel__header-right {
+  flex: 0 0 50%;
+  max-width: 50%;
+  display: flex;
+  justify-content: flex-end;
+  align-items: flex-start;
+}
+
+.deck-pile-panel__planning-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  width: 100%;
+}
+
+.player-effect-dock {
+  min-height: 0;
+  width: auto;
   display: flex;
   align-items: center;
   justify-content: flex-start;
   gap: 12px;
   flex-wrap: wrap;
-  padding: 2px 0;
+  padding: 0;
   box-sizing: border-box;
 }
 
 .player-effect-dock--empty {
-  justify-content: center;
+  display: none;
 }
 
 .player-effect-dock__placeholder {
-  width: 100%;
-  min-height: 72px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 18px;
-  border: 1px dashed rgba(161, 125, 83, 0.18);
-  background: rgba(255, 250, 240, 0.2);
-  color: rgba(96, 72, 52, 0.42);
-  font-size: 11px;
-  font-weight: 900;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
+  display: none;
 }
 
 /* =========================
@@ -11858,6 +11900,75 @@ body,
   text-align: left !important;
 }
 
+.deck-pile-panel__draft-confirm,
+.deck-pile-panel__planning-confirm {
+  margin-top: 0;
+  width: 100%;
+  max-width: 100%;
+  padding: 5px 8px;
+  font-family: 'Cinzel', serif;
+  font-weight: 700;
+  font-size: 0.68rem;
+  letter-spacing: 0.05em;
+  line-height: 1.2;
+  text-transform: uppercase;
+  color: #fff5d1;
+  background: linear-gradient(180deg, #d4af37 0%, #aa7c11 100%);
+  border: 1px solid #f9f1e2;
+  border-radius: 6px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.deck-pile-panel__draft-confirm:disabled,
+.deck-pile-panel__planning-confirm:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.deck-pile-panel__planning-status {
+  margin-top: 4px;
+  width: 100%;
+  color: rgba(78, 54, 36, 0.82);
+  font-size: 9px;
+  line-height: 1.35;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-align: right;
+  text-transform: uppercase;
+}
+
+.deck-pile-panel__pool-toggle {
+  flex: 0 0 auto;
+  margin-top: 0;
+  padding: 4px 10px;
+  font-family: 'Cinzel', serif;
+  font-weight: 600;
+  font-size: 0.62rem;
+  letter-spacing: 0.06em;
+  line-height: 1.2;
+  text-transform: uppercase;
+  color: #fff5d1;
+  background: rgba(8, 12, 22, 0.72);
+  border: 1px solid rgba(212, 175, 55, 0.55);
+  border-radius: 6px;
+  cursor: pointer;
+  white-space: nowrap;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.35);
+  transition: background 160ms ease, border-color 160ms ease, transform 160ms ease;
+}
+
+.deck-pile-panel__pool-toggle:hover:not(:disabled) {
+  background: rgba(18, 24, 38, 0.88);
+  border-color: rgba(249, 241, 226, 0.75);
+  transform: translateY(-1px);
+}
+
+.deck-pile-panel__pool-toggle:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
 @media (max-width: 1280px) {
   .player-effect-seal {
     width: 66px;
@@ -11915,11 +12026,26 @@ body,
 
 .player-effect-dock {
   overflow: visible !important;
-  justify-content: center;
+  justify-content: flex-start !important;
+}
+
+.deck-pile-panel__header {
+  width: 100% !important;
+}
+
+.deck-pile-panel__header-right {
+  flex: 0 0 50% !important;
+  max-width: 50% !important;
+  justify-content: flex-end !important;
+}
+
+.deck-pile-panel__header-left {
+  flex: 1 1 50% !important;
+  justify-content: flex-start !important;
 }
 
 .player-effect-dock:not(.player-effect-dock--empty) {
-  justify-content: flex-start;
+  justify-content: flex-start !important;
 }
 
 .player-effect-seal {
@@ -12090,7 +12216,7 @@ body,
 .game-shell {
   background:
     radial-gradient(circle at center, rgba(255, 255, 255, 0.16), transparent 58%),
-    url("/assets/images/backgrounds/saigon-collage-hover/saigon-collage-bg.png") center / cover no-repeat,
+    url("../assets/backgrounds/saigon-collage-hover/backgroundboard.jpg") center / cover no-repeat,
     linear-gradient(180deg, #f5efe6, #e8dccb) !important;
 }
 
@@ -13235,6 +13361,7 @@ body,
   object-fit: cover;
   z-index: 9999999;
   background: #000;
+  pointer-events: none;
 }
 
 #white-flash-overlay {
@@ -13265,3 +13392,882 @@ body,
     filter: blur(0);
   }
 }
+
+
+/* Hover effect added globally */
+.hand-card:hover { transform: translateY(-10px) !important; }
+
+
+/* SPRINT 1 & 2 ANIMATIONS */
+
+.hand-card--selected {
+  border: 3px solid #C89B3C !important;
+  box-shadow: 0 0 15px rgba(200, 155, 60, 0.4) !important;
+}
+
+@keyframes floatUpFade {
+  0% { opacity: 1; transform: translateY(0) scale(1); }
+  20% { opacity: 1; transform: translateY(-10px) scale(1.1); }
+  100% { opacity: 0; transform: translateY(-45px) scale(1); }
+}
+
+.floating-text {
+  position: absolute;
+  pointer-events: none;
+  font-weight: 900;
+  font-size: 26px;
+  animation: floatUpFade 1.2s ease-out forwards;
+  z-index: 9999;
+}
+.floating-text--coin { color: #C89B3C; text-shadow: 0 2px 4px rgba(0,0,0,0.5), 0 0 8px rgba(200,155,60,0.5); }
+.floating-text--stamina { color: #2F6F73; text-shadow: 0 2px 4px rgba(255,255,255,0.8), 0 0 8px rgba(47,111,115,0.5); }
+
+@keyframes resourcePulse {
+  0% { transform: scale(1); }
+  50% { transform: scale(1.15); }
+  100% { transform: scale(1); }
+}
+
+.resource-pulse {
+  animation: resourcePulse 0.3s ease-in-out !important;
+}
+
+/* ========================================================================= */
+/* DRAFT CENTER UI (LEGENDS OF RUNETERRA MULLIGAN STYLE)                     */
+/* ========================================================================= */
+
+.draft-center-overlay {
+  position: absolute;
+  inset: 0;
+  border-radius: 20px;
+  background: transparent;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+  z-index: 100;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  pointer-events: none;
+}
+
+.draft-center-header {
+  position: absolute;
+  top: 10%;
+  text-align: center;
+  color: rgba(255, 255, 255, 0.9);
+  pointer-events: none;
+  animation: draftHeaderSlideDown 0.6s cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+@keyframes draftHeaderSlideDown {
+  from { opacity: 0; transform: translateY(-30px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.draft-center-header h2 {
+  font-family: 'Cinzel', serif;
+  font-size: 4rem;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  margin: 0 0 10px 0;
+  text-shadow: 0 4px 15px rgba(0, 0, 0, 0.8), 0 0 40px rgba(100, 200, 255, 0.3);
+  background: linear-gradient(to bottom, #fff5d1, #d4af37);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.draft-center-header p {
+  font-family: 'Cinzel', serif;
+  font-size: 2rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  margin: 0;
+  text-shadow: 0 2px 8px rgba(0,0,0,0.8), 0 0 20px rgba(212, 175, 55, 0.6);
+  color: #fff5d1;
+  text-transform: uppercase;
+}
+
+.draft-center-container {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  align-items: center;
+  z-index: 2;
+  margin-top: 40px;
+  padding: 0;
+  pointer-events: none;
+}
+
+.draft-center-row {
+  display: flex;
+  justify-content: center;
+  gap: 26px;
+  pointer-events: none;
+}
+
+.draft-center-card-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  transform: scale(0.9);
+  transform-origin: top center;
+  transition: transform 0.35s cubic-bezier(0.2, 0.8, 0.2, 1), box-shadow 0.3s ease;
+  pointer-events: auto;
+  margin: 0;
+  opacity: 1;
+  animation: none;
+}
+
+.draft-center-card-wrapper--selected {
+  transform: translateY(-20px) scale(1.1);
+  z-index: 10;
+}
+
+.draft-center-overlay--dealing .draft-center-card-wrapper {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transform: scale(0.9);
+  animation: draftPoolFlyFromDeck 0.9s cubic-bezier(0.14, 0.72, 0.12, 1) forwards;
+  animation-delay: var(--draft-deal-delay, 0ms);
+  will-change: transform, opacity;
+}
+
+@keyframes draftPoolFlyFromDeck {
+  0% {
+    opacity: 0;
+    visibility: hidden;
+    transform: translate3d(620px, 460px, 0) rotate(38deg) scale(0.48);
+  }
+  3% {
+    opacity: 1;
+    visibility: visible;
+  }
+  40% {
+    transform: translate3d(320px, 100px, 0) rotate(16deg) scale(0.74);
+  }
+  70% {
+    transform: translate3d(80px, -24px, 0) rotate(-5deg) scale(0.88);
+  }
+  88% {
+    transform: translate3d(6px, 4px, 0) rotate(2deg) scale(0.93);
+  }
+  100% {
+    opacity: 1;
+    visibility: visible;
+    transform: translate3d(0, 0, 0) rotate(0deg) scale(0.9);
+  }
+}
+
+.draft-center-overlay:not(.draft-center-overlay--dealing) .draft-center-card-wrapper {
+  visibility: visible;
+  pointer-events: auto;
+}
+
+.draft-center-card {
+  border-radius: 16px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5), 0 0 0 2px rgba(212, 175, 55, 0.3);
+  transition: all 0.3s cubic-bezier(0.2, 0.8, 0.2, 1);
+  transform-style: preserve-3d;
+  cursor: pointer;
+}
+
+.draft-center-card-wrapper--selected .draft-center-card {
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.8), 0 0 0 4px #d4af37, 0 0 30px rgba(212, 175, 55, 0.6);
+}
+
+.draft-center-card:hover {
+  transform: translateY(-15px) scale(1.05);
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.6), 0 0 0 3px rgba(212, 175, 55, 0.8), 0 0 20px rgba(212, 175, 55, 0.5);
+}
+
+.draft-center-card .card-art {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 10px;
+}
+
+.draft-center-btn {
+  background: linear-gradient(180deg, #d4af37 0%, #aa7c11 100%);
+  color: #fff;
+  text-shadow: 0 1px 2px rgba(0,0,0,0.8);
+  border: 1px solid #f9f1e2;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.5), inset 0 1px 1px rgba(255, 255, 255, 0.4);
+  padding: 5px 12px;
+  font-family: 'Cinzel', serif;
+  font-weight: 700;
+  font-size: 0.82rem;
+  letter-spacing: 0.04em;
+  border-radius: 4px;
+  cursor: pointer;
+  text-transform: uppercase;
+  transition: all 0.2s ease;
+  min-width: 68px;
+}
+
+.draft-center-card-wrapper--selected .draft-center-btn {
+  background: linear-gradient(180deg, #aa7c11 0%, #614605 100%);
+  border-color: #d4af37;
+  color: #f9f1e2;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.8);
+  cursor: default;
+}
+
+.draft-center-btn:hover {
+  background: linear-gradient(180deg, #aa7c11 0%, #d4af37 100%);
+  transform: translateY(-2px);
+  box-shadow: 0 6px 15px rgba(0, 0, 0, 0.6), inset 0 1px 1px rgba(255, 255, 255, 0.6), 0 0 15px rgba(212, 175, 55, 0.5);
+}
+
+.draft-center-btn:active {
+  transform: translateY(1px);
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.6);
+}
+
+.draft-center-wait-banner {
+  position: absolute;
+  bottom: 10%;
+  left: 50%;
+  transform: translateX(-50%);
+  background: linear-gradient(90deg, transparent, rgba(0, 0, 0, 0.8) 20%, rgba(0, 0, 0, 0.9) 50%, rgba(0, 0, 0, 0.8) 80%, transparent);
+  color: #fff;
+  padding: 15px 100px;
+  font-family: 'Cinzel', serif;
+  font-size: 2rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  z-index: 900;
+  pointer-events: none;
+  animation: bannerGlow 2s infinite alternate, bannerSlideUp 0.6s cubic-bezier(0.2, 0.8, 0.2, 1);
+  text-shadow: 0 0 10px rgba(255, 255, 255, 0.5);
+  border-top: 1px solid rgba(255, 255, 255, 0.2);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+@keyframes bannerGlow {
+  from { text-shadow: 0 0 10px rgba(255, 255, 255, 0.5); }
+  to { text-shadow: 0 0 20px rgba(100, 200, 255, 0.8), 0 0 30px rgba(100, 200, 255, 0.5); }
+}
+
+@keyframes bannerSlideUp {
+  from { opacity: 0; transform: translate(-50%, 40px); }
+  to { opacity: 1; transform: translate(-50%, 0); }
+}
+
+.draft-center-card .hand-card {
+  margin: 0 !important;
+  transform: none !important;
+  box-shadow: none !important;
+  pointer-events: none !important;
+  flex: none !important;
+}
+
+.draft-center-overlay--returning {
+  pointer-events: none;
+}
+
+.draft-center-container--return {
+  display: flex;
+  flex-direction: row;
+  gap: 34px;
+  justify-content: center;
+  margin-top: 120px;
+}
+
+.draft-center-card-wrapper--return {
+  position: relative;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.draft-center-overlay--returning.pass-active .draft-center-card-wrapper--return {
+  pointer-events: none;
+  animation: draftReturnFadeAtDeckLineV2 1.35s cubic-bezier(0.18, 0.82, 0.24, 1) forwards;
+  will-change: transform, opacity;
+}
+
+.draft-center-overlay--passing.pass-active .draft-center-card-wrapper:not(.draft-center-card-wrapper--flown-to-hand) {
+  pointer-events: none !important;
+  animation: draftCenterPoolReturnFadeV2 1.35s cubic-bezier(0.18, 0.82, 0.24, 1) forwards;
+  will-change: transform, opacity;
+}
+
+.draft-center-overlay--passing .draft-center-card-wrapper--flown-to-hand {
+  visibility: hidden;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.draft-center-overlay--collapsed:not(.draft-center-overlay--expanding) {
+  visibility: hidden;
+  pointer-events: none;
+}
+
+.draft-center-overlay--collapsed:not(.draft-center-overlay--expanding) .draft-center-card-wrapper,
+.draft-center-overlay--collapsed:not(.draft-center-overlay--expanding) .draft-center-wait-banner {
+  visibility: hidden;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.draft-center-overlay--collapsing.pass-active .draft-center-card-wrapper:not(.draft-center-card-wrapper--flown-to-hand),
+.draft-center-overlay--expanding.pass-active .draft-center-card-wrapper:not(.draft-center-card-wrapper--flown-to-hand) {
+  pointer-events: none !important;
+  will-change: transform, opacity;
+}
+
+.draft-center-overlay--collapsing.pass-active .draft-center-card-wrapper:not(.draft-center-card-wrapper--flown-to-hand) {
+  animation: draftCenterPoolReturnFadeV2 1.35s cubic-bezier(0.18, 0.82, 0.24, 1) forwards;
+}
+
+.draft-center-overlay--expanding.pass-active .draft-center-card-wrapper:not(.draft-center-card-wrapper--flown-to-hand) {
+  animation: draftCenterPoolExpandFromDeckV2 1.35s cubic-bezier(0.18, 0.82, 0.24, 1) forwards;
+}
+
+.draft-center-overlay--collapsing .draft-center-card-wrapper--flown-to-hand,
+.draft-center-overlay--expanding .draft-center-card-wrapper--flown-to-hand {
+  visibility: hidden;
+  opacity: 0;
+  pointer-events: none;
+}
+
+@keyframes draftCenterPoolExpandFromDeckV2 {
+  0%,
+  8% {
+    opacity: 0;
+    transform:
+      scale(0.28)
+      translate3d(
+        var(--deck-in-x, 620px),
+        var(--deck-in-y, -120px),
+        0
+      )
+      rotate(var(--deck-r, 16deg));
+  }
+
+  18% {
+    opacity: 0.06;
+    transform:
+      scale(0.34)
+      translate3d(
+        var(--deck-in-x, 620px),
+        calc(var(--deck-in-y, -120px) - 16px),
+        0
+      )
+      rotate(var(--deck-r, 16deg));
+  }
+
+  32% {
+    opacity: 0.22;
+    transform:
+      scale(0.46)
+      translate3d(
+        var(--arc2-x, 420px),
+        calc(var(--arc2-y, -180px) - 58px),
+        0
+      )
+      rotate(18deg);
+  }
+
+  48% {
+    opacity: 0.55;
+    transform:
+      scale(0.58)
+      translate3d(
+        var(--arc1-x, 280px),
+        calc(var(--arc1-y, -140px) - 42px),
+        0
+      )
+      rotate(8deg);
+  }
+
+  66% {
+    opacity: 1;
+    transform:
+      scale(0.82)
+      translate3d(
+        calc(var(--gather-x, 0px) * 0.72),
+        calc(var(--gather-y, -28px) * 0.78),
+        0
+      )
+      rotate(0deg);
+  }
+
+  78% {
+    opacity: 1;
+    transform:
+      scale(0.86)
+      translate3d(
+        calc(var(--gather-x, 0px) * 0.72),
+        calc(var(--gather-y, -28px) * 0.78),
+        0
+      )
+      rotate(calc(var(--gather-r, 0deg) * 0.14));
+  }
+
+  100% {
+    opacity: 1;
+    transform: scale(0.9) translate3d(0, 0, 0) rotate(0deg);
+  }
+}
+
+@keyframes draftCenterPoolReturnFadeV2 {
+  0% {
+    opacity: 1;
+    transform: scale(0.9) translate3d(0, 0, 0) rotate(0deg);
+  }
+
+  22% {
+    opacity: 1;
+    transform:
+      scale(0.86)
+      translate3d(
+        calc(var(--gather-x, 0px) * 0.72),
+        calc(var(--gather-y, -28px) * 0.78),
+        0
+      )
+      rotate(calc(var(--gather-r, 0deg) * 0.14));
+  }
+
+  34% {
+    opacity: 1;
+    transform:
+      scale(0.82)
+      translate3d(
+        calc(var(--gather-x, 0px) * 0.72),
+        calc(var(--gather-y, -28px) * 0.78),
+        0
+      )
+      rotate(0deg);
+  }
+
+  52% {
+    opacity: 0.55;
+    transform:
+      scale(0.62)
+      translate3d(
+        var(--arc1-x, 160px),
+        calc(var(--arc1-y, -150px) - 96px),
+        0
+      )
+      rotate(10deg);
+  }
+
+  68% {
+    opacity: 0.22;
+    transform:
+      scale(0.46)
+      translate3d(
+        var(--arc2-x, 420px),
+        calc(var(--arc2-y, -180px) - 58px),
+        0
+      )
+      rotate(18deg);
+  }
+
+  82% {
+    opacity: 0.06;
+    transform:
+      scale(0.34)
+      translate3d(
+        var(--deck-in-x, 620px),
+        calc(var(--deck-in-y, -120px) - 16px),
+        0
+      )
+      rotate(var(--deck-r, 16deg));
+  }
+
+  92%,
+  100% {
+    opacity: 0;
+    transform:
+      scale(0.28)
+      translate3d(
+        var(--deck-in-x, 620px),
+        var(--deck-in-y, -120px),
+        0
+      )
+      rotate(var(--deck-r, 16deg));
+  }
+}
+
+/* ========================================================================= */
+/* DRAFT PLAYER HAND UI                                                      */
+/* ========================================================================= */
+
+.player-hand__cards--picked {
+  display: flex !important;
+  flex-direction: row !important;
+  justify-content: center !important;
+  align-items: flex-end !important;
+  transform: none !important;
+  width: 100% !important;
+  max-width: 100% !important;
+  gap: 0 !important;
+  padding: 0 12px 4px !important;
+  min-height: calc(var(--hand-card-h) * 0.84 + 20px) !important;
+}
+
+.player-hand--draft .player-hand__cards--picked {
+  transform: none !important;
+  width: 100% !important;
+  max-width: 100% !important;
+}
+
+.player-hand__cards--picked .hand-card--picked-draft {
+  flex: 0 0 auto;
+  width: calc(var(--hand-card-w) * 0.84) !important;
+  height: calc(var(--hand-card-h) * 0.84) !important;
+  margin-left: 0 !important;
+  position: relative !important;
+  pointer-events: none !important;
+  cursor: default !important;
+  transform-origin: 50% 110% !important;
+  transition: transform 220ms ease, margin 220ms ease !important;
+  z-index: 1;
+}
+
+/* overlap for fan - cards after first tuck under */
+.player-hand__cards--picked .hand-card--picked-draft:not(:first-child) {
+  margin-left: calc(var(--hand-card-w) * -0.38) !important;
+}
+
+/* Fan angles per picked count */
+.player-hand__cards--picked-count-1 .hand-card--picked-slot-1 {
+  transform: translate3d(0, -6px, 0) rotate(0deg) !important;
+  z-index: 3;
+}
+
+.player-hand__cards--picked-count-2 .hand-card--picked-slot-1 {
+  transform: translate3d(0, -4px, 0) rotate(-16deg) !important;
+  z-index: 1;
+}
+.player-hand__cards--picked-count-2 .hand-card--picked-slot-2 {
+  transform: translate3d(0, -4px, 0) rotate(16deg) !important;
+  z-index: 2;
+}
+
+.player-hand__cards--picked-count-3 .hand-card--picked-slot-1 {
+  transform: translate3d(0, -5px, 0) rotate(-18deg) !important;
+  z-index: 1;
+}
+.player-hand__cards--picked-count-3 .hand-card--picked-slot-2 {
+  transform: translate3d(0, -10px, 0) rotate(0deg) !important;
+  z-index: 3;
+}
+.player-hand__cards--picked-count-3 .hand-card--picked-slot-3 {
+  transform: translate3d(0, -5px, 0) rotate(18deg) !important;
+  z-index: 2;
+}
+
+.player-hand__cards--picked-count-4 .hand-card--picked-slot-1 {
+  transform: translate3d(0, -3px, 0) rotate(-20deg) !important;
+  z-index: 1;
+}
+.player-hand__cards--picked-count-4 .hand-card--picked-slot-2 {
+  transform: translate3d(0, -8px, 0) rotate(-8deg) !important;
+  z-index: 2;
+}
+.player-hand__cards--picked-count-4 .hand-card--picked-slot-3 {
+  transform: translate3d(0, -8px, 0) rotate(8deg) !important;
+  z-index: 3;
+}
+.player-hand__cards--picked-count-4 .hand-card--picked-slot-4 {
+  transform: translate3d(0, -3px, 0) rotate(20deg) !important;
+  z-index: 2;
+}
+
+.player-hand__cards--picked-count-5 .hand-card--picked-slot-1 {
+  transform: translate3d(0, -2px, 0) rotate(-18deg) !important;
+  z-index: 1;
+}
+.player-hand__cards--picked-count-5 .hand-card--picked-slot-2 {
+  transform: translate3d(0, -7px, 0) rotate(-9deg) !important;
+  z-index: 2;
+}
+.player-hand__cards--picked-count-5 .hand-card--picked-slot-3 {
+  transform: translate3d(0, -11px, 0) rotate(0deg) !important;
+  z-index: 5;
+}
+.player-hand__cards--picked-count-5 .hand-card--picked-slot-4 {
+  transform: translate3d(0, -7px, 0) rotate(9deg) !important;
+  z-index: 3;
+}
+.player-hand__cards--picked-count-5 .hand-card--picked-slot-5 {
+  transform: translate3d(0, -2px, 0) rotate(18deg) !important;
+  z-index: 2;
+}
+
+.player-hand--draft .hand-card--picked-draft {
+  animation: none !important;
+}
+
+.draft-center-card .hand-card--selected {
+  transform: none !important;
+  z-index: 1 !important;
+}
+
+.draft-center-card-wrapper--flown-to-hand {
+  visibility: hidden;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.hand-card--picked-pending {
+  box-shadow: 0 0 0 2px rgba(212, 175, 55, 0.55);
+}
+
+.hand-card--picked-pending-hidden {
+  opacity: 0 !important;
+  pointer-events: none !important;
+}
+
+.draft-pick-fly-layer {
+  position: fixed;
+  inset: 0;
+  z-index: 200000;
+  pointer-events: none;
+}
+
+.draft-pick-fly-card {
+  position: fixed;
+  z-index: 200001;
+  pointer-events: none;
+  transform-origin: 50% 110%;
+  will-change: transform, opacity;
+}
+
+.draft-pick-fly-card--animating {
+  animation: draftPickFlyMove 0.75s cubic-bezier(0.18, 0.82, 0.24, 1) forwards;
+}
+
+.draft-pick-fly-card--to-pool.draft-pick-fly-card--animating {
+  animation: draftPickFlyMoveToPool 0.75s cubic-bezier(0.18, 0.82, 0.24, 1) forwards;
+}
+
+.draft-pick-fly-card .hand-card {
+  width: 100% !important;
+  height: 100% !important;
+  margin: 0 !important;
+  pointer-events: none !important;
+}
+
+@keyframes draftPickFlyMove {
+  from {
+    transform: translate(0, 0) rotate(var(--fly-rotate-start, 0deg)) scale(var(--fly-scale-start, 1));
+    opacity: 1;
+  }
+  to {
+    transform: translate(var(--fly-dx, 0px), var(--fly-dy, 0px)) rotate(var(--fly-rotate-end, 0deg))
+      scale(var(--fly-scale-end, 1));
+    opacity: 1;
+  }
+}
+
+@keyframes draftPickFlyMoveToPool {
+  0% {
+    transform: translate(0, 0) rotate(var(--fly-rotate-start, 0deg)) scale(var(--fly-scale-start, 1));
+    opacity: 1;
+  }
+  45% {
+    transform: translate(calc(var(--fly-dx, 0px) * 0.48), calc(var(--fly-dy, 0px) * 0.38 - 28px))
+      rotate(var(--fly-rotate-start, 0deg))
+      scale(calc((var(--fly-scale-start, 1) + var(--fly-scale-end, 1)) / 2));
+    opacity: 1;
+  }
+  100% {
+    transform: translate(var(--fly-dx, 0px), var(--fly-dy, 0px)) rotate(var(--fly-rotate-end, 0deg))
+      scale(var(--fly-scale-end, 1));
+    opacity: 1;
+  }
+}
+
+/* =========================================================
+   UTILITY CARD PLACEMENT EFFECTS
+   - Utility +Xu / hồi Thể lực / +VP hiện effect tại ô vừa đặt.
+   - Orb TIỀN / THỂ LỰC pulse để người chơi thấy tác dụng.
+   ========================================================= */
+
+.board-cell {
+  position: relative;
+}
+
+.utility-effect-pop {
+  position: absolute;
+  inset: 0;
+  z-index: 999;
+  pointer-events: none;
+  display: grid;
+  place-items: center;
+  animation: utilityEffectPopLife 1050ms ease both;
+}
+
+.utility-effect-pop__burst {
+  position: absolute;
+  width: 94px;
+  height: 94px;
+  border-radius: 999px;
+  opacity: 0.9;
+  animation: utilityEffectBurst 1050ms ease-out both;
+}
+
+.utility-effect-pop--coin .utility-effect-pop__burst {
+  background: radial-gradient(circle, rgba(255, 225, 118, 0.58), rgba(245, 158, 11, 0.22) 42%, transparent 68%);
+  box-shadow: 0 0 28px rgba(245, 158, 11, 0.38);
+}
+
+.utility-effect-pop--stamina .utility-effect-pop__burst {
+  background: radial-gradient(circle, rgba(255, 144, 164, 0.52), rgba(225, 72, 102, 0.22) 42%, transparent 68%);
+  box-shadow: 0 0 28px rgba(225, 72, 102, 0.36);
+}
+
+.utility-effect-pop--vp .utility-effect-pop__burst {
+  background: radial-gradient(circle, rgba(125, 211, 252, 0.50), rgba(45, 139, 211, 0.22) 42%, transparent 68%);
+  box-shadow: 0 0 28px rgba(45, 139, 211, 0.34);
+}
+
+.utility-effect-pop__icon {
+  position: relative;
+  z-index: 2;
+  width: 58px;
+  height: 58px;
+  border-radius: 999px;
+  display: grid;
+  place-items: center;
+  font-size: 32px;
+  font-weight: 1000;
+  background: rgba(255, 252, 244, 0.96);
+  border: 2px solid rgba(255, 255, 255, 0.70);
+  box-shadow: 0 12px 22px rgba(49, 33, 18, 0.22), inset 0 1px 0 rgba(255, 255, 255, 0.85);
+  animation: utilityEffectIconRise 1050ms cubic-bezier(0.2, 0.84, 0.22, 1) both;
+}
+
+.utility-effect-pop__label {
+  position: absolute;
+  z-index: 3;
+  top: calc(50% + 32px);
+  min-width: 86px;
+  padding: 7px 12px;
+  border-radius: 999px;
+  color: white;
+  font-size: 14px;
+  line-height: 1;
+  font-weight: 1000;
+  letter-spacing: 0.02em;
+  text-align: center;
+  white-space: nowrap;
+  text-shadow: 0 1px 0 rgba(0,0,0,0.18);
+  box-shadow: 0 8px 14px rgba(49, 33, 18, 0.18);
+  animation: utilityEffectLabelRise 1050ms ease both;
+}
+
+.utility-effect-pop--stamina .utility-effect-pop__label {
+  min-width: 104px;
+}
+
+.utility-effect-pop--coin .utility-effect-pop__label {
+  background: linear-gradient(135deg, #f59e0b, #b45309);
+}
+
+.utility-effect-pop--stamina .utility-effect-pop__label {
+  background: linear-gradient(135deg, #ef476f, #a32143);
+}
+
+.utility-effect-pop--vp .utility-effect-pop__label {
+  background: linear-gradient(135deg, #38bdf8, #2563eb);
+}
+
+.utility-effect-pop__spark {
+  position: absolute;
+  z-index: 1;
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  opacity: 0;
+  animation: utilityEffectSpark 850ms ease-out both;
+}
+
+.utility-effect-pop--coin .utility-effect-pop__spark { background: #facc15; }
+.utility-effect-pop--stamina .utility-effect-pop__spark { background: #fb7185; }
+.utility-effect-pop--vp .utility-effect-pop__spark { background: #7dd3fc; }
+
+.utility-effect-pop__spark--1 { transform: translate(-28px, -20px); animation-delay: 80ms; }
+.utility-effect-pop__spark--2 { transform: translate(32px, -16px); animation-delay: 150ms; }
+.utility-effect-pop__spark--3 { transform: translate(2px, 32px); animation-delay: 220ms; }
+
+.resource-orb--effect-pulse .resource-orb__frame {
+  animation: resourceOrbUtilityPulse 1050ms ease both;
+}
+
+.resource-orb--effect-pulse.resource-orb--coin .resource-orb__frame {
+  box-shadow: 0 0 0 6px rgba(250, 204, 21, 0.18), 0 0 34px rgba(245, 158, 11, 0.38), inset 0 1px 0 rgba(255,255,255,0.55) !important;
+}
+
+.resource-orb--effect-pulse.resource-orb--stamina .resource-orb__frame {
+  box-shadow: 0 0 0 6px rgba(251, 113, 133, 0.18), 0 0 34px rgba(225, 72, 102, 0.36), inset 0 1px 0 rgba(255,255,255,0.55) !important;
+}
+
+.resource-orb--effect-pulse .resource-orb__icon {
+  animation: resourceOrbIconBounce 1050ms ease both;
+}
+
+.resource-orb--effect-pulse .resource-orb__value {
+  animation: resourceOrbValueFlash 1050ms ease both;
+}
+
+@keyframes utilityEffectPopLife {
+  0% { opacity: 0; transform: scale(0.76); }
+  12% { opacity: 1; transform: scale(1); }
+  72% { opacity: 1; }
+  100% { opacity: 0; transform: scale(1.08) translateY(-10px); }
+}
+
+@keyframes utilityEffectBurst {
+  0% { opacity: 0; transform: scale(0.2); }
+  22% { opacity: 1; transform: scale(1); }
+  100% { opacity: 0; transform: scale(1.55); }
+}
+
+@keyframes utilityEffectIconRise {
+  0% { opacity: 0; transform: translateY(14px) scale(0.6) rotate(-8deg); }
+  20% { opacity: 1; transform: translateY(0) scale(1.08) rotate(3deg); }
+  55% { transform: translateY(-7px) scale(1) rotate(0deg); }
+  100% { opacity: 0; transform: translateY(-32px) scale(0.88); }
+}
+
+@keyframes utilityEffectLabelRise {
+  0% { opacity: 0; transform: translateY(10px) scale(0.88); }
+  24% { opacity: 1; transform: translateY(0) scale(1); }
+  70% { opacity: 1; transform: translateY(-4px); }
+  100% { opacity: 0; transform: translateY(-20px) scale(0.92); }
+}
+
+@keyframes utilityEffectSpark {
+  0% { opacity: 0; scale: 0.25; }
+  20% { opacity: 1; scale: 1; }
+  100% { opacity: 0; translate: 0 -26px; scale: 0.2; }
+}
+
+@keyframes resourceOrbUtilityPulse {
+  0% { transform: scale(1); filter: brightness(1); }
+  20% { transform: scale(1.10); filter: brightness(1.22); }
+  55% { transform: scale(1.03); filter: brightness(1.08); }
+  100% { transform: scale(1); filter: brightness(1); }
+}
+
+@keyframes resourceOrbIconBounce {
+  0%, 100% { transform: translateY(0) scale(1); }
+  24% { transform: translateY(-4px) scale(1.15); }
+  54% { transform: translateY(1px) scale(1.02); }
+}
+
+@keyframes resourceOrbValueFlash {
+  0%, 100% { transform: scale(1); }
+  20% { transform: scale(1.18); }
+  48% { transform: scale(1.04); }
+}
+

--- a/TREKPOLOGY/src/ui/dashboard.ts
+++ b/TREKPOLOGY/src/ui/dashboard.ts
@@ -1,8 +1,25 @@
 import { authClientState } from "../online/socketClient.js";
 
-export const HERO_VIDEO_SRC = "/assets/videos/one-minute-in-vietnam.mp4";
+export const HERO_VIDEO_SRC = "./assets/videos/one-minute-in-vietnam.mp4";
+
+const HUB_HERO_MUTED_KEY = "trek.hubHeroMuted";
+let globalHeroVideo: HTMLVideoElement | null = null;
+
+export function cleanupDashboardHub() {
+  if (globalHeroVideo) {
+    try {
+      globalHeroVideo.pause();
+      globalHeroVideo.muted = true;
+      globalHeroVideo.removeAttribute('src');
+      globalHeroVideo.load();
+    } catch {}
+    globalHeroVideo = null;
+  }
+}
 
 export function initDashboardHub() {
+  cleanupDashboardHub();
+
   const media = document.getElementById("hub-hero-media") as HTMLElement | null;
   const video = document.getElementById("hub-hero-video") as HTMLVideoElement | null;
   const hitarea = document.getElementById("hub-hero-video-hitarea") as HTMLButtonElement | null;
@@ -10,6 +27,7 @@ export function initDashboardHub() {
   const volumeSlider = document.getElementById("hub-hero-video-volume") as HTMLInputElement | null;
 
   if (!media || !video || !hitarea || !muteButton || !volumeSlider) return;
+  globalHeroVideo = video;
 
   video.playsInline = true;
   video.volume = parseFloat(volumeSlider.value) || 0.85;
@@ -33,7 +51,8 @@ export function initDashboardHub() {
   };
 
   const tryAutoplay = async () => {
-    video.muted = false;
+    let userMutedState = localStorage.getItem(HUB_HERO_MUTED_KEY) === "true";
+    video.muted = userMutedState;
 
     try {
       await video.play();
@@ -62,6 +81,8 @@ export function initDashboardHub() {
     } else {
       video.muted = true;
     }
+    
+    localStorage.setItem(HUB_HERO_MUTED_KEY, String(video.muted));
 
     if (!video.paused) {
       void video.play();

--- a/TREKPOLOGY/src/ui/mapSelection.ts
+++ b/TREKPOLOGY/src/ui/mapSelection.ts
@@ -28,7 +28,7 @@ export function renderMapSelectionScreen() {
 
           ${renderMapCardWrapper(`
             <div class="map-card map-card--active">
-              <div class="map-card__bg" style="background-image: url('/assets/images/cities/saigon.jpg')"></div>
+              <div class="map-card__bg" style="background-image: url('./assets/saigon.jpg')"></div>
               <div class="map-card__overlay"></div>
               <div class="map-card__content">
                 <span class="map-card__badge">Đã Mở Khoá</span>
@@ -46,7 +46,7 @@ export function renderMapSelectionScreen() {
 
           ${renderMapCardWrapper(`
             <div class="map-card map-card--locked">
-              <div class="map-card__bg" style="background-image: url('/assets/images/cities/danang.jpg')"></div>
+              <div class="map-card__bg" style="background-image: url('./assets/danang.jpg')"></div>
               <div class="map-card__overlay"></div>
               <div class="map-card__content">
                 <span class="map-card__badge map-card__badge--locked">Sắp ra mắt</span>
@@ -60,7 +60,7 @@ export function renderMapSelectionScreen() {
 
           ${renderMapCardWrapper(`
             <div class="map-card map-card--locked">
-              <div class="map-card__bg" style="background-image: url('/assets/images/cities/hanoi.jpeg')"></div>
+              <div class="map-card__bg" style="background-image: url('./assets/hanoi.jpeg')"></div>
               <div class="map-card__overlay"></div>
               <div class="map-card__content">
                 <span class="map-card__badge map-card__badge--locked">Sắp ra mắt</span>


### PR DESCRIPTION
## Summary
- Port online draft center UX (dynamic deal timer, pass/deal animations, pool collapse) into `TREKPOLOGY/`
- Add multiplayer **planning confirm**: when all active online players confirm, skip the planning timer and advance to simulation
- Fix planning confirm socket handling and client sync/retry so solo play advances immediately
- Set starting resources to **30 coin** and **15 stamina** per player
- Include lobby/map assets and server `npm start` script

## Test plan
- [ ] `cd TREKPOLOGY/server && npm start` and `npx serve . -l 5174` in TREKPOLOGY
- [ ] Create online room solo → draft 5 rounds → planning → confirm → simulation runs without waiting full timer
- [ ] 2-player room: both must confirm before simulation; timer still works if one waits
- [ ] New game starts with 30 coin / 15 stamina


Made with [Cursor](https://cursor.com)